### PR TITLE
:lock: security(mcp): 脱敏凭据输出

### DIFF
--- a/src/dbjavagenix/database/connection_manager.py
+++ b/src/dbjavagenix/database/connection_manager.py
@@ -10,6 +10,7 @@ from contextlib import contextmanager
 
 from ..core.models import DatabaseConfig, DatabaseType
 from ..core.exceptions import DatabaseConnectionError, DatabaseQueryError
+from ..utils.security import redact_sensitive_text
 
 logger = logging.getLogger(__name__)
 
@@ -81,8 +82,9 @@ class ConnectionManager:
             return connection_id
             
         except Exception as e:
-            logger.error(f"Failed to create connection: {e}")
-            raise DatabaseConnectionError(f"Failed to connect to database: {str(e)}")
+            safe_error = redact_sensitive_text(e, (config.password,))
+            logger.error("Failed to create connection: %s", safe_error)
+            raise DatabaseConnectionError(f"Failed to connect to database: {safe_error}") from e
     
     def get_connection(self, connection_id: str) -> Any:
         """

--- a/src/dbjavagenix/database/mcp_tools.py
+++ b/src/dbjavagenix/database/mcp_tools.py
@@ -22,6 +22,7 @@ from ..database.connection_manager import connection_manager
 from ..database.introspection import DatabaseIntrospector
 from ..config.config_manager import ConfigManager
 from ..utils.pom_analyzer import PomAnalyzer
+from ..utils.security import redact_sensitive_data, redact_sensitive_text
 
 logger = logging.getLogger(__name__)
 
@@ -519,26 +520,28 @@ async def handle_db_connect_test(arguments: Dict[str, Any]) -> List[TextContent]
         )]
         
     except DatabaseConnectionError as e:
+        safe_error = redact_sensitive_text(e)
         error_response = {
             "success": False,
             "error": "connection_failed",
-            "message": str(e)
+            "message": safe_error
         }
         return [TextContent(
             type="text",
-            text=f"Database connection failed: {str(e)}\n\nRaw Response: {error_response}"
+            text=f"Database connection failed: {safe_error}\n\nRaw Response: {error_response}"
         )]
         
     except Exception as e:
         logger.error(f"Unexpected error in db_connect_test: {e}")
+        safe_error = redact_sensitive_text(e)
         error_response = {
             "success": False,
-            "error": "unexpected_error", 
-            "message": f"Unexpected error: {str(e)}"
+            "error": "unexpected_error",
+            "message": f"Unexpected error: {safe_error}"
         }
         return [TextContent(
             type="text",
-            text=f"Unexpected error: {str(e)}\n\nRaw Response: {error_response}"
+            text=f"Unexpected error: {safe_error}\n\nRaw Response: {error_response}"
         )]
 
 
@@ -3010,6 +3013,12 @@ async def handle_springboot_read_config(arguments: Dict[str, Any]) -> List[TextC
             'logging': _get(effective_config, 'logging', {}),
         }
 
+        # Configuration files can contain database passwords, API keys, and tokens.
+        # Keep the full structure useful for callers while ensuring no secret crosses
+        # the MCP response boundary.
+        safe_effective_config = redact_sensitive_data(effective_config)
+        safe_extracted = redact_sensitive_data(extracted)
+
         response = {
             'success': True,
             'project_root': str(project_root) if project_root else None,
@@ -3021,8 +3030,8 @@ async def handle_springboot_read_config(arguments: Dict[str, Any]) -> List[TextC
             'files_scanned': files_scanned,
             'profiles_available': sorted(list(profiles_found.keys())),
             'active_profile': profile or _get(effective_config, 'spring.profiles.active'),
-            'effective': extracted,
-            'raw_config': effective_config,
+            'effective': safe_extracted,
+            'raw_config': safe_effective_config,
         }
 
         text_lines = []
@@ -3031,7 +3040,7 @@ async def handle_springboot_read_config(arguments: Dict[str, Any]) -> List[TextC
         text_lines.append(f"Build Tool: {build_tool or 'Unknown'}  | Spring Boot: {spring_boot_version or 'Unknown'}")
         text_lines.append(f"Base Package: {base_package or 'Unknown'}")
         text_lines.append(f"Profiles: {', '.join(response['profiles_available']) if response['profiles_available'] else 'None'}")
-        eff = extracted
+        eff = safe_extracted
         text_lines.append('— Effective —')
         text_lines.append(f"app.name={eff.get('spring',{}).get('application',{}).get('name')}")
         text_lines.append(f"server.port={eff.get('server',{}).get('port')}")

--- a/src/dbjavagenix/server/mcp_server.py
+++ b/src/dbjavagenix/server/mcp_server.py
@@ -62,6 +62,7 @@ from ..database.observability_tools import (
     handle_server_metrics,
 )
 from ..utils.metrics import GLOBAL_TOOL_METRICS
+from ..utils.security import redact_sensitive_data
 from ..utils.logging_config import configure_logging
 from ..utils.tool_registry import filter_tools_for_listing
 
@@ -156,7 +157,7 @@ async def handle_call_tool(name: str, arguments: dict[str, Any]) -> list[TextCon
     Returns:
         Tool execution results
     """
-    logger.info(f"Calling tool: {name} with arguments: {arguments}")
+    logger.info("Calling tool: %s with arguments: %s", name, redact_sensitive_data(arguments))
     import time as _time_for_metrics
     _start_perf = _time_for_metrics.perf_counter()
     _is_error = False

--- a/src/dbjavagenix/utils/security.py
+++ b/src/dbjavagenix/utils/security.py
@@ -1,0 +1,84 @@
+"""Helpers for preventing credentials from crossing logging and response boundaries."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Iterable
+
+
+_SENSITIVE_KEY_NAMES = {
+    "password",
+    "passwd",
+    "secret",
+    "token",
+    "api_key",
+    "apikey",
+    "access_key",
+    "private_key",
+    "authorization",
+    "credential",
+}
+_SENSITIVE_KEY_PREFIXES = ("password_", "passwd_", "secret_", "authorization_", "credential_")
+_SENSITIVE_KEY_SUFFIXES = (
+    "_password",
+    "_passwd",
+    "_secret",
+    "_token",
+    "_api_key",
+    "_apikey",
+    "_access_key",
+    "_private_key",
+    "_authorization",
+    "_credential",
+)
+_URL_PASSWORD_RE = re.compile(r"(?P<prefix>://[^/\s:@]+:)(?P<password>[^@/\s]+)(?P<suffix>@)")
+_QUERY_SECRET_RE = re.compile(
+    r"(?P<prefix>[?&](?:password|passwd|token|api[_-]?key|secret)=)(?P<value>[^&\s]+)",
+    re.IGNORECASE,
+)
+
+
+def is_sensitive_key(key: object) -> bool:
+    """Return whether a mapping key commonly identifies a secret value."""
+    normalized = str(key).replace("-", "_").lower()
+    return (
+        normalized in _SENSITIVE_KEY_NAMES
+        or normalized.startswith(_SENSITIVE_KEY_PREFIXES)
+        or normalized.endswith(_SENSITIVE_KEY_SUFFIXES)
+    )
+
+
+def redact_sensitive_data(value: Any, replacement: str = "***") -> Any:
+    """Recursively redact secret-looking mapping values without mutating input."""
+    if isinstance(value, dict):
+        return {
+            key: replacement if is_sensitive_key(key) else redact_sensitive_data(item, replacement)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [redact_sensitive_data(item, replacement) for item in value]
+    if isinstance(value, tuple):
+        return tuple(redact_sensitive_data(item, replacement) for item in value)
+    if isinstance(value, set):
+        return {redact_sensitive_data(item, replacement) for item in value}
+    if isinstance(value, str):
+        return _redact_embedded_credentials(value, replacement)
+    return value
+
+
+def redact_sensitive_text(value: object, secrets: Iterable[object] = ()) -> str:
+    """Replace known secret values in exception text before it is logged or returned."""
+    text = str(value)
+    for secret in secrets:
+        if secret is None:
+            continue
+        candidate = str(secret)
+        if candidate:
+            text = text.replace(candidate, "***")
+    return _redact_embedded_credentials(text, "***")
+
+
+def _redact_embedded_credentials(value: str, replacement: str) -> str:
+    """Mask credentials embedded in JDBC/HTTP URLs and query strings."""
+    value = _URL_PASSWORD_RE.sub(r"\g<prefix>" + replacement + r"\g<suffix>", value)
+    return _QUERY_SECRET_RE.sub(r"\g<prefix>" + replacement, value)

--- a/tests/unit/test_security.py
+++ b/tests/unit/test_security.py
@@ -1,0 +1,119 @@
+"""Regression tests for secret redaction at logging and MCP response boundaries."""
+
+import logging
+
+import pytest
+
+from dbjavagenix.core.exceptions import DatabaseConnectionError
+from dbjavagenix.core.models import DatabaseConfig, DatabaseType
+from dbjavagenix.database.connection_manager import ConnectionManager
+from dbjavagenix.server import mcp_server
+from dbjavagenix.database import mcp_tools
+from dbjavagenix.utils.security import redact_sensitive_data, redact_sensitive_text
+
+
+def test_redact_sensitive_data_handles_nested_values_without_mutating_input():
+    payload = {
+        "username": "reader",
+        "password": "db-secret",
+        "nested": {"api-key": "llm-secret", "value": 3},
+        "token_count": 12,
+        "items": [{"access_token": "token-value"}],
+    }
+
+    redacted = redact_sensitive_data(payload)
+
+    assert redacted == {
+        "username": "reader",
+        "password": "***",
+        "nested": {"api-key": "***", "value": 3},
+        "token_count": 12,
+        "items": [{"access_token": "***"}],
+    }
+    assert payload["password"] == "db-secret"
+
+
+def test_redact_sensitive_text_replaces_known_secret_values():
+    assert redact_sensitive_text("connect failed for db-secret", ["db-secret"]) == (
+        "connect failed for ***"
+    )
+    assert redact_sensitive_text("jdbc:mysql://reader:db-secret@db/app") == (
+        "jdbc:mysql://reader:***@db/app"
+    )
+
+
+def test_connection_error_masks_password_in_log_and_exception(monkeypatch, caplog):
+    config = DatabaseConfig(
+        type=DatabaseType.MYSQL,
+        host="db.example",
+        port=3306,
+        database="app",
+        username="reader",
+        password="db-secret",
+    )
+
+    def fail_connect(**_kwargs):
+        raise RuntimeError("access denied for db-secret")
+
+    monkeypatch.setattr("dbjavagenix.database.connection_manager.pymysql.connect", fail_connect)
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(DatabaseConnectionError, match=r"\*\*\*") as exc_info:
+            ConnectionManager().create_connection(config)
+
+    assert "db-secret" not in str(exc_info.value)
+    assert "db-secret" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_mcp_call_logging_does_not_emit_credentials(monkeypatch, caplog):
+    async def handler(arguments):
+        return []
+
+    monkeypatch.setattr(mcp_server, "_tool_handlers", lambda: {"test_tool": handler})
+    with caplog.at_level(logging.INFO, logger=mcp_server.logger.name):
+        await mcp_server.handle_call_tool(
+            "test_tool",
+            {"username": "reader", "password": "db-secret", "nested": {"api_key": "llm-secret"}},
+        )
+
+    message = "\n".join(record.getMessage() for record in caplog.records)
+    assert "db-secret" not in message
+    assert "llm-secret" not in message
+    assert "***" in message
+
+
+@pytest.mark.asyncio
+async def test_spring_config_response_redacts_credentials(tmp_path, monkeypatch):
+    resources = tmp_path / "src" / "main" / "resources"
+    resources.mkdir(parents=True)
+    (resources / "application.yml").write_text(
+        "spring:\n"
+        "  application:\n"
+        "    name: demo\n"
+        "  datasource:\n"
+        "    url: jdbc:mysql://reader:db-secret@db/demo\n"
+        "    username: reader\n"
+        "    password: db-secret\n"
+        "custom:\n"
+        "  api-token: llm-secret\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        mcp_tools,
+        "detect_springboot_project_structure",
+        lambda _start_dir: {
+            "project_root": tmp_path,
+            "java_source_dir": None,
+            "resources_dir": resources,
+        },
+    )
+
+    response = await mcp_tools.handle_springboot_read_config({"project_path": str(tmp_path)})
+    text = response[0].text
+
+    assert "db-secret" not in text
+    assert "llm-secret" not in text
+    assert "'password': '***'" in text
+    assert "'api-token': '***'" in text
+    assert "reader:***@db/demo" in text
+    assert "name=demo" in text


### PR DESCRIPTION
## 关联 Issue

Closes #16

## 背景

MCP 服务此前会在调用日志中记录完整工具参数；`springboot_read_config` 会在 `Raw Response` 中返回 Spring 配置原文。这两个边界可能包含数据库密码、API Key、Token，以及 URL 中内嵌的密码。

## 变更

- 新增递归脱敏工具，按常见敏感字段名掩码嵌套映射，并处理 URL user-info 与查询参数中的凭据。
- MCP 工具调用日志改为记录脱敏后的参数。
- 连接失败日志和对外异常使用已脱敏的错误文本。
- Spring Boot 配置读取保留原有结构和非敏感字段，但对 `effective` 与 `raw_config` 中的敏感值脱敏。
- 新增回归测试，覆盖嵌套字段、URL 内嵌密码、连接异常、MCP 日志和配置响应。

## 没有做什么

- 未改变连接建立、配置加载或数据库查询行为。
- 未将配置文件加密或修改用户现有配置文件。
- 未将启发式字段匹配扩展为全局日志过滤器；后续新响应边界仍需显式使用脱敏工具。

## 兼容性

- 返回结构不变；只有敏感值从明文变为 `***`，这是预期的安全修复。
- 无迁移步骤；回滚可直接还原本 PR 的单个提交。

## 验证

```text
$env:PYTHONPATH='src'; python -m pytest tests/unit
563 passed，覆盖率 50%

ruff check src/dbjavagenix/utils/security.py src/dbjavagenix/server/mcp_server.py tests/unit/test_security.py
All checks passed
```

完整 `pytest` 在本机收集阶段仍要求真实 MySQL 的环境变量，因未配置该依赖而退出；该限制与本 PR 无关。

## 实验与结果

使用固定测试输入 `db-secret`、`llm-secret` 与 `jdbc:mysql://reader:db-secret@db/demo` 重放：

- MCP 调用日志和连接异常均不含 `db-secret`。
- Spring 配置响应不含两项明文凭据，URL 显示为 `reader:***@db/demo`。
- 非敏感字段如应用名与 `token_count` 保持可见。

本 PR 未进行性能基准，未报告性能提升数据。

## 风险与后续工作

- 风险：自定义且不含常见敏感字段名的配置值无法被自动识别。
- 后续：新增配置/日志响应边界时复用脱敏工具，并在真实问题出现时扩展字段规则与测试用例。