### PR TITLE
:zap: perf(database): 建立元数据描述基线

### DIFF
--- a/docs/benchmarks/introspection.md
+++ b/docs/benchmarks/introspection.md
@@ -1,0 +1,24 @@
+# 元数据描述基线
+
+该基准用于比较 `DatabaseIntrospector.describe_table()` 的真实变化，不预设优化目标，也不把单机延迟当作跨环境结论。
+
+## 复现
+
+基准只使用 SQLite 内存数据库，不需要 Docker 或外部数据库：
+
+```powershell
+$env:PYTHONPATH = "src"
+python scripts/benchmark_introspection.py --iterations 30 --warmup 5
+```
+
+输出为 JSON，包含中位数、P95、最小/最大延迟，以及每次描述调用的 SQL 查询次数。固定 schema 包含 `users`、`orders`、复合索引和外键，确保不同提交使用相同输入。
+
+## 解释结果
+
+- `queries_per_call` 用于识别 SQL 往返次数变化；它比单次延迟更适合作为代码优化的稳定信号。
+- 延迟受操作系统、Python 版本和当前负载影响。提交 PR 时应附上命令、环境和原始 JSON，不将本地数字写成普遍性能保证。
+- 当前基准只覆盖 SQLite；PostgreSQL/MySQL 对比需要可用的真实实例或 CI 服务后再扩展。
+
+## 当前范围
+
+本次只建立可重放基线，没有改变元数据查询实现，也没有声称性能提升。后续优化必须先用该基准记录前后结果，并同时确认元数据契约测试仍通过。

--- a/scripts/benchmark_introspection.py
+++ b/scripts/benchmark_introspection.py
@@ -1,0 +1,142 @@
+"""Reproducible metadata introspection benchmark.
+
+The benchmark intentionally uses only the local SQLite driver so it can run without
+Docker or external services.  It measures the public ``describe_table`` contract,
+including the number of SQL round trips made per call.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import platform
+import statistics
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT / "src") not in sys.path:
+    sys.path.insert(0, str(ROOT / "src"))
+
+from dbjavagenix.core.models import DatabaseConfig, DatabaseType
+from dbjavagenix.database.connection_manager import ConnectionManager
+from dbjavagenix.database.introspection import DatabaseIntrospector
+
+
+def _build_fixture() -> tuple[ConnectionManager, str]:
+    manager = ConnectionManager()
+    connection_id = manager.create_connection(
+        DatabaseConfig(
+            type=DatabaseType.SQLITE,
+            host="",
+            port=0,
+            database=":memory:",
+            username="",
+            password="",
+        )
+    )
+    manager.execute_query(
+        connection_id,
+        """
+        PRAGMA foreign_keys = ON;
+        """,
+    )
+    manager.execute_query(
+        connection_id,
+        """
+        CREATE TABLE users (
+            id INTEGER PRIMARY KEY,
+            email TEXT NOT NULL,
+            created_at TIMESTAMP NOT NULL
+        )
+        """,
+    )
+    manager.execute_query(
+        connection_id,
+        """
+        CREATE TABLE orders (
+            id INTEGER PRIMARY KEY,
+            user_id INTEGER NOT NULL,
+            total_cents INTEGER NOT NULL,
+            created_at TIMESTAMP NOT NULL,
+            FOREIGN KEY(user_id) REFERENCES users(id)
+        )
+        """,
+    )
+    manager.execute_query(
+        connection_id,
+        "CREATE UNIQUE INDEX orders_user_created_idx ON orders(user_id, created_at)",
+    )
+    return manager, connection_id
+
+
+def _percentile(samples: list[float], percentile: float) -> float:
+    ordered = sorted(samples)
+    index = max(0, min(len(ordered) - 1, math.ceil(percentile * len(ordered)) - 1))
+    return ordered[index]
+
+
+def run_benchmark(iterations: int = 30, warmup: int = 5) -> dict[str, Any]:
+    """Measure SQLite ``describe_table`` latency and SQL round trips."""
+    if iterations < 1:
+        raise ValueError("iterations must be at least 1")
+    if warmup < 0:
+        raise ValueError("warmup must not be negative")
+
+    manager, connection_id = _build_fixture()
+    query_count = 0
+    original_execute = manager.execute_query
+
+    def counted_execute(*args: Any, **kwargs: Any):
+        nonlocal query_count
+        query_count += 1
+        return original_execute(*args, **kwargs)
+
+    manager.execute_query = counted_execute  # type: ignore[method-assign]
+    introspector = DatabaseIntrospector(manager)
+    try:
+        for _ in range(warmup):
+            introspector.describe_table(connection_id, "orders")
+        query_count = 0
+
+        samples: list[float] = []
+        metadata: dict[str, Any] = {}
+        for _ in range(iterations):
+            start = time.perf_counter()
+            metadata = introspector.describe_table(connection_id, "orders")
+            samples.append((time.perf_counter() - start) * 1000)
+
+        return {
+            "database": "sqlite",
+            "operation": "describe_table",
+            "table": "orders",
+            "iterations": iterations,
+            "warmup": warmup,
+            "columns": len(metadata["columns"]),
+            "indexes": len(metadata["indexes"]),
+            "foreign_keys": len(metadata["foreign_keys"]),
+            "queries_per_call": query_count / iterations,
+            "min_ms": min(samples),
+            "median_ms": statistics.median(samples),
+            "p95_ms": _percentile(samples, 0.95),
+            "max_ms": max(samples),
+            "python": platform.python_version(),
+            "platform": platform.platform(),
+        }
+    finally:
+        manager.close_connection(connection_id)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--iterations", type=int, default=30)
+    parser.add_argument("--warmup", type=int, default=5)
+    args = parser.parse_args()
+    print(json.dumps(run_benchmark(args.iterations, args.warmup), ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_introspection_benchmark.py
+++ b/tests/unit/test_introspection_benchmark.py
@@ -1,0 +1,28 @@
+"""Tests for the reproducible local introspection benchmark."""
+
+import runpy
+from pathlib import Path
+
+import pytest
+
+
+_MODULE = runpy.run_path(str(Path(__file__).parents[2] / "scripts" / "benchmark_introspection.py"))
+run_benchmark = _MODULE["run_benchmark"]
+
+
+def test_benchmark_reports_contract_and_round_trip_baseline():
+    result = run_benchmark(iterations=3, warmup=1)
+
+    assert result["database"] == "sqlite"
+    assert result["operation"] == "describe_table"
+    assert result["columns"] == 4
+    assert result["indexes"] == 2
+    assert result["foreign_keys"] == 1
+    assert result["queries_per_call"] == 6
+    assert 0 < result["median_ms"] <= result["p95_ms"] <= result["max_ms"]
+
+
+@pytest.mark.parametrize("iterations, warmup, message", [(0, 1, "at least 1"), (1, -1, "negative")])
+def test_benchmark_rejects_invalid_parameters(iterations, warmup, message):
+    with pytest.raises(ValueError, match=message):
+        run_benchmark(iterations=iterations, warmup=warmup)


### PR DESCRIPTION
## 关联 Issue

Closes #14

## 背景

当前元数据描述由 `DatabaseIntrospector.describe_table()` 统一提供，但仓库没有可重复的延迟与 SQL 往返基线。没有固定输入和采样方法时，无法判断后续优化是否真实有效。

## 变更

- 新增 `scripts/benchmark_introspection.py`，使用固定 SQLite 内存 schema 测量 `describe_table`。
- 支持 `--iterations` 和 `--warmup`，输出最小值、中位数、P95、最大值、查询次数和运行环境 JSON。
- 固定 schema 覆盖外键、复合索引和主键，确保前后提交使用同一工作量。
- 新增参数校验和基准契约测试。
- 新增中文基准文档，明确单机数据的解释边界以及 PostgreSQL/MySQL 尚未覆盖的限制。

## 没有做什么

- 未修改元数据查询实现，不声称任何性能提升。
- 未把本机延迟数字写成跨环境 SLA 或招聘材料结论。
- 未依赖 Docker、真实数据库或第三方 benchmark 插件。

## 兼容性

仅新增脚本、文档和测试，不改变运行时 API、MCP 工具响应或数据库行为。

## 验证

```text
$env:PYTHONPATH='src'; python -m pytest tests/unit
567 passed，覆盖率 50%

ruff check scripts/benchmark_introspection.py tests/unit/test_introspection_benchmark.py
All checks passed

ruff format --check scripts/benchmark_introspection.py tests/unit/test_introspection_benchmark.py
2 files already formatted
```

## 实验与结果

命令：

```text
$env:PYTHONPATH='src'; python scripts/benchmark_introspection.py --iterations 30 --warmup 5
```

本机一次完整输出的关键字段：

```json
{"database":"sqlite","operation":"describe_table","columns":4,"indexes":2,"foreign_keys":1,"queries_per_call":6.0,"min_ms":0.1026,"median_ms":0.1101,"p95_ms":0.1205,"max_ms":0.1318,"python":"3.10.1","platform":"Windows-10-10.0.26200-SP0"}
```

该结果仅是当前机器、当前 Python 进程负载下的可重放基线；本 PR 没有性能优化数据。

## 风险与后续工作

- 风险：SQLite 内存数据库不能代表网络数据库的延迟，单次样本也会受本机调度影响。
- 后续：在具备稳定 PostgreSQL/MySQL 实例后扩展同一 schema 和输出格式，再依据前后实测决定是否优化 SQL 往返。
- 回滚：删除新增脚本、测试和文档即可，不涉及运行时代码回滚。