### PR TITLE
:sparkles: feat(postgresql): 支持 schema 级表元数据描述

### DIFF
--- a/src/dbjavagenix/database/introspection.py
+++ b/src/dbjavagenix/database/introspection.py
@@ -76,7 +76,9 @@ class DatabaseIntrospector:
             for row in rows
         ]
 
-    def get_table(self, connection_id: str, table_name: str) -> Dict[str, Any]:
+    def get_table(
+        self, connection_id: str, table_name: str, schema: str | None = None
+    ) -> Dict[str, Any]:
         config = self._config(connection_id)
         if config.type == DatabaseType.MYSQL:
             rows = self.connection_manager.execute_query(
@@ -89,18 +91,26 @@ class DatabaseIntrospector:
                 (config.database, table_name),
             )
         elif config.type == DatabaseType.POSTGRESQL:
+            schema_filter = "AND table_schema = %s" if schema else ""
+            params = (table_name, schema) if schema else (table_name,)
             rows = self.connection_manager.execute_query(
                 connection_id,
-                """
-                SELECT table_name, table_schema, '' AS table_comment,
+                f"""
+                SELECT t.table_name, t.table_schema,
+                       COALESCE(obj_description(c.oid, 'pg_class'), '') AS table_comment,
                        '' AS engine, '' AS table_collation
-                FROM information_schema.tables
-                WHERE table_catalog = current_database()
-                  AND table_type = 'BASE TABLE'
-                  AND table_schema NOT IN ('pg_catalog', 'information_schema')
-                  AND table_name = %s
+                FROM information_schema.tables t
+                JOIN pg_catalog.pg_namespace n ON n.nspname = t.table_schema
+                JOIN pg_catalog.pg_class c
+                  ON c.relnamespace = n.oid AND c.relname = t.table_name
+                WHERE t.table_catalog = current_database()
+                  AND t.table_type = 'BASE TABLE'
+                  AND t.table_schema NOT IN ('pg_catalog', 'information_schema')
+                  AND t.table_name = %s
+                  {schema_filter}
+                ORDER BY t.table_schema
                 """,
-                (table_name,),
+                params,
             )
         elif config.type == DatabaseType.SQLITE:
             rows = self.connection_manager.execute_query(
@@ -113,6 +123,14 @@ class DatabaseIntrospector:
 
         if not rows:
             raise DatabaseAnalysisError(f"Table {table_name} not found")
+        if config.type == DatabaseType.POSTGRESQL and schema is None and len(rows) > 1:
+            public_rows = [row for row in rows if self._value(row, "table_schema") == "public"]
+            if len(public_rows) == 1:
+                rows = public_rows
+            else:
+                raise DatabaseAnalysisError(
+                    f"Table {table_name} exists in multiple schemas; specify schema explicitly"
+                )
         row = rows[0]
         return {
             "name": self._value(row, "TABLE_NAME", "table_name", "name", default=table_name),
@@ -122,7 +140,9 @@ class DatabaseIntrospector:
             "collation": self._value(row, "TABLE_COLLATION", "table_collation"),
         }
 
-    def get_columns(self, connection_id: str, table_name: str) -> List[Dict[str, Any]]:
+    def get_columns(
+        self, connection_id: str, table_name: str, schema: str | None = None
+    ) -> List[Dict[str, Any]]:
         config = self._config(connection_id)
         if config.type == DatabaseType.MYSQL:
             rows = self.connection_manager.execute_query(
@@ -138,21 +158,32 @@ class DatabaseIntrospector:
                 (config.database, table_name),
             )
         elif config.type == DatabaseType.POSTGRESQL:
+            schema_filter = "AND c.table_schema = %s" if schema else ""
+            params = (table_name, schema) if schema else (table_name,)
             rows = self.connection_manager.execute_query(
                 connection_id,
-                """
-                SELECT column_name, data_type, is_nullable, column_default,
-                       '' AS column_comment, data_type AS column_type,
-                       numeric_precision, numeric_scale, character_maximum_length,
-                       '' AS column_key,
-                       CASE WHEN column_default LIKE 'nextval(%' THEN 'auto_increment' ELSE '' END AS extra
-                FROM information_schema.columns
-                WHERE table_catalog = current_database()
-                  AND table_schema NOT IN ('pg_catalog', 'information_schema')
-                  AND table_name = %s
-                ORDER BY ordinal_position
+                f"""
+                SELECT c.column_name, c.data_type, c.udt_name, c.is_nullable,
+                       c.column_default,
+                       COALESCE(col_description(a.attrelid, a.attnum), '') AS column_comment,
+                       format_type(a.atttypid, a.atttypmod) AS column_type,
+                       c.numeric_precision, c.numeric_scale,
+                       c.character_maximum_length, '' AS column_key,
+                       CASE WHEN c.column_default LIKE 'nextval(%' THEN 'auto_increment' ELSE '' END AS extra
+                FROM information_schema.columns c
+                JOIN pg_catalog.pg_namespace n ON n.nspname = c.table_schema
+                JOIN pg_catalog.pg_class tbl
+                  ON tbl.relnamespace = n.oid AND tbl.relname = c.table_name
+                JOIN pg_catalog.pg_attribute a
+                  ON a.attrelid = tbl.oid AND a.attname = c.column_name
+                 AND a.attnum > 0 AND NOT a.attisdropped
+                WHERE c.table_catalog = current_database()
+                  AND c.table_schema NOT IN ('pg_catalog', 'information_schema')
+                  AND c.table_name = %s
+                  {schema_filter}
+                ORDER BY c.ordinal_position
                 """,
-                (table_name,),
+                params,
             )
         elif config.type == DatabaseType.SQLITE:
             rows = self.connection_manager.execute_query(
@@ -178,9 +209,14 @@ class DatabaseIntrospector:
                     "name": name,
                     "type": data_type,
                     "nullable": bool(nullable),
-                    "default_value": self._value(row, "COLUMN_DEFAULT", "column_default", "dflt_value"),
-                    "comment": self._value(row, "COLUMN_COMMENT", "column_comment", default="") or "",
-                    "column_type": self._value(row, "COLUMN_TYPE", "column_type", "type", default=data_type),
+                    "default_value": self._value(
+                        row, "COLUMN_DEFAULT", "column_default", "dflt_value"
+                    ),
+                    "comment": self._value(row, "COLUMN_COMMENT", "column_comment", default="")
+                    or "",
+                    "column_type": self._value(
+                        row, "COLUMN_TYPE", "column_type", "type", default=data_type
+                    ),
                     "precision": self._value(row, "NUMERIC_PRECISION", "numeric_precision"),
                     "scale": self._value(row, "NUMERIC_SCALE", "numeric_scale"),
                     "max_length": self._value(
@@ -195,7 +231,9 @@ class DatabaseIntrospector:
             )
         return columns
 
-    def get_primary_keys(self, connection_id: str, table_name: str) -> List[str]:
+    def get_primary_keys(
+        self, connection_id: str, table_name: str, schema: str | None = None
+    ) -> List[str]:
         config = self._config(connection_id)
         if config.type == DatabaseType.MYSQL:
             rows = self.connection_manager.execute_query(
@@ -210,9 +248,11 @@ class DatabaseIntrospector:
                 (config.database, table_name),
             )
         elif config.type == DatabaseType.POSTGRESQL:
+            schema_filter = "AND tc.constraint_schema = %s" if schema else ""
+            params = (table_name, schema) if schema else (table_name,)
             rows = self.connection_manager.execute_query(
                 connection_id,
-                """
+                f"""
                 SELECT kcu.column_name
                 FROM information_schema.table_constraints tc
                 JOIN information_schema.key_column_usage kcu
@@ -224,9 +264,10 @@ class DatabaseIntrospector:
                   AND tc.constraint_type = 'PRIMARY KEY'
                   AND tc.table_schema NOT IN ('pg_catalog', 'information_schema')
                   AND tc.table_name = %s
+                  {schema_filter}
                 ORDER BY kcu.ordinal_position
                 """,
-                (table_name,),
+                params,
             )
         elif config.type == DatabaseType.SQLITE:
             rows = self.connection_manager.execute_query(
@@ -238,7 +279,9 @@ class DatabaseIntrospector:
             raise DatabaseAnalysisError(f"Primary key metadata not implemented for {config.type}")
         return [str(self._value(row, "COLUMN_NAME", "column_name", "name")) for row in rows]
 
-    def get_foreign_keys(self, connection_id: str, table_name: str) -> List[Dict[str, Any]]:
+    def get_foreign_keys(
+        self, connection_id: str, table_name: str, schema: str | None = None
+    ) -> List[Dict[str, Any]]:
         config = self._config(connection_id)
         if config.type == DatabaseType.MYSQL:
             rows = self.connection_manager.execute_query(
@@ -253,9 +296,11 @@ class DatabaseIntrospector:
                 (config.database, table_name),
             )
         elif config.type == DatabaseType.POSTGRESQL:
+            schema_filter = "AND tc.table_schema = %s" if schema else ""
+            params = (table_name, schema) if schema else (table_name,)
             rows = self.connection_manager.execute_query(
                 connection_id,
-                """
+                f"""
                 SELECT tc.constraint_name, kcu.column_name,
                        ccu.table_name AS referenced_table_name,
                        ccu.column_name AS referenced_column_name
@@ -273,9 +318,10 @@ class DatabaseIntrospector:
                   AND tc.constraint_type = 'FOREIGN KEY'
                   AND tc.table_schema NOT IN ('pg_catalog', 'information_schema')
                   AND tc.table_name = %s
+                  {schema_filter}
                 ORDER BY tc.constraint_name, kcu.ordinal_position
                 """,
-                (table_name,),
+                params,
             )
         elif config.type == DatabaseType.SQLITE:
             rows = self.connection_manager.execute_query(
@@ -301,7 +347,9 @@ class DatabaseIntrospector:
             for row in rows
         ]
 
-    def get_indexes(self, connection_id: str, table_name: str) -> List[Dict[str, Any]]:
+    def get_indexes(
+        self, connection_id: str, table_name: str, schema: str | None = None
+    ) -> List[Dict[str, Any]]:
         config = self._config(connection_id)
         if config.type == DatabaseType.MYSQL:
             rows = self.connection_manager.execute_query(
@@ -318,9 +366,11 @@ class DatabaseIntrospector:
                 for row in rows
             ]
         if config.type == DatabaseType.POSTGRESQL:
+            schema_filter = "AND ns.nspname = %s" if schema else ""
+            params = (table_name, schema) if schema else (table_name,)
             rows = self.connection_manager.execute_query(
                 connection_id,
-                """
+                f"""
                 SELECT idx.relname AS key_name, att.attname AS column_name,
                        i.indisunique AS is_unique, keys.ordinality AS seq_in_index,
                        am.amname AS index_type
@@ -333,9 +383,10 @@ class DatabaseIntrospector:
                 JOIN pg_attribute att ON att.attrelid = tbl.oid AND att.attnum = keys.attnum
                 WHERE ns.nspname NOT IN ('pg_catalog', 'information_schema')
                   AND tbl.relname = %s
+                  {schema_filter}
                 ORDER BY idx.relname, keys.ordinality
                 """,
-                (table_name,),
+                params,
             )
             return [
                 {
@@ -363,3 +414,30 @@ class DatabaseIntrospector:
                 for row in rows
             ]
         raise DatabaseAnalysisError(f"Index metadata not implemented for {config.type}")
+
+    def describe_table(
+        self, connection_id: str, table_name: str, schema: str | None = None
+    ) -> Dict[str, Any]:
+        """Return one normalized metadata document for a table."""
+        table = self.get_table(connection_id, table_name, schema)
+        resolved_schema = schema or table.get("schema")
+        columns = self.get_columns(connection_id, table_name, resolved_schema)
+        primary_keys = self.get_primary_keys(connection_id, table_name, resolved_schema)
+        foreign_keys = self.get_foreign_keys(connection_id, table_name, resolved_schema)
+        indexes = self.get_indexes(connection_id, table_name, resolved_schema)
+        primary_key_set = set(primary_keys)
+        for column in columns:
+            column["primary_key"] = (
+                column.get("primary_key", False) or column["name"] in primary_key_set
+            )
+        return {
+            "name": table["name"],
+            "schema": resolved_schema,
+            "comment": table.get("comment", ""),
+            "engine": table.get("engine"),
+            "collation": table.get("collation"),
+            "columns": columns,
+            "primary_keys": primary_keys,
+            "foreign_keys": foreign_keys,
+            "indexes": indexes,
+        }

--- a/src/dbjavagenix/database/mcp_tools.py
+++ b/src/dbjavagenix/database/mcp_tools.py
@@ -4,6 +4,7 @@ MCP tools for database connection and basic query operations
 import logging
 import os
 import re
+from functools import lru_cache
 from pathlib import Path
 from typing import Dict, Any, List, Optional
 
@@ -11,8 +12,14 @@ from mcp.types import Tool, TextContent, ImageContent, EmbeddedResource
 
 from ..core.models import DatabaseConfig, DatabaseType
 from ..utils.dependency_manager import DependencyManager
-from ..core.exceptions import DatabaseConnectionError, DatabaseQueryError, MCPServiceError
+from ..core.exceptions import (
+    DatabaseAnalysisError,
+    DatabaseConnectionError,
+    DatabaseQueryError,
+    MCPServiceError,
+)
 from ..database.connection_manager import connection_manager
+from ..database.introspection import DatabaseIntrospector
 from ..config.config_manager import ConfigManager
 from ..utils.pom_analyzer import PomAnalyzer
 
@@ -312,6 +319,10 @@ def get_table_analysis_tools() -> List[Tool]:
                         "type": "string",
                         "description": "Table name"
                     },
+                    "schema": {
+                        "type": "string",
+                        "description": "PostgreSQL schema (defaults to the resolved table schema)"
+                    },
                     "include_java_types": {
                         "type": "boolean",
                         "description": "Include Java type mapping for columns",
@@ -339,6 +350,10 @@ def get_table_analysis_tools() -> List[Tool]:
                     "table": {
                         "type": "string",
                         "description": "Table name"
+                    },
+                    "schema": {
+                        "type": "string",
+                        "description": "PostgreSQL schema (optional)"
                     }
                 },
                 "required": ["connection_id", "database", "table"]
@@ -362,6 +377,10 @@ def get_table_analysis_tools() -> List[Tool]:
                     "table": {
                         "type": "string",
                         "description": "Table name"
+                    },
+                    "schema": {
+                        "type": "string",
+                        "description": "PostgreSQL schema (optional)"
                     }
                 },
                 "required": ["connection_id", "database", "table"]
@@ -385,6 +404,10 @@ def get_table_analysis_tools() -> List[Tool]:
                     "table": {
                         "type": "string",
                         "description": "Table name"
+                    },
+                    "schema": {
+                        "type": "string",
+                        "description": "PostgreSQL schema (optional)"
                     }
                 },
                 "required": ["connection_id", "database", "table"]
@@ -408,6 +431,10 @@ def get_table_analysis_tools() -> List[Tool]:
                     "table": {
                         "type": "string",
                         "description": "Table name"
+                    },
+                    "schema": {
+                        "type": "string",
+                        "description": "PostgreSQL schema (optional)"
                     }
                 },
                 "required": ["connection_id", "database", "table"]
@@ -705,7 +732,7 @@ async def handle_db_query_table_exists(arguments: Dict[str, Any]) -> List[TextCo
         connection_id = arguments["connection_id"]
         database = arguments["database"]
         table = arguments["table"]
-        
+
         # Get connection info to determine database type  
         config = connection_manager.get_connection_info(connection_id)
         if not config:
@@ -836,7 +863,7 @@ async def handle_db_query_execute(arguments: Dict[str, Any]) -> List[TextContent
             text=result_text
         )]
         
-    except (DatabaseConnectionError, DatabaseQueryError, MCPServiceError) as e:
+    except (DatabaseAnalysisError, DatabaseConnectionError, DatabaseQueryError, MCPServiceError) as e:
         error_response = {
             "success": False,
             "error": "query_failed",
@@ -875,22 +902,36 @@ def _get_java_type_mapping(db_type: DatabaseType, column_type: str, precision: O
     """
     try:
         config_manager = ConfigManager()
-        type_mapping = config_manager.get_type_mapping()
+        if hasattr(config_manager, "get_type_mapping"):
+            type_mapping = config_manager.get_type_mapping()
+        else:
+            type_mapping = _load_default_type_mapping()
         
         db_key = db_type.value.lower()
-        column_type_upper = column_type.upper()
+        column_type_upper = column_type.upper().strip()
+        base_type = re.sub(r"\([^)]*\)", "", column_type_upper)
+        base_type = re.sub(r"\s+", " ", base_type).strip()
+        type_candidates = [
+            column_type_upper,
+            base_type,
+            column_type_upper.replace(" ", "_"),
+            base_type.replace(" ", "_"),
+        ]
         
         if db_key in type_mapping:
             db_mapping = type_mapping[db_key]
             
             # Search in all categories
             for category in db_mapping.values():
-                if isinstance(category, dict) and column_type_upper in category:
-                    mapping = category[column_type_upper]
-                    return {
-                        "java_type": mapping.get("java_type", "Object"),
-                        "imports": mapping.get("imports", [])
-                    }
+                if not isinstance(category, dict):
+                    continue
+                for candidate in type_candidates:
+                    if candidate in category:
+                        mapping = category[candidate]
+                        return {
+                            "java_type": mapping.get("java_type", "Object"),
+                            "imports": mapping.get("imports", []),
+                        }
         
         # Default fallback
         return {"java_type": "Object", "imports": []}
@@ -898,6 +939,25 @@ def _get_java_type_mapping(db_type: DatabaseType, column_type: str, precision: O
     except Exception as e:
         logger.warning(f"Failed to get Java type mapping: {e}")
         return {"java_type": "Object", "imports": []}
+
+
+@lru_cache(maxsize=1)
+def _load_default_type_mapping() -> Dict[str, Any]:
+    """Load the YAML mapping blocks embedded in the project reference file."""
+    try:
+        import yaml
+
+        path = Path(__file__).resolve().parents[1] / "config" / "default_type_mapping.yaml"
+        text = path.read_text(encoding="utf-8")
+        mapping: Dict[str, Any] = {}
+        for block in re.findall(r"```yaml\s*(.*?)```", text, flags=re.DOTALL):
+            loaded = yaml.safe_load(block)
+            if isinstance(loaded, dict):
+                mapping.update(loaded)
+        return mapping
+    except Exception as exc:
+        logger.warning("Failed to load default type mapping: %s", exc)
+        return {}
 
 
 async def handle_db_table_describe(arguments: Dict[str, Any]) -> List[TextContent]:
@@ -914,107 +974,47 @@ async def handle_db_table_describe(arguments: Dict[str, Any]) -> List[TextConten
         connection_id = arguments["connection_id"]
         database = arguments["database"]
         table = arguments["table"]
+        schema = arguments.get("schema") or None
         include_java_types = arguments.get("include_java_types", True)
-        
-        # Get connection info to determine database type
-        config = connection_manager.get_connection_info(connection_id)
-        if not config:
-            raise DatabaseConnectionError(f"Connection {connection_id} not found")
-        
-        # Query table structure based on database type
-        if config.type == DatabaseType.MYSQL:
-            query = """
-            SELECT 
-                COLUMN_NAME,
-                DATA_TYPE,
-                IS_NULLABLE,
-                COLUMN_DEFAULT,
-                COLUMN_COMMENT,
-                COLUMN_TYPE,
-                NUMERIC_PRECISION,
-                NUMERIC_SCALE,
-                CHARACTER_MAXIMUM_LENGTH,
-                COLUMN_KEY
-            FROM information_schema.COLUMNS 
-            WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s
-            ORDER BY ORDINAL_POSITION
-            """
-            results = connection_manager.execute_query(connection_id, query, (database, table))
-
-        elif config.type == DatabaseType.SQLITE:
-            # SQLite PRAGMA table_info
-            query = f"PRAGMA table_info('{table}')"
-            pragma_results = connection_manager.execute_query(connection_id, query)
-            
-            # Convert PRAGMA results to standard format
-            results = []
-            for row in pragma_results:
-                results.append({
-                    "COLUMN_NAME": row.get("name", ""),
-                    "DATA_TYPE": row.get("type", ""),
-                    "IS_NULLABLE": "YES" if row.get("notnull", 0) == 0 else "NO",
-                    "COLUMN_DEFAULT": row.get("dflt_value"),
-                    "COLUMN_COMMENT": "",
-                    "COLUMN_TYPE": row.get("type", ""),
-                    "NUMERIC_PRECISION": None,
-                    "NUMERIC_SCALE": None, 
-                    "CHARACTER_MAXIMUM_LENGTH": None,
-                    "COLUMN_KEY": "PRI" if row.get("pk", 0) == 1 else ""
-                })
-        else:
-            raise MCPServiceError(f"Table description not implemented for {config.type}")
-        
-        if not results:
-            raise DatabaseQueryError(f"Table '{table}' not found in database '{database}'")
-        
-        # Process column information
+        introspector = DatabaseIntrospector(connection_manager)
+        config = introspector.get_config(connection_id)
+        metadata = introspector.describe_table(connection_id, table, schema)
         columns = []
         java_imports = set()
-        
-        for row in results:
+
+        for row in metadata["columns"]:
             column_info = {
-                "name": row["COLUMN_NAME"],
-                "data_type": row["DATA_TYPE"],
-                "column_type": row["COLUMN_TYPE"],
-                "nullable": row["IS_NULLABLE"] == "YES",
-                "default_value": row["COLUMN_DEFAULT"],
-                "comment": row.get("COLUMN_COMMENT", ""),
-                "is_primary_key": row["COLUMN_KEY"] == "PRI",
-                "precision": row.get("NUMERIC_PRECISION"),
-                "scale": row.get("NUMERIC_SCALE"),
-                "max_length": row.get("CHARACTER_MAXIMUM_LENGTH")
+                "name": row["name"],
+                "data_type": row["type"],
+                "column_type": row["column_type"],
+                "nullable": row["nullable"],
+                "default_value": row["default_value"],
+                "comment": row["comment"],
+                "is_primary_key": row["primary_key"],
+                "precision": row["precision"],
+                "scale": row["scale"],
+                "max_length": row["max_length"],
             }
-            
+
             # Add Java type mapping if requested
             if include_java_types:
                 java_mapping = _get_java_type_mapping(
-                    config.type, 
-                    row["DATA_TYPE"],
-                    row.get("NUMERIC_PRECISION"),
-                    row.get("NUMERIC_SCALE")
+                    config.type,
+                    row["column_type"] or row["type"],
+                    row["precision"],
+                    row["scale"],
                 )
                 column_info["java_type"] = java_mapping["java_type"]
                 java_imports.update(java_mapping["imports"])
-            
+
             columns.append(column_info)
-        
-        # Get additional table information
-        table_comment = ""
-        if config.type == DatabaseType.MYSQL:
-            comment_query = """
-            SELECT TABLE_COMMENT 
-            FROM information_schema.TABLES 
-            WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s
-            """
-            comment_results = connection_manager.execute_query(connection_id, comment_query, (database, table))
-            if comment_results:
-                table_comment = comment_results[0].get("TABLE_COMMENT", "")
-        
+
         response = {
             "success": True,
             "database": database,
             "table": table,
-            "comment": table_comment,
+            "schema": metadata["schema"],
+            "comment": metadata["comment"],
             "columns": columns,
             "column_count": len(columns),
             "java_imports": sorted(list(java_imports)) if include_java_types else []
@@ -1022,8 +1022,8 @@ async def handle_db_table_describe(arguments: Dict[str, Any]) -> List[TextConten
         
         # Format display text
         result_text = f"Table Structure: {database}.{table}\n"
-        if table_comment:
-            result_text += f"Comment: {table_comment}\n"
+        if metadata["comment"]:
+            result_text += f"Comment: {metadata['comment']}\n"
         result_text += f"\nColumns ({len(columns)}):\n\n"
         
         for i, col in enumerate(columns, 1):
@@ -1052,7 +1052,7 @@ async def handle_db_table_describe(arguments: Dict[str, Any]) -> List[TextConten
             text=result_text
         )]
         
-    except (DatabaseConnectionError, DatabaseQueryError, MCPServiceError) as e:
+    except (DatabaseAnalysisError, DatabaseConnectionError, DatabaseQueryError, MCPServiceError) as e:
         error_response = {
             "success": False,
             "error": "analysis_failed",
@@ -1090,7 +1090,8 @@ async def handle_db_table_columns(arguments: Dict[str, Any]) -> List[TextContent
         connection_id = arguments["connection_id"]
         database = arguments["database"]
         table = arguments["table"]
-        
+        schema = arguments.get("schema") or None
+
         # Get connection info to determine database type
         config = connection_manager.get_connection_info(connection_id)
         if not config:
@@ -1115,6 +1116,26 @@ async def handle_db_table_columns(arguments: Dict[str, Any]) -> List[TextContent
             ORDER BY ORDINAL_POSITION
             """
             results = connection_manager.execute_query(connection_id, query, (database, table))
+
+        elif config.type == DatabaseType.POSTGRESQL:
+            columns = DatabaseIntrospector(connection_manager).get_columns(
+                connection_id, table, schema
+            )
+            results = [
+                {
+                    "COLUMN_NAME": column["name"],
+                    "DATA_TYPE": column["type"],
+                    "COLUMN_TYPE": column["column_type"],
+                    "IS_NULLABLE": "YES" if column["nullable"] else "NO",
+                    "COLUMN_DEFAULT": column["default_value"],
+                    "COLUMN_COMMENT": column["comment"],
+                    "NUMERIC_PRECISION": column["precision"],
+                    "NUMERIC_SCALE": column["scale"],
+                    "CHARACTER_MAXIMUM_LENGTH": column["max_length"],
+                    "ORDINAL_POSITION": position,
+                }
+                for position, column in enumerate(columns, 1)
+            ]
             
         elif config.type == DatabaseType.SQLITE:
             query = f"PRAGMA table_info('{table}')"
@@ -1167,7 +1188,7 @@ async def handle_db_table_columns(arguments: Dict[str, Any]) -> List[TextContent
             text=result_text
         )]
         
-    except (DatabaseConnectionError, DatabaseQueryError, MCPServiceError) as e:
+    except (DatabaseAnalysisError, DatabaseConnectionError, DatabaseQueryError, MCPServiceError) as e:
         error_response = {
             "success": False,
             "error": "query_failed",
@@ -1205,7 +1226,8 @@ async def handle_db_table_primary_keys(arguments: Dict[str, Any]) -> List[TextCo
         connection_id = arguments["connection_id"]
         database = arguments["database"]
         table = arguments["table"]
-        
+        schema = arguments.get("schema") or None
+
         # Get connection info to determine database type
         config = connection_manager.get_connection_info(connection_id)
         if not config:
@@ -1224,6 +1246,15 @@ async def handle_db_table_primary_keys(arguments: Dict[str, Any]) -> List[TextCo
             ORDER BY ORDINAL_POSITION
             """
             results = connection_manager.execute_query(connection_id, query, (database, table))
+
+        elif config.type == DatabaseType.POSTGRESQL:
+            primary_keys = DatabaseIntrospector(connection_manager).get_primary_keys(
+                connection_id, table, schema
+            )
+            results = [
+                {"COLUMN_NAME": column_name, "ORDINAL_POSITION": position}
+                for position, column_name in enumerate(primary_keys, 1)
+            ]
             
         elif config.type == DatabaseType.SQLITE:
             query = f"PRAGMA table_info('{table}')"
@@ -1264,7 +1295,7 @@ async def handle_db_table_primary_keys(arguments: Dict[str, Any]) -> List[TextCo
             text=result_text
         )]
         
-    except (DatabaseConnectionError, DatabaseQueryError, MCPServiceError) as e:
+    except (DatabaseAnalysisError, DatabaseConnectionError, DatabaseQueryError, MCPServiceError) as e:
         error_response = {
             "success": False,
             "error": "query_failed",
@@ -1302,7 +1333,8 @@ async def handle_db_table_foreign_keys(arguments: Dict[str, Any]) -> List[TextCo
         connection_id = arguments["connection_id"]
         database = arguments["database"]
         table = arguments["table"]
-        
+        schema = arguments.get("schema") or None
+
         # Get connection info to determine database type
         config = connection_manager.get_connection_info(connection_id)
         if not config:
@@ -1329,6 +1361,23 @@ async def handle_db_table_foreign_keys(arguments: Dict[str, Any]) -> List[TextCo
             ORDER BY kcu.ORDINAL_POSITION
             """
             results = connection_manager.execute_query(connection_id, query, (database, table))
+
+        elif config.type == DatabaseType.POSTGRESQL:
+            foreign_keys = DatabaseIntrospector(connection_manager).get_foreign_keys(
+                connection_id, table, schema
+            )
+            results = [
+                {
+                    "COLUMN_NAME": foreign_key["column_name"],
+                    "REFERENCED_TABLE_SCHEMA": schema or "",
+                    "REFERENCED_TABLE_NAME": foreign_key["referenced_table"],
+                    "REFERENCED_COLUMN_NAME": foreign_key["referenced_column"],
+                    "CONSTRAINT_NAME": foreign_key["constraint_name"],
+                    "UPDATE_RULE": "",
+                    "DELETE_RULE": "",
+                }
+                for foreign_key in foreign_keys
+            ]
             
         elif config.type == DatabaseType.SQLITE:
             query = f"PRAGMA foreign_key_list('{table}')"
@@ -1388,7 +1437,7 @@ async def handle_db_table_foreign_keys(arguments: Dict[str, Any]) -> List[TextCo
             text=result_text
         )]
         
-    except (DatabaseConnectionError, DatabaseQueryError, MCPServiceError) as e:
+    except (DatabaseAnalysisError, DatabaseConnectionError, DatabaseQueryError, MCPServiceError) as e:
         error_response = {
             "success": False,
             "error": "query_failed",
@@ -1426,7 +1475,8 @@ async def handle_db_table_indexes(arguments: Dict[str, Any]) -> List[TextContent
         connection_id = arguments["connection_id"]
         database = arguments["database"]
         table = arguments["table"]
-        
+        schema = arguments.get("schema") or None
+
         # Get connection info to determine database type
         config = connection_manager.get_connection_info(connection_id)
         if not config:
@@ -1449,7 +1499,24 @@ async def handle_db_table_indexes(arguments: Dict[str, Any]) -> List[TextContent
             ORDER BY INDEX_NAME, SEQ_IN_INDEX
             """
             results = connection_manager.execute_query(connection_id, query, (database, table))
-            
+
+        elif config.type == DatabaseType.POSTGRESQL:
+            indexes = DatabaseIntrospector(connection_manager).get_indexes(
+                connection_id, table, schema
+            )
+            results = [
+                {
+                    "INDEX_NAME": index["key_name"],
+                    "COLUMN_NAME": index["column_name"],
+                    "SEQ_IN_INDEX": index["seq_in_index"],
+                    "NON_UNIQUE": 0 if index["unique"] else 1,
+                    "INDEX_TYPE": index["index_type"],
+                    "NULLABLE": "",
+                    "INDEX_COMMENT": "",
+                }
+                for index in indexes
+            ]
+
         elif config.type == DatabaseType.SQLITE:
             # Get index list
             index_query = f"PRAGMA index_list('{table}')"

--- a/tests/unit/test_database_introspection.py
+++ b/tests/unit/test_database_introspection.py
@@ -107,3 +107,68 @@ def test_postgresql_introspection_uses_catalog_queries():
 
     assert len(manager.calls) == 5
     assert all("SHOW TABLES" not in query for query, _ in manager.calls)
+
+
+class SchemaAwarePostgresManager(RecordingManager):
+    def execute_query(self, connection_id, query, params=None):
+        self.calls.append((query, params))
+        if "information_schema.tables" in query:
+            return [
+                {"table_name": "users", "table_schema": params[1] if len(params) > 1 else "public"}
+            ]
+        if "information_schema.columns" in query:
+            return [
+                {
+                    "column_name": "id",
+                    "data_type": "USER-DEFINED",
+                    "is_nullable": "NO",
+                    "column_type": "uuid",
+                    "column_comment": "stable identifier",
+                },
+                {
+                    "column_name": "created_at",
+                    "data_type": "timestamp with time zone",
+                    "is_nullable": "NO",
+                    "column_type": "timestamp with time zone",
+                },
+            ]
+        if "table_constraints" in query and "PRIMARY KEY" in query:
+            return [{"column_name": "id"}]
+        if "pg_index" in query:
+            return [{"key_name": "users_pkey", "column_name": "id", "is_unique": True}]
+        return []
+
+
+def test_postgresql_describe_table_scopes_all_catalog_queries_to_schema():
+    manager = SchemaAwarePostgresManager()
+    metadata = DatabaseIntrospector(manager).describe_table("pg-1", "users", "tenant_a")
+
+    assert metadata["schema"] == "tenant_a"
+    assert metadata["comment"] == ""
+    assert metadata["primary_keys"] == ["id"]
+    assert metadata["columns"][0]["column_type"] == "uuid"
+    assert metadata["columns"][0]["comment"] == "stable identifier"
+    assert metadata["columns"][0]["primary_key"] is True
+    assert all(params == ("users", "tenant_a") for _, params in manager.calls if params)
+
+
+def test_postgresql_get_table_rejects_ambiguous_schema():
+    manager = RecordingManager()
+
+    def execute_query(connection_id, query, params=None):
+        if "information_schema.tables" in query:
+            return [
+                {"table_name": "users", "table_schema": "tenant_a"},
+                {"table_name": "users", "table_schema": "tenant_b"},
+            ]
+        return []
+
+    manager.execute_query = execute_query
+    introspector = DatabaseIntrospector(manager)
+
+    try:
+        introspector.get_table("pg-1", "users")
+    except Exception as exc:
+        assert "multiple schemas" in str(exc)
+    else:
+        raise AssertionError("ambiguous PostgreSQL table should require schema")

--- a/tests/unit/test_postgresql_mcp_tools.py
+++ b/tests/unit/test_postgresql_mcp_tools.py
@@ -107,3 +107,140 @@ async def test_table_exists_uses_postgresql_catalog(monkeypatch, postgres_info):
 
     assert "exists in database" in response[0].text
     assert calls[0][2] == ("app", "users")
+
+
+def test_postgresql_java_mapping_normalizes_catalog_type_names():
+    assert mcp_tools._get_java_type_mapping(
+        DatabaseType.POSTGRESQL, "timestamp with time zone"
+    ) == {"java_type": "OffsetDateTime", "imports": ["java.time.OffsetDateTime"]}
+    assert mcp_tools._get_java_type_mapping(DatabaseType.POSTGRESQL, "uuid") == {
+        "java_type": "UUID",
+        "imports": ["java.util.UUID"],
+    }
+    assert mcp_tools._get_java_type_mapping(DatabaseType.POSTGRESQL, "jsonb") == {
+        "java_type": "String",
+        "imports": [],
+    }
+    assert mcp_tools._get_java_type_mapping(DatabaseType.POSTGRESQL, "character varying(255)") == {
+        "java_type": "String",
+        "imports": [],
+    }
+    assert mcp_tools._get_java_type_mapping(
+        DatabaseType.POSTGRESQL, "timestamp(6) with time zone"
+    ) == {"java_type": "OffsetDateTime", "imports": ["java.time.OffsetDateTime"]}
+
+
+@pytest.mark.asyncio
+async def test_table_describe_uses_normalized_introspection_with_schema(monkeypatch):
+    class Introspector:
+        def __init__(self, manager):
+            assert manager is mcp_tools.connection_manager
+
+        def get_config(self, connection_id):
+            assert connection_id == "pg-1"
+            return SimpleNamespace(type=DatabaseType.POSTGRESQL)
+
+        def describe_table(self, connection_id, table, schema):
+            assert (connection_id, table, schema) == ("pg-1", "users", "tenant_a")
+            return {
+                "name": "users",
+                "schema": "tenant_a",
+                "comment": "tenant users",
+                "columns": [
+                    {
+                        "name": "id",
+                        "type": "USER-DEFINED",
+                        "column_type": "uuid",
+                        "nullable": False,
+                        "default_value": None,
+                        "comment": "identifier",
+                        "primary_key": True,
+                        "precision": None,
+                        "scale": None,
+                        "max_length": None,
+                    }
+                ],
+            }
+
+    monkeypatch.setattr(mcp_tools, "DatabaseIntrospector", Introspector)
+    response = await mcp_tools.handle_db_table_describe(
+        {
+            "connection_id": "pg-1",
+            "database": "app",
+            "schema": "tenant_a",
+            "table": "users",
+            "include_java_types": False,
+        }
+    )
+
+    text = response[0].text
+    assert "tenant_a" in text
+    assert "tenant users" in text
+    assert "USER-DEFINED" in text
+
+
+@pytest.mark.asyncio
+async def test_postgresql_table_detail_tools_forward_schema(monkeypatch):
+    class Introspector:
+        def __init__(self, manager):
+            pass
+
+        def get_columns(self, connection_id, table, schema):
+            assert (connection_id, table, schema) == ("pg-1", "users", "tenant_a")
+            return [
+                {
+                    "name": "id",
+                    "type": "bigint",
+                    "column_type": "bigint",
+                    "nullable": False,
+                    "default_value": None,
+                    "comment": "",
+                    "precision": None,
+                    "scale": None,
+                    "max_length": None,
+                }
+            ]
+
+        def get_primary_keys(self, connection_id, table, schema):
+            assert (connection_id, table, schema) == ("pg-1", "users", "tenant_a")
+            return ["id"]
+
+        def get_foreign_keys(self, connection_id, table, schema):
+            assert (connection_id, table, schema) == ("pg-1", "users", "tenant_a")
+            return [
+                {
+                    "column_name": "org_id",
+                    "referenced_table": "orgs",
+                    "referenced_column": "id",
+                    "constraint_name": "users_org_fk",
+                }
+            ]
+
+        def get_indexes(self, connection_id, table, schema):
+            assert (connection_id, table, schema) == ("pg-1", "users", "tenant_a")
+            return [
+                {
+                    "key_name": "users_pkey",
+                    "column_name": "id",
+                    "seq_in_index": 1,
+                    "unique": True,
+                    "index_type": "btree",
+                }
+            ]
+
+    monkeypatch.setattr(mcp_tools, "DatabaseIntrospector", Introspector)
+    monkeypatch.setattr(
+        mcp_tools.connection_manager,
+        "get_connection_info",
+        lambda connection_id: SimpleNamespace(type=DatabaseType.POSTGRESQL),
+    )
+    common = {"connection_id": "pg-1", "database": "app", "schema": "tenant_a", "table": "users"}
+
+    responses = await mcp_tools.handle_db_table_columns(common)
+    assert "bigint" in responses[0].text
+    responses = await mcp_tools.handle_db_table_primary_keys(common)
+    assert "id" in responses[0].text
+    responses = await mcp_tools.handle_db_table_foreign_keys(common)
+    assert "orgs.id" in responses[0].text
+    responses = await mcp_tools.handle_db_table_indexes(common)
+    assert "users_pkey" in responses[0].text


### PR DESCRIPTION
## 变更说明
关联 #11。

本 PR 基于真实的 PostgreSQL 元数据兼容问题，完成以下实现：

- 在统一 `DatabaseIntrospector` 中支持显式 schema 查询表、列、主键、外键和索引。
- 读取 PostgreSQL 表注释和列注释，并保留 `format_type` 返回的原生类型。
- `db_table_describe` 复用统一元数据结构，返回 schema、注释、约束和规范化列信息。
- 四个细粒度表分析工具接入 PostgreSQL 分支并转发 schema 参数。
- 修复 Java 类型映射因 `ConfigManager` 缺少接口而全部退化为 `Object` 的问题；补充类型修饰符归一化。

## 验证结果

- `pytest -q tests/unit/ --cov=src/dbjavagenix --cov-fail-under=35`：555 passed，覆盖率 47.67%。
- `ruff check src/ tests/ scripts/`：通过。
- changed-file `ruff format --check`：通过。
- `python -m compileall -q src tests`：通过。
- `pytest -q tests/integration/ --no-cov`：本机未安装 Docker，3 项按测试夹具规则跳过。

本 PR 不包含未经基准测试验证的性能提升数字；后续性能结论应基于可重放的真实数据库基准。