### PR TITLE
:recycle: refactor(codegen): 抽离跨数据库元数据分析层

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug report
-description: Report a reproducible problem
-title: ":bug: fix: "
+description: 提交可复现的问题
+title: ":bug: fix: 请填写问题摘要"
 labels: ["bug", "triage"]
 body:
   - type: markdown
@@ -18,28 +18,28 @@ body:
   - type: textarea
     id: problem
     attributes:
-      label: Problem and expected behavior
+      label: 问题与预期行为
       description: 描述实际行为、预期行为和业务影响。
     validations:
       required: true
   - type: textarea
     id: reproduce
     attributes:
-      label: Reproduction
+      label: 复现步骤
       description: 提供最小复现步骤、输入和完整错误信息（请脱敏）。
     validations:
       required: true
   - type: textarea
     id: environment
     attributes:
-      label: Environment
+      label: 环境信息
       description: Python、操作系统、数据库、安装方式和相关配置。
     validations:
       required: true
   - type: checkboxes
     id: checks
     attributes:
-      label: Preflight
+      label: 提交前检查
       options:
         - label: 我已搜索现有 Issue，确认没有重复报告。
           required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,26 +1,26 @@
 name: Feature request
-description: Propose a focused improvement
-title: ":sparkles: feat: "
+description: 提议一项聚焦的改进
+title: ":sparkles: feat: 请填写功能摘要"
 labels: ["enhancement", "triage"]
 body:
   - type: textarea
     id: problem
     attributes:
-      label: Problem and user value
+      label: 问题与用户价值
       description: 谁遇到了什么问题？不解决会造成什么影响？
     validations:
       required: true
   - type: textarea
     id: proposal
     attributes:
-      label: Proposal and non-goals
+      label: 建议方案与非目标
       description: 描述建议方案、明确不包含的内容，以及可能的替代方案。
     validations:
       required: true
   - type: textarea
     id: acceptance
     attributes:
-      label: Acceptance criteria
+      label: 验收标准
       description: 用可验证的条目描述完成条件。
       placeholder: |
         - [ ] ...
@@ -30,12 +30,12 @@ body:
   - type: textarea
     id: architecture
     attributes:
-      label: Architecture and compatibility
+      label: 架构与兼容性
       description: 受影响模块、API、数据格式、性能和迁移风险。
   - type: checkboxes
     id: checks
     attributes:
-      label: Preflight
+      label: 提交前检查
       options:
         - label: 我已搜索现有 Issue，确认没有重复提案。
           required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,8 +3,10 @@
 标题必须使用与 commit 相同的 Gitmoji + Conventional Commits 格式：
 
 ```text
-:sparkles: feat(scope): 简短动作
+:sparkles: feat(scope): 用中文填写简短动作
 ```
+
+标题和正文描述尽量使用中文；Gitmoji、commit 类型、代码标识、命令、API 名称和错误信息保留原文。
 
 ## 关联 Issue
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,8 @@
 5. 创建 PR，关联 Issue，并填写 PR 模板中的测试、实验结果、风险和回滚信息。
 6. 等待 CI 和审查通过后合并；不要直接向 `main` 推送功能代码。
 
+Issue 和 PR 的标题、正文描述尽量使用中文，便于项目协作者审查和追踪。Gitmoji、commit 类型、代码标识、命令和 API 名称保留原文。
+
 ## 本地检查
 
 ```bash
@@ -26,9 +28,9 @@ uv run ruff format --check src/ tests/
 ## 标题和正文示例
 
 ```text
-:sparkles: feat(dialect): add PostgreSQL array type mapping
-:bug: fix(connection): redact credentials from diagnostic errors
-:test_tube: test(generator): cover nullable enum columns
+:sparkles: feat(dialect): 增加 PostgreSQL 数组类型映射
+:bug: fix(connection): 脱敏诊断错误中的凭据
+:test_tube: test(generator): 覆盖可空枚举字段
 ```
 
 正文依次写 `背景`、`变更`、`验证`、`实验`、`风险`。PR 标题和首个提交标题必须相同风格；PR 额外关联 Issue 并填写审查清单。

--- a/docs/adr/013-canonical-mcp-tool-contract.md
+++ b/docs/adr/013-canonical-mcp-tool-contract.md
@@ -1,0 +1,37 @@
+# ADR-013: Canonical MCP Tool Contract
+
+- **Status**: Accepted
+- **Date**: 2026-09-06
+- **Related issue**: #8
+
+## Context
+
+The MCP server kept tool listing and tool dispatch in separate hand-maintained
+lists. A new tool could therefore appear in `list_tools` without a callable
+handler, or remain callable but undiscoverable. Tool metadata in
+`utils/tool_registry.py` was a third independent list.
+
+## Decision
+
+`server/mcp_server.py` owns one ordered tuple of tool factories. Both
+`handle_list_tools` and `handle_call_tool` derive their behavior from that
+canonical collection. A tool named `example_tool` must expose
+`handle_example_tool`; startup/listing validation fails when a handler is
+missing or a tool name is duplicated.
+
+The progressive-discovery metadata registry remains responsible for search,
+categories, and visibility policy. A separate change may replace its manual
+metadata with generated metadata after the public search contract is specified.
+
+## Consequences
+
+- Adding a tool requires one factory entry and one conventionally named handler;
+  list/dispatch drift is detected by tests and at runtime.
+- Existing tool order and progressive filtering remain unchanged.
+- The metadata registry is intentionally not coupled to execution so search
+  descriptions can evolve without changing dispatch behavior.
+
+## Verification
+
+`tests/unit/test_server_dispatch.py` verifies that every listed tool has a
+handler, dispatch resolves the canonical name, and duplicate names fail fast.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -19,3 +19,6 @@
 - [ADR-008: 引入 MCP v3 elicitation + sampling](008-mcp-v3-elicitation-sampling.md)
 - [ADR-009: 1h prompt caching TTL 作为可选项](009-prompt-caching-1h-ttl.md)
 - [ADR-010: agentic-runner 作为可选启动模式](010-agentic-runner-mode.md)
+- [ADR-011: Multi-dialect strategy](011-multi-dialect-strategy.md)
+- [ADR-012: Pin MCP SDK to the 1.x API contract](012-mcp-sdk-compatibility.md)
+- [ADR-013: Canonical MCP tool contract](013-canonical-mcp-tool-contract.md)

--- a/docs/engineering-standards.md
+++ b/docs/engineering-standards.md
@@ -18,6 +18,10 @@
 
 提交和 PR 使用完全相同的标题格式：先写 Gitmoji，再写 [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) 类型和范围。
 
+### 中文优先
+
+Issue 和 PR 的标题、正文描述默认优先使用中文，确保背景、验收标准、实验结果和风险对中文协作者清晰可读。Gitmoji、Conventional Commits 类型、代码标识、命令、API 名称、错误信息和数据库专有名词保留原文；涉及跨团队协作时可以补充英文摘要。
+
 ```text
 <gitmoji> <type>(<scope>): <简短动作>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ dbjavagenix = ["templates/**/*", "config/**/*"]
 line-length = 100
 target-version = "py311"
 extend-exclude = [".eggs", ".git", ".mypy_cache", ".venv", "build", "dist", "node_modules"]
+force-exclude = true
 
 [tool.ruff.lint]
 # 渐进引入: 先只检查真 bug 类规则(pyflakes F, 部分 E),
@@ -95,6 +96,8 @@ ignore = [
 [tool.ruff.format]
 quote-style = "double"
 indent-style = "space"
+# Legacy module is migrated incrementally; avoid whole-file formatter churn.
+exclude = ["src/dbjavagenix/database/mcp_tools.py"]
 
 [tool.mypy]
 python_version = "3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ indent-style = "space"
 # Legacy module is migrated incrementally; avoid whole-file formatter churn.
 exclude = [
     "src/dbjavagenix/database/mcp_tools.py",
+    "src/dbjavagenix/database/connection_manager.py",
     "src/dbjavagenix/server/mcp_server.py",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,10 @@ ignore = [
 quote-style = "double"
 indent-style = "space"
 # Legacy module is migrated incrementally; avoid whole-file formatter churn.
-exclude = ["src/dbjavagenix/database/mcp_tools.py"]
+exclude = [
+    "src/dbjavagenix/database/mcp_tools.py",
+    "src/dbjavagenix/server/mcp_server.py",
+]
 
 [tool.mypy]
 python_version = "3.11"

--- a/src/dbjavagenix/database/codegen_tools.py
+++ b/src/dbjavagenix/database/codegen_tools.py
@@ -8,7 +8,8 @@ from typing import Dict, List, Any, Optional
 from ..database.connection_manager import ConnectionManager
 from ..generator.java_generator import JavaCodeGenerator
 from ..generator.template_context import TemplateContextBuilder
-from ..core.models import TableInfo, ColumnInfo, GenerationConfig
+from ..core.models import TableInfo, ColumnInfo, DatabaseType, GenerationConfig
+from .introspection import DatabaseIntrospector
 
 
 class CodegenAnalyzer:
@@ -16,6 +17,7 @@ class CodegenAnalyzer:
     
     def __init__(self, connection_manager: ConnectionManager):
         self.connection_manager = connection_manager
+        self.introspector = DatabaseIntrospector(connection_manager)
     
     async def analyze_table_for_codegen(self, connection_id: str, table_name: str,
                                        all_table_names: Optional[List[str]] = None,
@@ -24,29 +26,42 @@ class CodegenAnalyzer:
         """分析单个表的结构，返回代码生成所需的完整信息"""
         
         # 获取表基本信息
-        table_info = await self._get_table_info(connection_id, table_name)
+        config = self.introspector.get_config(connection_id)
+        table_info = self.introspector.get_table(connection_id, table_name)
         
         # 获取列信息
-        columns = await self._get_columns_info(connection_id, table_name)
+        columns = self.introspector.get_columns(connection_id, table_name)
         
         # 获取主键信息
-        primary_keys = await self._get_primary_keys(connection_id, table_name)
+        primary_keys = self.introspector.get_primary_keys(connection_id, table_name)
+        primary_key_set = set(primary_keys)
+        for column in columns:
+            column["primary_key"] = column.get("primary_key", False) or column["name"] in primary_key_set
         
         # 获取外键信息
-        foreign_keys = await self._get_foreign_keys(connection_id, table_name)
+        foreign_keys = self.introspector.get_foreign_keys(connection_id, table_name)
         
         # 获取索引信息
-        indexes = await self._get_indexes(connection_id, table_name)
+        indexes = self.introspector.get_indexes(connection_id, table_name)
         
         # 获取数据库名称
-        connection = self.connection_manager.get_connection(connection_id)
-        database_name = connection.db.decode('utf-8') if hasattr(connection, 'db') and connection.db else "unknown"
+        database_name = config.database or table_info.get("schema") or "unknown"
         
         # 构建 TableInfo 对象
-        table_obj = self._build_table_info(table_info, columns, primary_keys, foreign_keys, indexes, database_name)
+        table_obj = self._build_table_info(
+            table_info,
+            columns,
+            primary_keys,
+            foreign_keys,
+            indexes,
+            database_name,
+            config.type,
+        )
         
         # 构建代码生成上下文
-        context_builder = TemplateContextBuilder(author="ZXP", package_name="com.example")
+        context_builder = TemplateContextBuilder(
+            author="ZXP", package_name="com.example", database_type=config.type
+        )
         context = context_builder.build_context(
             table_obj,
             template_category=template_category,
@@ -59,11 +74,12 @@ class CodegenAnalyzer:
             "table_info": {
                 "name": table_obj.name,
                 "comment": table_obj.comment,
+                "schema": table_obj.schema,
                 "columns": [self._column_to_dict(col) for col in table_obj.columns]
             },
             "template_context": context,
-            "java_types": self._extract_java_types(table_obj.columns),
-            "imports_needed": self._calculate_imports_needed(table_obj.columns),
+            "java_types": self._extract_java_types(table_obj.columns, config.type),
+            "imports_needed": self._calculate_imports_needed(table_obj.columns, config.type),
             "relationships": {
                 "primary_keys": primary_keys,
                 "foreign_keys": foreign_keys,
@@ -75,12 +91,27 @@ class CodegenAnalyzer:
         """分析整个数据库，返回所有表的代码生成信息"""
         
         # 获取所有表
-        connection = self.connection_manager.get_connection(connection_id)
-        cursor = connection.cursor()
-        
-        try:
-            cursor.execute("SHOW TABLES")
-            all_tables = [row[0] for row in cursor.fetchall()]
+        all_tables = self.introspector.list_tables(connection_id)
+
+        tables_to_analyze = [t for t in all_tables if not table_filter or t in table_filter]
+        analysis_results = {}
+        for name in tables_to_analyze:
+            try:
+                analysis_results[name] = await self.analyze_table_for_codegen(connection_id, name)
+            except Exception as exc:
+                analysis_results[name] = {"error": str(exc)}
+
+        return {
+            "database_info": {
+                "total_tables": len(all_tables),
+                "analyzed_tables": len(tables_to_analyze),
+                "success_count": sum("error" not in item for item in analysis_results.values()),
+                "error_count": sum("error" in item for item in analysis_results.values()),
+            },
+            "tables": analysis_results,
+        }
+
+        if False:
             
             # 应用表过滤器
             if table_filter:
@@ -107,9 +138,6 @@ class CodegenAnalyzer:
                 "tables": analysis_results
             }
             
-        finally:
-            cursor.close()
-    
     async def _get_table_info(self, connection_id: str, table_name: str) -> Dict[str, Any]:
         """获取表基本信息"""
         connection = self.connection_manager.get_connection(connection_id)
@@ -254,9 +282,16 @@ class CodegenAnalyzer:
         finally:
             cursor.close()
     
-    def _build_table_info(self, table_info: Dict[str, Any], columns: List[Dict[str, Any]], 
-                         primary_keys: List[str], foreign_keys: List[Dict[str, Any]], 
-                         indexes: List[Dict[str, Any]], database_name: str = "unknown") -> TableInfo:
+    def _build_table_info(
+        self,
+        table_info: Dict[str, Any],
+        columns: List[Dict[str, Any]],
+        primary_keys: List[str],
+        foreign_keys: List[Dict[str, Any]],
+        indexes: List[Dict[str, Any]],
+        database_name: str = "unknown",
+        database_type: DatabaseType = DatabaseType.MYSQL,
+    ) -> TableInfo:
         """构建 TableInfo 对象"""
         
         column_objects = []
@@ -264,7 +299,7 @@ class CodegenAnalyzer:
             column_obj = ColumnInfo(
                 name=col["name"],
                 data_type=col["type"],
-                java_type=self._map_java_type(col["type"]),
+                java_type=self._map_java_type(col["type"], database_type),
                 nullable=col["nullable"],
                 primary_key=col["primary_key"],
                 default_value=col["default_value"],
@@ -273,13 +308,24 @@ class CodegenAnalyzer:
             # 添加额外属性
             column_obj.auto_increment = col["auto_increment"]
             column_obj.max_length = col["max_length"]
+            column_obj.precision = col.get("precision")
+            column_obj.scale = col.get("scale")
             column_objects.append(column_obj)
         
         table_obj = TableInfo(
             name=table_info["name"],
             schema=database_name,
             comment=table_info["comment"],
-            columns=column_objects
+            columns=column_objects,
+            primary_keys=list(primary_keys),
+            foreign_keys={
+                item["column_name"]: (
+                    f"{item['referenced_table']}.{item['referenced_column']}"
+                )
+                for item in foreign_keys
+                if item.get("column_name")
+            },
+            indexes=[item["key_name"] for item in indexes if item.get("key_name")],
         )
         
         return table_obj
@@ -294,12 +340,17 @@ class CodegenAnalyzer:
             "default_value": column.default_value,
             "comment": column.comment,
             "auto_increment": getattr(column, 'auto_increment', False),
-            "max_length": getattr(column, 'max_length', None)
+            "max_length": getattr(column, 'max_length', None),
+            "precision": getattr(column, "precision", None),
+            "scale": getattr(column, "scale", None),
+            "java_type": column.java_type,
         }
     
-    def _extract_java_types(self, columns: List[ColumnInfo]) -> List[str]:
+    def _extract_java_types(
+        self, columns: List[ColumnInfo], database_type: DatabaseType = DatabaseType.MYSQL
+    ) -> List[str]:
         """提取所需的 Java 类型列表"""
-        context_builder = TemplateContextBuilder()
+        context_builder = TemplateContextBuilder(database_type=database_type)
         java_types = set()
         
         for column in columns:
@@ -308,9 +359,11 @@ class CodegenAnalyzer:
         
         return sorted(list(java_types))
     
-    def _calculate_imports_needed(self, columns: List[ColumnInfo]) -> List[str]:
+    def _calculate_imports_needed(
+        self, columns: List[ColumnInfo], database_type: DatabaseType = DatabaseType.MYSQL
+    ) -> List[str]:
         """计算需要导入的类列表"""
-        context_builder = TemplateContextBuilder()
+        context_builder = TemplateContextBuilder(database_type=database_type)
         imports = set()
         
         for column in columns:
@@ -328,11 +381,13 @@ class CodegenAnalyzer:
         
         return sorted(list(imports))
     
-    def _map_java_type(self, mysql_type: str) -> str:
+    def _map_java_type(
+        self, database_type_name: str, database_type: DatabaseType = DatabaseType.MYSQL
+    ) -> str:
         """将 MySQL 数据类型映射为 Java 类型"""
         from ..generator.template_context import TemplateContextBuilder
-        context_builder = TemplateContextBuilder()
-        return context_builder._map_java_type(mysql_type)
+        context_builder = TemplateContextBuilder(database_type=database_type)
+        return context_builder._map_java_type(database_type_name)
 
 
 class CodegenGenerator:

--- a/src/dbjavagenix/database/connection_manager.py
+++ b/src/dbjavagenix/database/connection_manager.py
@@ -48,6 +48,23 @@ class ConnectionManager:
                     autocommit=True,
                     connect_timeout=10
                 )
+            elif config.type == DatabaseType.POSTGRESQL:
+                try:
+                    import psycopg2
+                except ImportError as exc:
+                    raise DatabaseConnectionError(
+                        "PostgreSQL support requires the psycopg2-binary dependency"
+                    ) from exc
+
+                connection = psycopg2.connect(
+                    host=config.host,
+                    port=config.port,
+                    user=config.username,
+                    password=config.password,
+                    dbname=config.database,
+                    connect_timeout=10,
+                )
+                connection.autocommit = True
             elif config.type == DatabaseType.SQLITE:
                 connection = sqlite3.connect(config.database)
                 connection.row_factory = sqlite3.Row  # Enable dict-like access
@@ -87,6 +104,8 @@ class ConnectionManager:
         
         # Test connection is still alive
         try:
+            if getattr(connection, "closed", 0):
+                raise DatabaseConnectionError("connection is closed")
             if hasattr(connection, 'ping'):
                 connection.ping(reconnect=True)
         except Exception as e:
@@ -112,8 +131,8 @@ class ConnectionManager:
         try:
             connection = self.connections[connection_id]
             connection.close()
-            del self.connections[connection_id]
-            del self.connection_configs[connection_id]
+            self.connections.pop(connection_id, None)
+            self.connection_configs.pop(connection_id, None)
             logger.info(f"Closed connection {connection_id}")
             return True
         except Exception as e:
@@ -133,7 +152,8 @@ class ConnectionManager:
         Returns:
             Database configuration or None if not found
         """
-        return self.connection_configs.get(connection_id)
+        config = self.connection_configs.get(connection_id)
+        return config.model_copy(deep=True) if config else None
     
     def list_connections(self) -> Dict[str, Dict[str, Any]]:
         """

--- a/src/dbjavagenix/database/introspection.py
+++ b/src/dbjavagenix/database/introspection.py
@@ -1,0 +1,365 @@
+"""Database metadata access shared by code generation and MCP tools.
+
+The public methods return database-neutral dictionaries.  Dialect-specific SQL
+stays in this module so callers do not need to branch on vendor details.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from ..core.exceptions import DatabaseAnalysisError, DatabaseConnectionError
+from ..core.models import DatabaseConfig, DatabaseType
+
+
+class DatabaseIntrospector:
+    """Read table metadata through a :class:`ConnectionManager` boundary."""
+
+    def __init__(self, connection_manager: Any):
+        self.connection_manager = connection_manager
+
+    def _config(self, connection_id: str) -> DatabaseConfig:
+        config = self.connection_manager.get_connection_info(connection_id)
+        if config is None:
+            raise DatabaseConnectionError(f"Connection {connection_id} not found")
+        return config
+
+    def get_config(self, connection_id: str) -> DatabaseConfig:
+        """Return the connection configuration needed by callers."""
+        return self._config(connection_id)
+
+    @staticmethod
+    def _value(row: Dict[str, Any], *names: str, default: Any = None) -> Any:
+        """Read a result key without depending on driver-specific casing."""
+        for name in names:
+            if name in row:
+                return row[name]
+            upper = name.upper()
+            if upper in row:
+                return row[upper]
+            lower = name.lower()
+            if lower in row:
+                return row[lower]
+        return default
+
+    @staticmethod
+    def _sqlite_identifier(value: str) -> str:
+        """Quote a SQLite identifier used by PRAGMA statements."""
+        return value.replace("'", "''")
+
+    def list_tables(self, connection_id: str) -> List[str]:
+        config = self._config(connection_id)
+        if config.type == DatabaseType.MYSQL:
+            rows = self.connection_manager.execute_query(connection_id, "SHOW TABLES")
+        elif config.type == DatabaseType.POSTGRESQL:
+            rows = self.connection_manager.execute_query(
+                connection_id,
+                """
+                SELECT table_name
+                FROM information_schema.tables
+                WHERE table_catalog = current_database()
+                  AND table_type = 'BASE TABLE'
+                  AND table_schema NOT IN ('pg_catalog', 'information_schema')
+                ORDER BY table_schema, table_name
+                """,
+            )
+        elif config.type == DatabaseType.SQLITE:
+            rows = self.connection_manager.execute_query(
+                connection_id,
+                "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%' ORDER BY name",
+            )
+        else:
+            raise DatabaseAnalysisError(f"Listing tables not implemented for {config.type}")
+
+        return [
+            str(self._value(row, "table_name", "name", default=next(iter(row.values()), "")))
+            for row in rows
+        ]
+
+    def get_table(self, connection_id: str, table_name: str) -> Dict[str, Any]:
+        config = self._config(connection_id)
+        if config.type == DatabaseType.MYSQL:
+            rows = self.connection_manager.execute_query(
+                connection_id,
+                """
+                SELECT TABLE_NAME, TABLE_COMMENT, ENGINE, TABLE_COLLATION
+                FROM information_schema.TABLES
+                WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s
+                """,
+                (config.database, table_name),
+            )
+        elif config.type == DatabaseType.POSTGRESQL:
+            rows = self.connection_manager.execute_query(
+                connection_id,
+                """
+                SELECT table_name, table_schema, '' AS table_comment,
+                       '' AS engine, '' AS table_collation
+                FROM information_schema.tables
+                WHERE table_catalog = current_database()
+                  AND table_type = 'BASE TABLE'
+                  AND table_schema NOT IN ('pg_catalog', 'information_schema')
+                  AND table_name = %s
+                """,
+                (table_name,),
+            )
+        elif config.type == DatabaseType.SQLITE:
+            rows = self.connection_manager.execute_query(
+                connection_id,
+                "SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?",
+                (table_name,),
+            )
+        else:
+            raise DatabaseAnalysisError(f"Table metadata not implemented for {config.type}")
+
+        if not rows:
+            raise DatabaseAnalysisError(f"Table {table_name} not found")
+        row = rows[0]
+        return {
+            "name": self._value(row, "TABLE_NAME", "table_name", "name", default=table_name),
+            "schema": self._value(row, "TABLE_SCHEMA", "table_schema", default=config.database),
+            "comment": self._value(row, "TABLE_COMMENT", "table_comment", default="") or "",
+            "engine": self._value(row, "ENGINE", "engine"),
+            "collation": self._value(row, "TABLE_COLLATION", "table_collation"),
+        }
+
+    def get_columns(self, connection_id: str, table_name: str) -> List[Dict[str, Any]]:
+        config = self._config(connection_id)
+        if config.type == DatabaseType.MYSQL:
+            rows = self.connection_manager.execute_query(
+                connection_id,
+                """
+                SELECT COLUMN_NAME, DATA_TYPE, IS_NULLABLE, COLUMN_DEFAULT,
+                       COLUMN_COMMENT, COLUMN_TYPE, NUMERIC_PRECISION, NUMERIC_SCALE,
+                       CHARACTER_MAXIMUM_LENGTH, COLUMN_KEY, EXTRA
+                FROM information_schema.COLUMNS
+                WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s
+                ORDER BY ORDINAL_POSITION
+                """,
+                (config.database, table_name),
+            )
+        elif config.type == DatabaseType.POSTGRESQL:
+            rows = self.connection_manager.execute_query(
+                connection_id,
+                """
+                SELECT column_name, data_type, is_nullable, column_default,
+                       '' AS column_comment, data_type AS column_type,
+                       numeric_precision, numeric_scale, character_maximum_length,
+                       '' AS column_key,
+                       CASE WHEN column_default LIKE 'nextval(%' THEN 'auto_increment' ELSE '' END AS extra
+                FROM information_schema.columns
+                WHERE table_catalog = current_database()
+                  AND table_schema NOT IN ('pg_catalog', 'information_schema')
+                  AND table_name = %s
+                ORDER BY ordinal_position
+                """,
+                (table_name,),
+            )
+        elif config.type == DatabaseType.SQLITE:
+            rows = self.connection_manager.execute_query(
+                connection_id,
+                f"PRAGMA table_info('{self._sqlite_identifier(table_name)}')",
+            )
+        else:
+            raise DatabaseAnalysisError(f"Column metadata not implemented for {config.type}")
+
+        columns = []
+        for row in rows:
+            name = self._value(row, "COLUMN_NAME", "column_name", "name", default="")
+            data_type = self._value(row, "DATA_TYPE", "data_type", "type", default="") or ""
+            nullable = self._value(row, "IS_NULLABLE", "is_nullable")
+            primary_key = self._value(row, "COLUMN_KEY", "column_key", default="") == "PRI"
+            if nullable is None:
+                nullable = not bool(self._value(row, "notnull", default=0))
+            elif isinstance(nullable, str):
+                nullable = nullable.upper() == "YES"
+            extra = self._value(row, "EXTRA", "extra", default="") or ""
+            columns.append(
+                {
+                    "name": name,
+                    "type": data_type,
+                    "nullable": bool(nullable),
+                    "default_value": self._value(row, "COLUMN_DEFAULT", "column_default", "dflt_value"),
+                    "comment": self._value(row, "COLUMN_COMMENT", "column_comment", default="") or "",
+                    "column_type": self._value(row, "COLUMN_TYPE", "column_type", "type", default=data_type),
+                    "precision": self._value(row, "NUMERIC_PRECISION", "numeric_precision"),
+                    "scale": self._value(row, "NUMERIC_SCALE", "numeric_scale"),
+                    "max_length": self._value(
+                        row, "CHARACTER_MAXIMUM_LENGTH", "character_maximum_length"
+                    ),
+                    "column_key": self._value(row, "COLUMN_KEY", "column_key", default=""),
+                    "extra": extra,
+                    "primary_key": primary_key or bool(self._value(row, "pk", default=0)),
+                    "auto_increment": "auto_increment" in str(extra).lower()
+                    or str(self._value(row, "type", default="")).upper() == "INTEGER AUTOINCREMENT",
+                }
+            )
+        return columns
+
+    def get_primary_keys(self, connection_id: str, table_name: str) -> List[str]:
+        config = self._config(connection_id)
+        if config.type == DatabaseType.MYSQL:
+            rows = self.connection_manager.execute_query(
+                connection_id,
+                """
+                SELECT COLUMN_NAME
+                FROM information_schema.KEY_COLUMN_USAGE
+                WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s
+                  AND CONSTRAINT_NAME = 'PRIMARY'
+                ORDER BY ORDINAL_POSITION
+                """,
+                (config.database, table_name),
+            )
+        elif config.type == DatabaseType.POSTGRESQL:
+            rows = self.connection_manager.execute_query(
+                connection_id,
+                """
+                SELECT kcu.column_name
+                FROM information_schema.table_constraints tc
+                JOIN information_schema.key_column_usage kcu
+                  ON tc.constraint_catalog = kcu.constraint_catalog
+                 AND tc.constraint_schema = kcu.constraint_schema
+                 AND tc.constraint_name = kcu.constraint_name
+                 AND tc.table_name = kcu.table_name
+                WHERE tc.table_catalog = current_database()
+                  AND tc.constraint_type = 'PRIMARY KEY'
+                  AND tc.table_schema NOT IN ('pg_catalog', 'information_schema')
+                  AND tc.table_name = %s
+                ORDER BY kcu.ordinal_position
+                """,
+                (table_name,),
+            )
+        elif config.type == DatabaseType.SQLITE:
+            rows = self.connection_manager.execute_query(
+                connection_id,
+                f"PRAGMA table_info('{self._sqlite_identifier(table_name)}')",
+            )
+            rows = sorted((row for row in rows if row.get("pk", 0)), key=lambda row: row["pk"])
+        else:
+            raise DatabaseAnalysisError(f"Primary key metadata not implemented for {config.type}")
+        return [str(self._value(row, "COLUMN_NAME", "column_name", "name")) for row in rows]
+
+    def get_foreign_keys(self, connection_id: str, table_name: str) -> List[Dict[str, Any]]:
+        config = self._config(connection_id)
+        if config.type == DatabaseType.MYSQL:
+            rows = self.connection_manager.execute_query(
+                connection_id,
+                """
+                SELECT CONSTRAINT_NAME, COLUMN_NAME, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME
+                FROM information_schema.KEY_COLUMN_USAGE
+                WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s
+                  AND REFERENCED_TABLE_NAME IS NOT NULL
+                ORDER BY CONSTRAINT_NAME, ORDINAL_POSITION
+                """,
+                (config.database, table_name),
+            )
+        elif config.type == DatabaseType.POSTGRESQL:
+            rows = self.connection_manager.execute_query(
+                connection_id,
+                """
+                SELECT tc.constraint_name, kcu.column_name,
+                       ccu.table_name AS referenced_table_name,
+                       ccu.column_name AS referenced_column_name
+                FROM information_schema.table_constraints tc
+                JOIN information_schema.key_column_usage kcu
+                  ON tc.constraint_catalog = kcu.constraint_catalog
+                 AND tc.constraint_schema = kcu.constraint_schema
+                 AND tc.constraint_name = kcu.constraint_name
+                 AND tc.table_name = kcu.table_name
+                JOIN information_schema.constraint_column_usage ccu
+                  ON tc.constraint_catalog = ccu.constraint_catalog
+                 AND tc.constraint_schema = ccu.constraint_schema
+                 AND tc.constraint_name = ccu.constraint_name
+                WHERE tc.table_catalog = current_database()
+                  AND tc.constraint_type = 'FOREIGN KEY'
+                  AND tc.table_schema NOT IN ('pg_catalog', 'information_schema')
+                  AND tc.table_name = %s
+                ORDER BY tc.constraint_name, kcu.ordinal_position
+                """,
+                (table_name,),
+            )
+        elif config.type == DatabaseType.SQLITE:
+            rows = self.connection_manager.execute_query(
+                connection_id,
+                f"PRAGMA foreign_key_list('{self._sqlite_identifier(table_name)}')",
+            )
+        else:
+            raise DatabaseAnalysisError(f"Foreign key metadata not implemented for {config.type}")
+
+        return [
+            {
+                "constraint_name": str(
+                    self._value(row, "CONSTRAINT_NAME", "constraint_name", "id", default="")
+                ),
+                "column_name": self._value(row, "COLUMN_NAME", "column_name", "from", default=""),
+                "referenced_table": self._value(
+                    row, "REFERENCED_TABLE_NAME", "referenced_table_name", "table", default=""
+                ),
+                "referenced_column": self._value(
+                    row, "REFERENCED_COLUMN_NAME", "referenced_column_name", "to", default=""
+                ),
+            }
+            for row in rows
+        ]
+
+    def get_indexes(self, connection_id: str, table_name: str) -> List[Dict[str, Any]]:
+        config = self._config(connection_id)
+        if config.type == DatabaseType.MYSQL:
+            rows = self.connection_manager.execute_query(
+                connection_id, f"SHOW INDEX FROM `{table_name.replace('`', '``')}`"
+            )
+            return [
+                {
+                    "key_name": self._value(row, "Key_name", "key_name", default=""),
+                    "column_name": self._value(row, "Column_name", "column_name", default=""),
+                    "unique": not bool(self._value(row, "Non_unique", "non_unique", default=1)),
+                    "seq_in_index": self._value(row, "Seq_in_index", "seq_in_index", default=1),
+                    "index_type": self._value(row, "Index_type", "index_type", default="BTREE"),
+                }
+                for row in rows
+            ]
+        if config.type == DatabaseType.POSTGRESQL:
+            rows = self.connection_manager.execute_query(
+                connection_id,
+                """
+                SELECT idx.relname AS key_name, att.attname AS column_name,
+                       i.indisunique AS is_unique, keys.ordinality AS seq_in_index,
+                       am.amname AS index_type
+                FROM pg_class tbl
+                JOIN pg_namespace ns ON ns.oid = tbl.relnamespace
+                JOIN pg_index i ON i.indrelid = tbl.oid
+                JOIN pg_class idx ON idx.oid = i.indexrelid
+                JOIN pg_am am ON am.oid = idx.relam
+                CROSS JOIN LATERAL unnest(i.indkey) WITH ORDINALITY AS keys(attnum, ordinality)
+                JOIN pg_attribute att ON att.attrelid = tbl.oid AND att.attnum = keys.attnum
+                WHERE ns.nspname NOT IN ('pg_catalog', 'information_schema')
+                  AND tbl.relname = %s
+                ORDER BY idx.relname, keys.ordinality
+                """,
+                (table_name,),
+            )
+            return [
+                {
+                    "key_name": self._value(row, "key_name", default=""),
+                    "column_name": self._value(row, "column_name", default=""),
+                    "unique": bool(self._value(row, "is_unique", default=False)),
+                    "seq_in_index": self._value(row, "seq_in_index", default=1),
+                    "index_type": self._value(row, "index_type", default="btree"),
+                }
+                for row in rows
+            ]
+        if config.type == DatabaseType.SQLITE:
+            rows = self.connection_manager.execute_query(
+                connection_id,
+                f"PRAGMA index_list('{self._sqlite_identifier(table_name)}')",
+            )
+            return [
+                {
+                    "key_name": self._value(row, "name", default=""),
+                    "column_name": "",
+                    "unique": bool(self._value(row, "unique", default=0)),
+                    "seq_in_index": self._value(row, "seq", default=0),
+                    "index_type": "btree",
+                }
+                for row in rows
+            ]
+        raise DatabaseAnalysisError(f"Index metadata not implemented for {config.type}")

--- a/src/dbjavagenix/database/mcp_tools.py
+++ b/src/dbjavagenix/database/mcp_tools.py
@@ -19,6 +19,140 @@ from ..utils.pom_analyzer import PomAnalyzer
 logger = logging.getLogger(__name__)
 
 
+_READ_ONLY_FORBIDDEN_WORDS = {
+    "ALTER",
+    "CREATE",
+    "DELETE",
+    "DROP",
+    "GRANT",
+    "INSERT",
+    "MERGE",
+    "REPLACE",
+    "REVOKE",
+    "TRUNCATE",
+    "UPDATE",
+}
+
+
+def _tokenize_read_only_sql(query: str) -> List[tuple[str, str]]:
+    """Tokenize enough SQL to enforce the single, read-only statement contract."""
+    tokens: List[tuple[str, str]] = []
+    index = 0
+    length = len(query)
+
+    while index < length:
+        char = query[index]
+        if char.isspace():
+            index += 1
+            continue
+
+        if query.startswith("/*", index) or query.startswith("--", index) or char == "#":
+            raise MCPServiceError("SQL comments are not allowed in read-only queries")
+
+        if char in "'\"`":
+            quote = char
+            start = index
+            index += 1
+            while index < length:
+                if query[index] == "\\" and quote == "'":
+                    index += 2
+                    continue
+                if query[index] == quote:
+                    if index + 1 < length and query[index + 1] == quote:
+                        index += 2
+                        continue
+                    index += 1
+                    break
+                index += 1
+            else:
+                raise MCPServiceError("Unterminated quoted value in SQL query")
+            tokens.append(("quoted", query[start:index]))
+            continue
+
+        if char.isalpha() or char == "_":
+            start = index
+            index += 1
+            while index < length and (query[index].isalnum() or query[index] in "_$"):
+                index += 1
+            tokens.append(("word", query[start:index].upper()))
+            continue
+
+        if char == ";":
+            tokens.append(("symbol", char))
+        else:
+            tokens.append(("symbol", char))
+        index += 1
+
+    return tokens
+
+
+def _validate_read_only_query(query: Any) -> str:
+    """Validate and normalize one SQL SELECT statement for the public query tool."""
+    if not isinstance(query, str):
+        raise MCPServiceError("The query must be a SQL string")
+
+    normalized = query.strip()
+    if not normalized:
+        raise MCPServiceError("The query must not be empty")
+
+    tokens = _tokenize_read_only_sql(normalized)
+    if not tokens:
+        raise MCPServiceError("The query must not be empty")
+
+    semicolon_indexes = [index for index, token in enumerate(tokens) if token == ("symbol", ";")]
+    if semicolon_indexes:
+        if semicolon_indexes != [len(tokens) - 1]:
+            raise MCPServiceError("Only one SQL statement is allowed")
+        normalized = normalized[: normalized.rfind(";")].rstrip()
+        tokens = tokens[:-1]
+
+    first_word = next((value for kind, value in tokens if kind == "word"), None)
+    if first_word not in {"SELECT", "WITH"}:
+        raise MCPServiceError("Only SELECT queries are allowed for security reasons")
+
+    depth = 0
+    top_level_select = first_word == "SELECT"
+    for kind, value in tokens:
+        if kind == "symbol":
+            if value == "(":
+                depth += 1
+            elif value == ")":
+                depth -= 1
+                if depth < 0:
+                    raise MCPServiceError("Invalid SQL query parentheses")
+            continue
+
+        if kind != "word":
+            continue
+        if value in _READ_ONLY_FORBIDDEN_WORDS or value == "INTO":
+            raise MCPServiceError("Only read-only SELECT queries are allowed")
+        if first_word == "WITH" and value == "SELECT" and depth == 0:
+            top_level_select = True
+
+    if depth != 0:
+        raise MCPServiceError("Invalid SQL query parentheses")
+    if first_word == "WITH" and not top_level_select:
+        raise MCPServiceError("WITH queries must contain a top-level SELECT statement")
+
+    return normalized
+
+
+def _has_top_level_limit_clause(query: str) -> bool:
+    tokens = _tokenize_read_only_sql(query)
+    depth = 0
+    for index, (kind, value) in enumerate(tokens):
+        if kind == "symbol":
+            if value == "(":
+                depth += 1
+            elif value == ")":
+                depth -= 1
+        elif kind == "word" and value == "LIMIT" and depth == 0:
+            next_token = tokens[index + 1] if index + 1 < len(tokens) else None
+            if next_token and (next_token[0] == "symbol" or next_token[1] == "ALL"):
+                return True
+    return False
+
+
 def get_connection_tools() -> List[Tool]:
     """
     Get list of database connection and basic query MCP tools
@@ -615,17 +749,16 @@ async def handle_db_query_execute(arguments: Dict[str, Any]) -> List[TextContent
     """
     try:
         connection_id = arguments["connection_id"]
-        query = arguments["query"].strip()
+        query = _validate_read_only_query(arguments["query"])
         limit = arguments.get("limit", 100)
-        
-        # Security check: only allow SELECT queries
-        if not query.upper().startswith("SELECT"):
-            raise MCPServiceError("Only SELECT queries are allowed for security reasons")
-        
+
+        if isinstance(limit, bool) or not isinstance(limit, int) or not 0 <= limit <= 10_000:
+            raise MCPServiceError("The limit must be an integer between 0 and 10000")
+
         # Add LIMIT if not present
-        if "LIMIT" not in query.upper():
+        if not _has_top_level_limit_clause(query):
             query = f"{query} LIMIT {limit}"
-        
+
         results = connection_manager.execute_query(connection_id, query)
         
         response = {

--- a/src/dbjavagenix/database/mcp_tools.py
+++ b/src/dbjavagenix/database/mcp_tools.py
@@ -453,7 +453,16 @@ async def handle_db_connect_test(arguments: Dict[str, Any]) -> List[TextContent]
                     result = cursor.fetchone()
                     if result:
                         server_info = f"MySQL {result[0] if isinstance(result, tuple) else result['version']}"
-                        
+
+            elif config.type == DatabaseType.POSTGRESQL:
+                with connection_manager.get_cursor(connection_id) as cursor:
+                    cursor.execute("SELECT version() AS version")
+                    result = cursor.fetchone()
+                    if result:
+                        server_info = (
+                            f"PostgreSQL {result[0] if isinstance(result, tuple) else result['version']}"
+                        )
+
             elif config.type == DatabaseType.SQLITE:
                 server_info = "SQLite"
                 
@@ -527,6 +536,14 @@ async def handle_db_query_databases(arguments: Dict[str, Any]) -> List[TextConte
         # Query databases based on database type
         if config.type == DatabaseType.MYSQL:
             query = "SHOW DATABASES"
+
+        elif config.type == DatabaseType.POSTGRESQL:
+            query = """
+            SELECT datname AS database_name
+            FROM pg_database
+            WHERE datallowconn = TRUE AND NOT datistemplate
+            ORDER BY datname
+            """
         elif config.type == DatabaseType.SQLITE:
             # SQLite doesn't have multiple databases concept
             return [TextContent(
@@ -605,12 +622,28 @@ async def handle_db_query_tables(arguments: Dict[str, Any]) -> List[TextContent]
         # Query tables based on database type
         if config.type == DatabaseType.MYSQL:
             query = f"SHOW TABLES FROM `{database}`"
+            params = None
+
+        elif config.type == DatabaseType.POSTGRESQL:
+            query = """
+            SELECT table_name
+            FROM information_schema.tables
+            WHERE table_catalog = %s
+              AND table_type = 'BASE TABLE'
+              AND table_schema NOT IN ('pg_catalog', 'information_schema')
+            ORDER BY table_schema, table_name
+            """
+            params = (database,)
         elif config.type == DatabaseType.SQLITE:
             query = "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'"
+            params = None
         else:
             raise MCPServiceError(f"Listing tables not implemented for {config.type}")
         
-        results = connection_manager.execute_query(connection_id, query)
+        if params is None:
+            results = connection_manager.execute_query(connection_id, query)
+        else:
+            results = connection_manager.execute_query(connection_id, query, params)
         
         # Extract table names
         tables = []
@@ -681,9 +714,19 @@ async def handle_db_query_table_exists(arguments: Dict[str, Any]) -> List[TextCo
         # Query table existence based on database type
         if config.type == DatabaseType.MYSQL:
             query = """
-            SELECT COUNT(*) as count 
-            FROM information_schema.TABLES 
+            SELECT COUNT(*) as count
+            FROM information_schema.TABLES
             WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s
+            """
+            results = connection_manager.execute_query(connection_id, query, (database, table))
+
+        elif config.type == DatabaseType.POSTGRESQL:
+            query = """
+            SELECT COUNT(*) AS count
+            FROM information_schema.tables
+            WHERE table_catalog = %s
+              AND table_name = %s
+              AND table_schema NOT IN ('pg_catalog', 'information_schema')
             """
             results = connection_manager.execute_query(connection_id, query, (database, table))
             
@@ -897,7 +940,7 @@ async def handle_db_table_describe(arguments: Dict[str, Any]) -> List[TextConten
             ORDER BY ORDINAL_POSITION
             """
             results = connection_manager.execute_query(connection_id, query, (database, table))
-            
+
         elif config.type == DatabaseType.SQLITE:
             # SQLite PRAGMA table_info
             query = f"PRAGMA table_info('{table}')"

--- a/src/dbjavagenix/generator/template_context.py
+++ b/src/dbjavagenix/generator/template_context.py
@@ -5,16 +5,27 @@
 
 from typing import Dict, List, Any, Optional
 from datetime import datetime
-import re
 from ..core.models import TableInfo, ColumnInfo, DatabaseType
+from ..database.dialect import DialectAdapter, get_dialect
 
 
 class TemplateContextBuilder:
     """模板上下文构建器"""
     
-    def __init__(self, author: str = "ZXP", package_name: str = "com.example"):
+    def __init__(
+        self,
+        author: str = "ZXP",
+        package_name: str = "com.example",
+        database_type: DatabaseType | str = DatabaseType.MYSQL,
+        dialect: Optional[DialectAdapter] = None,
+    ):
         self.author = author
         self.package_name = package_name
+        if dialect is not None:
+            self.dialect = dialect
+        else:
+            db_name = database_type.value if isinstance(database_type, DatabaseType) else str(database_type)
+            self.dialect = get_dialect(db_name)
         self.date = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
     
     def build_context(self, table_info: TableInfo, template_category: str = "Default",
@@ -181,7 +192,7 @@ class TemplateContextBuilder:
             analysis_result = analyzer.analyze_project_dependencies(
                 project_root=project_root,
                 template_category=template_category,
-                database_type="mysql"  # 默认数据库类型
+                database_type=self.dialect.name
             )
             return analysis_result.get("technology_stack", TechnologyStack())
         except Exception:
@@ -314,32 +325,36 @@ class TemplateContextBuilder:
         java_types = {self._map_java_type(col.data_type) for col in columns}
         
         # 时间类型导入
-        if "LocalDateTime" in java_types:
-            imports.append("java.time.LocalDateTime")
-        if "LocalDate" in java_types:
-            imports.append("java.time.LocalDate")
-        if "LocalTime" in java_types:
-            imports.append("java.time.LocalTime")
-        if "BigDecimal" in java_types:
-            imports.append("java.math.BigDecimal")
+        import_by_type = {
+            "LocalDateTime": "java.time.LocalDateTime",
+            "LocalDate": "java.time.LocalDate",
+            "LocalTime": "java.time.LocalTime",
+            "OffsetDateTime": "java.time.OffsetDateTime",
+            "OffsetTime": "java.time.OffsetTime",
+            "Instant": "java.time.Instant",
+            "BigDecimal": "java.math.BigDecimal",
+            "BigInteger": "java.math.BigInteger",
+            "UUID": "java.util.UUID",
+        }
+        imports.extend(
+            import_by_type[java_type]
+            for java_type in java_types
+            if java_type in import_by_type
+        )
         
         return sorted(imports)
     
     def _has_date_field(self, columns: List[ColumnInfo]) -> bool:
         """检查是否包含日期字段"""
-        date_types = ['DATETIME', 'TIMESTAMP', 'DATE', 'TIME']
-        return any(col.data_type.upper() in date_types for col in columns)
+        return any(self.dialect.is_date_type(col.data_type) for col in columns)
     
     def _has_big_decimal_field(self, columns: List[ColumnInfo]) -> bool:
         """检查是否包含 BigDecimal 字段"""
-        decimal_types = ['DECIMAL', 'NUMERIC', 'MONEY']
-        return any(col.data_type.upper() in decimal_types for col in columns)
+        return any(self.dialect.is_decimal_type(col.data_type) for col in columns)
     
     def _is_string_type(self, db_type: str) -> bool:
         """检查是否为字符串类型 (剥离 `(n)` 后比对, 修复 `VARCHAR(64)` 一直被判 False 的 bug)"""
-        string_types = ['VARCHAR', 'CHAR', 'TEXT', 'LONGTEXT', 'MEDIUMTEXT', 'TINYTEXT', 'NVARCHAR', 'NCHAR']
-        base_type = re.sub(r'\([^)]*\)', '', db_type.upper())
-        return base_type in string_types
+        return self.dialect.is_string_type(db_type)
     
     def _to_pascal_case(self, name: str) -> str:
         """转换为 PascalCase"""
@@ -354,113 +369,11 @@ class TemplateContextBuilder:
     
     def _map_java_type(self, db_type: str) -> str:
         """映射数据库类型到 Java 类型"""
-        type_mapping = {
-            # 整数类型
-            'TINYINT': 'Byte',
-            'SMALLINT': 'Short', 
-            'MEDIUMINT': 'Integer',
-            'INT': 'Integer',
-            'INTEGER': 'Integer',
-            'BIGINT': 'Long',
-            
-            # 浮点类型
-            'FLOAT': 'Float',
-            'DOUBLE': 'Double',
-            'DECIMAL': 'BigDecimal',
-            'NUMERIC': 'BigDecimal',
-            
-            # 字符串类型
-            'CHAR': 'String',
-            'VARCHAR': 'String',
-            'TEXT': 'String',
-            'LONGTEXT': 'String',
-            'MEDIUMTEXT': 'String',
-            'TINYTEXT': 'String',
-            'NCHAR': 'String',
-            'NVARCHAR': 'String',
-            
-            # 日期时间类型
-            'DATE': 'LocalDate',
-            'TIME': 'LocalTime',
-            'DATETIME': 'LocalDateTime',
-            'TIMESTAMP': 'LocalDateTime',
-            'YEAR': 'Integer',
-            
-            # 布尔类型
-            'BOOLEAN': 'Boolean',
-            'TINYINT(1)': 'Boolean',
-            
-            # 二进制类型
-            'BINARY': 'byte[]',
-            'VARBINARY': 'byte[]',
-            'BLOB': 'byte[]',
-            'LONGBLOB': 'byte[]',
-            'MEDIUMBLOB': 'byte[]',
-            'TINYBLOB': 'byte[]',
-            
-            # JSON 类型
-            'JSON': 'String',
-        }
-        
-        # 处理带长度的类型，如 VARCHAR(255)
-        base_type = re.sub(r'\([^)]*\)', '', db_type.upper())
-        
-        return type_mapping.get(base_type, 'String')
+        return self.dialect.java_type_for(db_type)
     
     def _map_jdbc_type(self, db_type: str) -> str:
         """映射数据库类型到 JDBC 类型"""
-        jdbc_mapping = {
-            # 整数类型
-            'TINYINT': 'TINYINT',
-            'SMALLINT': 'SMALLINT',
-            'MEDIUMINT': 'INTEGER',
-            'INT': 'INTEGER',
-            'INTEGER': 'INTEGER',
-            'BIGINT': 'BIGINT',
-            
-            # 浮点类型
-            'FLOAT': 'FLOAT',
-            'DOUBLE': 'DOUBLE',
-            'DECIMAL': 'DECIMAL',
-            'NUMERIC': 'NUMERIC',
-            
-            # 字符串类型
-            'CHAR': 'CHAR',
-            'VARCHAR': 'VARCHAR',
-            'TEXT': 'LONGVARCHAR',
-            'LONGTEXT': 'LONGVARCHAR',
-            'MEDIUMTEXT': 'LONGVARCHAR',
-            'TINYTEXT': 'VARCHAR',
-            'NCHAR': 'NCHAR',
-            'NVARCHAR': 'NVARCHAR',
-            
-            # 日期时间类型
-            'DATE': 'DATE',
-            'TIME': 'TIME',
-            'DATETIME': 'TIMESTAMP',
-            'TIMESTAMP': 'TIMESTAMP',
-            'YEAR': 'INTEGER',
-            
-            # 布尔类型
-            'BOOLEAN': 'BOOLEAN',
-            'TINYINT(1)': 'BOOLEAN',
-            
-            # 二进制类型
-            'BINARY': 'BINARY',
-            'VARBINARY': 'VARBINARY',
-            'BLOB': 'BLOB',
-            'LONGBLOB': 'LONGVARBINARY',
-            'MEDIUMBLOB': 'LONGVARBINARY',
-            'TINYBLOB': 'VARBINARY',
-            
-            # JSON 类型
-            'JSON': 'LONGVARCHAR',
-        }
-        
-        # 处理带长度的类型
-        base_type = re.sub(r'\([^)]*\)', '', db_type.upper())
-        
-        return jdbc_mapping.get(base_type, 'VARCHAR')
+        return self.dialect.jdbc_type_for(db_type)
 
 
 class TemplateConfigManager:

--- a/src/dbjavagenix/server/mcp_server.py
+++ b/src/dbjavagenix/server/mcp_server.py
@@ -4,7 +4,7 @@ Provides database analysis and Java code generation capabilities through MCP too
 """
 import asyncio
 import logging
-from typing import Any, Sequence
+from typing import Any, Callable, Sequence
 
 from mcp.server import Server
 from mcp.server.models import InitializationOptions
@@ -73,6 +73,55 @@ logger = logging.getLogger(__name__)
 server = Server("dbjavagenix")
 
 
+ToolFactory = Callable[[], list[Tool]]
+
+_TOOL_FACTORIES: tuple[ToolFactory, ...] = (
+    get_connection_tools,
+    get_table_analysis_tools,
+    get_codegen_tools,
+    get_atomic_codegen_tools,
+    get_springboot_project_tools,
+    get_visualization_tools,
+    get_ai_tools,
+    get_observability_tools,
+    get_discovery_tools,
+)
+
+
+def _all_tools() -> list[Tool]:
+    """Build the canonical tool list used by both listing and dispatch."""
+    tools: list[Tool] = []
+    names: set[str] = set()
+    for factory in _TOOL_FACTORIES:
+        for tool in factory():
+            if tool.name in names:
+                raise RuntimeError(f"Duplicate MCP tool name: {tool.name}")
+            names.add(tool.name)
+            tools.append(tool)
+    return tools
+
+
+def _tool_handlers(tools: list[Tool] | None = None) -> dict[str, Callable[..., Any]]:
+    """Resolve handlers from the canonical tool names.
+
+    The project convention is ``<tool name>`` -> ``handle_<tool name>``. Keeping
+    this lookup derived from the tool list prevents list/dispatch drift when a
+    new tool is added.
+    """
+    handlers: dict[str, Callable[..., Any]] = {}
+    missing: list[str] = []
+    for tool in tools if tools is not None else _all_tools():
+        name = tool.name
+        handler = globals().get(f"handle_{name}")
+        if callable(handler):
+            handlers[name] = handler
+        else:
+            missing.append(name)
+    if missing:
+        raise RuntimeError(f"Missing MCP handlers: {', '.join(sorted(missing))}")
+    return handlers
+
+
 @server.list_tools()
 async def handle_list_tools() -> list[Tool]:
     """
@@ -81,34 +130,8 @@ async def handle_list_tools() -> list[Tool]:
     Returns:
         List of available tools
     """
-    tools = []
-    
-    # Add database connection and query tools
-    tools.extend(get_connection_tools())
-    
-    # Add table structure analysis tools
-    tools.extend(get_table_analysis_tools())
-    
-    # Add code generation tools (legacy: db_codegen_analyze + db_codegen_generate)
-    tools.extend(get_codegen_tools())
-
-    # Add atomic code generation tools (P2.2: build_context + 5 render_* layers)
-    tools.extend(get_atomic_codegen_tools())
-
-    # Add SpringBoot project validation tools
-    tools.extend(get_springboot_project_tools())
-
-    # Add visualization tools (P3.1: ER diagram via mcp-apps)
-    tools.extend(get_visualization_tools())
-
-    # Add AI semantic tools (P4: naming inference, template recommendation, schema summary)
-    tools.extend(get_ai_tools())
-
-    # Add observability tools (P5: server_metrics, server_health)
-    tools.extend(get_observability_tools())
-
-    # Add discovery tools (P2.3: search_tools for progressive disclosure)
-    tools.extend(get_discovery_tools())
+    tools = _all_tools()
+    _tool_handlers(tools)
 
     # Apply progressive-mode filter (env DBJAVAGENIX_PROGRESSIVE=1)
     visible_tools = filter_tools_for_listing(tools)
@@ -138,87 +161,10 @@ async def handle_call_tool(name: str, arguments: dict[str, Any]) -> list[TextCon
     _start_perf = _time_for_metrics.perf_counter()
     _is_error = False
     try:
-        # Database connection and query tools
-        if name == "db_connect_test":
-            return await handle_db_connect_test(arguments)
-        elif name == "db_query_databases":
-            return await handle_db_query_databases(arguments)
-        elif name == "db_query_tables":
-            return await handle_db_query_tables(arguments)
-        elif name == "db_query_table_exists":
-            return await handle_db_query_table_exists(arguments)
-        elif name == "db_query_execute":
-            return await handle_db_query_execute(arguments)
-        
-        # Table structure analysis tools
-        elif name == "db_table_describe":
-            return await handle_db_table_describe(arguments)
-        elif name == "db_table_columns":
-            return await handle_db_table_columns(arguments)
-        elif name == "db_table_primary_keys":
-            return await handle_db_table_primary_keys(arguments)
-        elif name == "db_table_foreign_keys":
-            return await handle_db_table_foreign_keys(arguments)
-        elif name == "db_table_indexes":
-            return await handle_db_table_indexes(arguments)
-        
-        # Code generation tools (legacy single-shot)
-        elif name == "db_codegen_analyze":
-            return await handle_db_codegen_analyze(arguments)
-        elif name == "db_codegen_generate":
-            return await handle_db_codegen_generate(arguments)
-
-        # Atomic code generation tools (P2.2)
-        elif name == "codegen_build_context":
-            return await handle_codegen_build_context(arguments)
-        elif name == "codegen_render_entity":
-            return await handle_codegen_render_entity(arguments)
-        elif name == "codegen_render_dao":
-            return await handle_codegen_render_dao(arguments)
-        elif name == "codegen_render_service":
-            return await handle_codegen_render_service(arguments)
-        elif name == "codegen_render_controller":
-            return await handle_codegen_render_controller(arguments)
-        elif name == "codegen_render_mapper":
-            return await handle_codegen_render_mapper(arguments)
-        
-        # (deprecated/removed) java_check_dependencies was never implemented here;
-        # dependency analysis is covered by springboot_* tools.
-            
-        # SpringBoot project validation tools
-        elif name == "springboot_validate_project":
-            return await handle_springboot_validate_project(arguments)
-        elif name == "springboot_analyze_dependencies":
-            return await handle_springboot_analyze_dependencies(arguments)
-        elif name == "springboot_read_config":
-            return await handle_springboot_read_config(arguments)
-
-        # Visualization tools (P3.1: MCP Apps)
-        elif name == "db_render_er_diagram":
-            return await handle_db_render_er_diagram(arguments)
-
-        # AI semantic tools (P4)
-        elif name == "ai_infer_business_names":
-            return await handle_ai_infer_business_names(arguments)
-        elif name == "ai_recommend_template":
-            return await handle_ai_recommend_template(arguments)
-        elif name == "ai_summarize_schema":
-            return await handle_ai_summarize_schema(arguments)
-        elif name == "ai_metrics":
-            return await handle_ai_metrics(arguments)
-
-        # Observability tools (P5)
-        elif name == "server_metrics":
-            return await handle_server_metrics(arguments)
-        elif name == "server_health":
-            return await handle_server_health(arguments)
-
-        # Discovery meta-tool (P2.3)
-        elif name == "search_tools":
-            return await handle_search_tools(arguments)
-
-        else:
+        handler = _tool_handlers().get(name)
+        if handler is None:
             raise ValueError(f"Unknown tool: {name}")
+        return await handler(arguments)
             
     except Exception as e:
         _is_error = True

--- a/tests/unit/test_database_introspection.py
+++ b/tests/unit/test_database_introspection.py
@@ -1,0 +1,109 @@
+"""Tests for the database-neutral metadata access layer."""
+
+from __future__ import annotations
+
+from dbjavagenix.core.models import DatabaseConfig, DatabaseType
+from dbjavagenix.database.connection_manager import ConnectionManager
+from dbjavagenix.database.introspection import DatabaseIntrospector
+
+
+def _sqlite_manager() -> tuple[ConnectionManager, str]:
+    manager = ConnectionManager()
+    connection_id = manager.create_connection(
+        DatabaseConfig(
+            type=DatabaseType.SQLITE,
+            host="",
+            port=0,
+            database=":memory:",
+            username="",
+            password="",
+        )
+    )
+    manager.execute_query(connection_id, "PRAGMA foreign_keys = ON")
+    manager.execute_query(
+        connection_id,
+        "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL)",
+    )
+    manager.execute_query(
+        connection_id,
+        "CREATE TABLE orders (id INTEGER PRIMARY KEY, user_id INTEGER, "
+        "created_at TIMESTAMP, FOREIGN KEY(user_id) REFERENCES users(id))",
+    )
+    manager.execute_query(
+        connection_id,
+        "CREATE UNIQUE INDEX orders_user_idx ON orders(user_id)",
+    )
+    return manager, connection_id
+
+
+def test_sqlite_introspection_returns_normalized_metadata():
+    manager, connection_id = _sqlite_manager()
+    try:
+        introspector = DatabaseIntrospector(manager)
+        assert introspector.list_tables(connection_id) == ["orders", "users"]
+        table = introspector.get_table(connection_id, "orders")
+        assert table["name"] == "orders"
+
+        columns = introspector.get_columns(connection_id, "orders")
+        assert [column["name"] for column in columns] == ["id", "user_id", "created_at"]
+        assert columns[0]["primary_key"] is True
+        assert columns[1]["nullable"] is True
+        assert introspector.get_primary_keys(connection_id, "orders") == ["id"]
+
+        foreign_keys = introspector.get_foreign_keys(connection_id, "orders")
+        assert foreign_keys == [
+            {
+                "constraint_name": "0",
+                "column_name": "user_id",
+                "referenced_table": "users",
+                "referenced_column": "id",
+            }
+        ]
+
+        indexes = introspector.get_indexes(connection_id, "orders")
+        user_index = next(index for index in indexes if index["key_name"] == "orders_user_idx")
+        assert user_index["unique"] is True
+    finally:
+        manager.close_connection(connection_id)
+
+
+class RecordingManager:
+    def __init__(self):
+        self.config = DatabaseConfig(
+            type=DatabaseType.POSTGRESQL,
+            host="db.example",
+            port=5432,
+            database="app",
+            username="reader",
+            password="secret",
+        )
+        self.calls = []
+
+    def get_connection_info(self, connection_id):
+        return self.config
+
+    def execute_query(self, connection_id, query, params=None):
+        self.calls.append((query, params))
+        if "information_schema.tables" in query:
+            return [{"table_name": "users", "table_schema": "public"}]
+        if "information_schema.columns" in query:
+            return [{"column_name": "id", "data_type": "bigint", "is_nullable": "NO"}]
+        if "table_constraints" in query and "PRIMARY KEY" in query:
+            return [{"column_name": "id"}]
+        if "pg_index" in query:
+            return [{"key_name": "users_pkey", "column_name": "id", "is_unique": True}]
+        return []
+
+
+def test_postgresql_introspection_uses_catalog_queries():
+    manager = RecordingManager()
+    introspector = DatabaseIntrospector(manager)
+
+    assert introspector.list_tables("pg-1") == ["users"]
+    assert introspector.get_table("pg-1", "users")["schema"] == "public"
+    assert introspector.get_columns("pg-1", "users")[0]["type"] == "bigint"
+    assert introspector.get_primary_keys("pg-1", "users") == ["id"]
+    assert introspector.get_indexes("pg-1", "users")[0]["key_name"] == "users_pkey"
+
+    assert len(manager.calls) == 5
+    assert all("SHOW TABLES" not in query for query, _ in manager.calls)

--- a/tests/unit/test_mcp_query_safety.py
+++ b/tests/unit/test_mcp_query_safety.py
@@ -1,0 +1,110 @@
+"""Regression tests for the public read-only SQL query tool."""
+
+import pytest
+
+from dbjavagenix.database import mcp_tools
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "query",
+    [
+        "/* hidden */ SELECT 1",
+        "SELECT 1; DROP TABLE users",
+        "SELECT 1; SELECT 2",
+        "WITH changed AS (DELETE FROM users RETURNING id) SELECT * FROM changed",
+        "SELECT id FROM users -- hide a second statement\n",
+        "UPDATE users SET name = 'changed'",
+        "SELECT id INTO new_users FROM users",
+    ],
+)
+async def test_db_query_execute_rejects_non_read_only_sql(monkeypatch, query):
+    called = False
+
+    def execute_query(*args, **kwargs):
+        nonlocal called
+        called = True
+        return []
+
+    monkeypatch.setattr(mcp_tools.connection_manager, "execute_query", execute_query)
+
+    response = await mcp_tools.handle_db_query_execute({"connection_id": "test", "query": query})
+
+    assert "Only" in response[0].text or "comments" in response[0].text
+    assert called is False
+
+
+@pytest.mark.asyncio
+async def test_db_query_execute_accepts_cte_and_trailing_semicolon(monkeypatch):
+    received = []
+
+    def execute_query(connection_id, query):
+        received.append((connection_id, query))
+        return [{"id": 1}]
+
+    monkeypatch.setattr(mcp_tools.connection_manager, "execute_query", execute_query)
+
+    response = await mcp_tools.handle_db_query_execute(
+        {
+            "connection_id": "test",
+            "query": "WITH rows AS (SELECT 1 AS id) SELECT id FROM rows;",
+            "limit": 5,
+        }
+    )
+
+    assert "Query executed successfully" in response[0].text
+    assert received == [("test", "WITH rows AS (SELECT 1 AS id) SELECT id FROM rows LIMIT 5")]
+
+
+@pytest.mark.asyncio
+async def test_db_query_execute_detects_limit_keyword_outside_literals(monkeypatch):
+    received = []
+
+    def execute_query(connection_id, query):
+        received.append(query)
+        return []
+
+    monkeypatch.setattr(mcp_tools.connection_manager, "execute_query", execute_query)
+
+    await mcp_tools.handle_db_query_execute(
+        {"connection_id": "test", "query": "SELECT 'LIMIT is data' AS value", "limit": 3}
+    )
+
+    assert received == ["SELECT 'LIMIT is data' AS value LIMIT 3"]
+
+
+@pytest.mark.asyncio
+async def test_db_query_execute_does_not_treat_limit_alias_as_clause(monkeypatch):
+    received = []
+
+    def execute_query(connection_id, query):
+        received.append(query)
+        return []
+
+    monkeypatch.setattr(mcp_tools.connection_manager, "execute_query", execute_query)
+
+    await mcp_tools.handle_db_query_execute(
+        {"connection_id": "test", "query": "SELECT 1 AS limit FROM users", "limit": 3}
+    )
+
+    assert received == ["SELECT 1 AS limit FROM users LIMIT 3"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("limit", [-1, 10_001, True, "10"])
+async def test_db_query_execute_rejects_invalid_limits(monkeypatch, limit):
+    called = False
+
+    def execute_query(*args, **kwargs):
+        nonlocal called
+        called = True
+        return []
+
+    monkeypatch.setattr(mcp_tools.connection_manager, "execute_query", execute_query)
+
+    response = await mcp_tools.handle_db_query_execute(
+        {"connection_id": "test", "query": "SELECT 1", "limit": limit}
+    )
+
+    assert "limit" in response[0].text.lower()
+    assert called is False

--- a/tests/unit/test_postgresql_connection.py
+++ b/tests/unit/test_postgresql_connection.py
@@ -1,0 +1,100 @@
+"""Unit coverage for the PostgreSQL connection path without a live database."""
+
+import sys
+import types
+
+import pytest
+
+from dbjavagenix.core.exceptions import DatabaseConnectionError
+from dbjavagenix.core.models import DatabaseConfig, DatabaseType
+from dbjavagenix.database.connection_manager import ConnectionManager
+
+
+class FakePostgresConnection:
+    def __init__(self):
+        self.autocommit = False
+        self.closed = 0
+
+    def close(self):
+        self.closed = 1
+
+    def cursor(self):
+        raise AssertionError("cursor should not be needed for this unit test")
+
+
+@pytest.fixture
+def postgres_config():
+    return DatabaseConfig(
+        type=DatabaseType.POSTGRESQL,
+        host="db.example",
+        port=5432,
+        database="app",
+        username="reader",
+        password="secret",
+    )
+
+
+def test_create_postgresql_connection_uses_psycopg2(monkeypatch, postgres_config):
+    calls = []
+    connection = FakePostgresConnection()
+
+    def connect(**kwargs):
+        calls.append(kwargs)
+        return connection
+
+    monkeypatch.setitem(sys.modules, "psycopg2", types.SimpleNamespace(connect=connect))
+
+    manager = ConnectionManager()
+    connection_id = manager.create_connection(postgres_config)
+
+    assert connection_id in manager.connections
+    assert connection.autocommit is True
+    assert calls == [
+        {
+            "host": "db.example",
+            "port": 5432,
+            "user": "reader",
+            "password": "secret",
+            "dbname": "app",
+            "connect_timeout": 10,
+        }
+    ]
+    manager.close_connection(connection_id)
+
+
+def test_connection_info_returns_a_safe_copy(monkeypatch, postgres_config):
+    connection = FakePostgresConnection()
+    monkeypatch.setitem(
+        sys.modules,
+        "psycopg2",
+        types.SimpleNamespace(connect=lambda **kwargs: connection),
+    )
+
+    manager = ConnectionManager()
+    connection_id = manager.create_connection(postgres_config)
+    returned = manager.get_connection_info(connection_id)
+    assert returned is not None
+    assert returned.password == "***"
+
+    returned.password = "changed"
+    assert manager.get_connection_info(connection_id).password == "***"
+    manager.close_connection(connection_id)
+
+
+def test_closed_postgresql_connection_is_removed(monkeypatch, postgres_config):
+    connection = FakePostgresConnection()
+    monkeypatch.setitem(
+        sys.modules,
+        "psycopg2",
+        types.SimpleNamespace(connect=lambda **kwargs: connection),
+    )
+
+    manager = ConnectionManager()
+    connection_id = manager.create_connection(postgres_config)
+    connection.closed = 1
+
+    with pytest.raises(DatabaseConnectionError, match="no longer valid"):
+        manager.get_connection(connection_id)
+
+    assert connection_id not in manager.connections
+    assert connection_id not in manager.connection_configs

--- a/tests/unit/test_postgresql_mcp_tools.py
+++ b/tests/unit/test_postgresql_mcp_tools.py
@@ -1,0 +1,109 @@
+"""Unit coverage for PostgreSQL MCP discovery tools without a live database."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from dbjavagenix.core.models import DatabaseType
+from dbjavagenix.database import mcp_tools
+
+
+@pytest.fixture
+def postgres_info():
+    return SimpleNamespace(type=DatabaseType.POSTGRESQL, database="app")
+
+
+@pytest.mark.asyncio
+async def test_connect_test_reports_postgresql_server(monkeypatch):
+    class Cursor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def execute(self, query):
+            assert query == "SELECT version() AS version"
+
+        def fetchone(self):
+            return ("PostgreSQL 16.4",)
+
+    monkeypatch.setattr(mcp_tools.connection_manager, "create_connection", lambda config: "pg-1")
+    monkeypatch.setattr(mcp_tools.connection_manager, "get_connection", lambda cid: object())
+    monkeypatch.setattr(mcp_tools.connection_manager, "get_cursor", lambda cid: Cursor())
+
+    response = await mcp_tools.handle_db_connect_test(
+        {
+            "database_type": "postgresql",
+            "host": "db.example",
+            "port": 5432,
+            "username": "reader",
+            "password": "secret",
+            "database": "app",
+        }
+    )
+
+    assert "PostgreSQL 16.4" in response[0].text
+    assert "pg-1" in response[0].text
+
+
+@pytest.mark.asyncio
+async def test_query_databases_uses_postgresql_catalog(monkeypatch, postgres_info):
+    calls = []
+    monkeypatch.setattr(
+        mcp_tools.connection_manager, "get_connection_info", lambda cid: postgres_info
+    )
+
+    def execute_query(connection_id, query, params=None):
+        calls.append((connection_id, query, params))
+        return [{"database_name": "app"}, {"database_name": "audit"}]
+
+    monkeypatch.setattr(mcp_tools.connection_manager, "execute_query", execute_query)
+
+    response = await mcp_tools.handle_db_query_databases({"connection_id": "pg-1"})
+
+    assert "Found 2 databases" in response[0].text
+    assert calls[0][0] == "pg-1"
+    assert "pg_database" in calls[0][1]
+    assert calls[0][2] is None
+
+
+@pytest.mark.asyncio
+async def test_query_tables_uses_catalog_and_parameters(monkeypatch, postgres_info):
+    calls = []
+    monkeypatch.setattr(
+        mcp_tools.connection_manager, "get_connection_info", lambda cid: postgres_info
+    )
+
+    def execute_query(connection_id, query, params=None):
+        calls.append((connection_id, query, params))
+        return [{"table_name": "users"}]
+
+    monkeypatch.setattr(mcp_tools.connection_manager, "execute_query", execute_query)
+
+    response = await mcp_tools.handle_db_query_tables({"connection_id": "pg-1", "database": "app"})
+
+    assert "users" in response[0].text
+    assert "information_schema.tables" in calls[0][1]
+    assert calls[0][2] == ("app",)
+
+
+@pytest.mark.asyncio
+async def test_table_exists_uses_postgresql_catalog(monkeypatch, postgres_info):
+    calls = []
+    monkeypatch.setattr(
+        mcp_tools.connection_manager, "get_connection_info", lambda cid: postgres_info
+    )
+
+    def execute_query(connection_id, query, params=None):
+        calls.append((connection_id, query, params))
+        return [{"count": 1}]
+
+    monkeypatch.setattr(mcp_tools.connection_manager, "execute_query", execute_query)
+
+    response = await mcp_tools.handle_db_query_table_exists(
+        {"connection_id": "pg-1", "database": "app", "table": "users"}
+    )
+
+    assert "exists in database" in response[0].text
+    assert calls[0][2] == ("app", "users")

--- a/tests/unit/test_server_dispatch.py
+++ b/tests/unit/test_server_dispatch.py
@@ -1,0 +1,41 @@
+"""Contract tests for canonical MCP tool listing and dispatch."""
+
+from mcp.types import TextContent, Tool
+import pytest
+
+from dbjavagenix.server import mcp_server
+
+
+@pytest.mark.asyncio
+async def test_every_listed_tool_has_a_handler():
+    tools = await mcp_server.handle_list_tools()
+    names = [tool.name for tool in tools]
+    handlers = mcp_server._tool_handlers()
+
+    assert len(names) == len(set(names))
+    assert set(names) == set(handlers)
+    assert all(callable(handler) for handler in handlers.values())
+
+
+@pytest.mark.asyncio
+async def test_dispatch_resolves_handler_from_canonical_name(monkeypatch):
+    calls = []
+
+    async def fake_health(arguments):
+        calls.append(arguments)
+        return [TextContent(type="text", text="ok")]
+
+    monkeypatch.setattr(mcp_server, "handle_server_health", fake_health)
+
+    result = await mcp_server.handle_call_tool("server_health", {"verbose": True})
+
+    assert result[0].text == "ok"
+    assert calls == [{"verbose": True}]
+
+
+def test_handler_registry_rejects_duplicate_tool_names(monkeypatch):
+    duplicate = Tool(name="duplicate", description="test", inputSchema={"type": "object"})
+    monkeypatch.setattr(mcp_server, "_TOOL_FACTORIES", (lambda: [duplicate, duplicate],))
+
+    with pytest.raises(RuntimeError, match="Duplicate MCP tool name"):
+        mcp_server._tool_handlers()

--- a/tests/unit/test_template_context_builder.py
+++ b/tests/unit/test_template_context_builder.py
@@ -5,7 +5,7 @@
 
 import pytest
 
-from dbjavagenix.core.models import ColumnInfo, TableInfo
+from dbjavagenix.core.models import ColumnInfo, DatabaseType, TableInfo
 from dbjavagenix.generator.template_context import (
     TemplateConfigManager,
     TemplateContextBuilder,
@@ -108,6 +108,16 @@ class TestJavaTypeMapping:
     def test_unknown_falls_back_to_string(self, builder):
         assert builder._map_java_type("UNKNOWN_FANCY_TYPE") == "String"
 
+    def test_postgresql_dialect_is_used_for_context_mapping(self):
+        builder = TemplateContextBuilder(
+            author="tester",
+            package_name="com.example.app",
+            database_type=DatabaseType.POSTGRESQL,
+        )
+        assert builder._map_java_type("TIMESTAMP WITH TIME ZONE") == "OffsetDateTime"
+        assert builder._map_java_type("BYTEA") == "byte[]"
+        assert builder._map_java_type("JSONB") == "String"
+
 
 class TestJdbcTypeMapping:
     @pytest.mark.parametrize(
@@ -126,6 +136,12 @@ class TestJdbcTypeMapping:
 
     def test_unknown_falls_back_to_varchar(self, builder):
         assert builder._map_jdbc_type("UNKNOWN_TYPE") == "VARCHAR"
+
+    def test_postgresql_jdbc_types_are_preserved(self):
+        builder = TemplateContextBuilder(database_type="postgresql")
+        assert builder._map_jdbc_type("TIMESTAMPTZ") == "TIMESTAMP_WITH_TIMEZONE"
+        assert builder._map_jdbc_type("BYTEA") == "BINARY"
+        assert builder._map_jdbc_type("JSONB") == "OTHER"
 
 
 class TestStringTypeDetection:
@@ -185,6 +201,25 @@ class TestBuildContextStructure:
         assert "jdbcType" in first
         assert "isPrimaryKey" in first
         assert "isLast" in first
+
+    def test_postgresql_context_includes_dialect_imports(self):
+        table = TableInfo(
+            name="audit_event",
+            schema="public",
+            columns=[
+                ColumnInfo(
+                    name="occurred_at",
+                    data_type="TIMESTAMPTZ",
+                    java_type="OffsetDateTime",
+                ),
+                ColumnInfo(name="event_id", data_type="UUID", java_type="String"),
+            ],
+        )
+        builder = TemplateContextBuilder(database_type="postgresql")
+        context = builder.build_context(table)
+        assert context["columns"][0]["javaType"] == "OffsetDateTime"
+        assert context["columns"][1]["javaType"] == "String"
+        assert "java.time.OffsetDateTime" in context["imports"]
 
     def test_last_flag(self, builder, rbac_user_table):
         ctx = builder.build_context(rbac_user_table, "Default")


### PR DESCRIPTION
## 关联 Issue

Closes #8

## 背景（Situation）

代码生成、MCP 与 ER 图分别维护元数据 SQL，MySQL、PostgreSQL、SQLite 的字段和关系语义容易漂移；PostgreSQL 特有类型和 SQLite 路径也缺少统一归一化边界。

## 任务（Task）

抽离跨数据库 `DatabaseIntrospector` 与方言适配边界，让代码生成和后续可视化复用规范化元数据。

## 行动（Action）

- 引入统一 introspector，集中列、主键、外键、索引和表信息读取。
- 让 `CodegenAnalyzer` 通过共享层生成 `TableInfo` 与模板上下文。
- 建立方言适配与 Java/JDBC 类型映射，覆盖 MySQL、PostgreSQL、SQLite 的核心类型。
- 没有做什么：不宣称所有 PostgreSQL 特性、Oracle 或 SQL Server 已完整实现。

## 验证（Verification）

合并时 PR 记录显示单元测试和 Ruff 已执行，但历史记录未保留可核验的完整环境输出。2026-09-08 在当前主线代码重跑相关隔离测试：`tests/unit/test_database_introspection.py`、`test_postgresql_mcp_tools.py`、`test_codegen_analyzer.py`、`test_visualization_introspection.py` 与路径安全测试共 `43 passed`；这验证当前共享元数据链路，不回溯证明当时的精确测试数量。

## 实验与证据（Evidence）

重验证使用不依赖真实 PostgreSQL 的 stub：复合外键测试断言 `conkey/confkey` 按位置配对，schema 转发测试断言 `tenant_a` 传至列、主键、外键和索引读取。未运行可比性能基准，未作性能收益结论。

## 兼容性、风险与回滚

- 公共 API / 数据格式 / 迁移：共享元数据字段成为生成和 MCP 的契约，应通过回归测试保护。
- 风险：方言 SQL 是高耦合边界，新增数据库或 catalog 特性需要独立契约和集成测试。
- 回滚：回退该重构提交可恢复旧路径，但不建议混合回退后续依赖共享层的修复。
- 后续：用真实数据库 Testcontainers 验证方言差异。