### PR TITLE
:sparkles: feat(config): 支持 DATABASE_URL 配置覆盖

### DIFF
--- a/src/dbjavagenix/config/config_manager.py
+++ b/src/dbjavagenix/config/config_manager.py
@@ -1,10 +1,12 @@
 """
 Configuration management for DBJavaGenix
 """
+
 import os
 import yaml
 from pathlib import Path
 from typing import Optional, Dict, Any
+from urllib.parse import parse_qs, unquote, urlparse
 from pydantic import BaseModel, Field
 
 from ..core.models import DatabaseConfig, AIConfig, GenerationConfig
@@ -13,10 +15,11 @@ from ..core.exceptions import ConfigurationError
 
 class AppConfig(BaseModel):
     """Main application configuration"""
+
     database: DatabaseConfig
     ai: AIConfig
     generation: GenerationConfig
-    
+
     # Global settings
     debug: bool = Field(default=False, description="Enable debug mode")
     log_level: str = Field(default="INFO", description="Logging level")
@@ -25,93 +28,136 @@ class AppConfig(BaseModel):
 
 class ConfigManager:
     """Configuration manager"""
-    
+
     def __init__(self, config_path: Optional[str] = None):
         self.config_path = config_path or self._find_config_file()
         self._config: Optional[AppConfig] = None
-    
+
     def _find_config_file(self) -> str:
         """Find configuration file"""
         # Priority order: env var -> current dir -> home dir -> default
         paths = [
             os.getenv("DBJAVAGENIX_CONFIG"),
             "./config.yaml",
-            "./config.yml", 
+            "./config.yml",
             os.path.expanduser("~/.dbjavagenix/config.yaml"),
             os.path.expanduser("~/.dbjavagenix/config.yml"),
         ]
-        
+
         for path in paths:
             if path and Path(path).exists():
                 return path
-        
+
         # Return default path if none found
         return "./config.yaml"
-    
+
     def load_config(self) -> AppConfig:
         """Load configuration from file"""
         if self._config is not None:
             return self._config
-        
+
         try:
             if not Path(self.config_path).exists():
                 raise ConfigurationError(f"Configuration file not found: {self.config_path}")
-            
-            with open(self.config_path, 'r', encoding='utf-8') as f:
+
+            with open(self.config_path, "r", encoding="utf-8") as f:
                 config_data = yaml.safe_load(f)
-            
+
             # Override with environment variables
             config_data = self._apply_env_overrides(config_data)
-            
+
             self._config = AppConfig(**config_data)
             return self._config
-            
+
         except Exception as e:
             raise ConfigurationError(f"Failed to load configuration: {e}")
-    
+
     def _apply_env_overrides(self, config_data: Dict[str, Any]) -> Dict[str, Any]:
         """Apply environment variable overrides"""
         # Database overrides
         if db_url := os.getenv("DATABASE_URL"):
             config_data.setdefault("database", {})
-            # Parse DATABASE_URL and update config_data["database"]
-            # Format: mysql://user:pass@host:port/db
-            # This is a simplified implementation
-        
+            config_data["database"].update(self._parse_database_url(db_url))
+
         # AI service overrides
         if api_key := os.getenv("AI_API_KEY"):
             config_data.setdefault("ai", {})
             config_data["ai"]["api_key"] = api_key
-        
+
         if ai_provider := os.getenv("AI_PROVIDER"):
             config_data.setdefault("ai", {})
             config_data["ai"]["provider"] = ai_provider
-        
+
         # Generation overrides
         if output_dir := os.getenv("OUTPUT_DIR"):
             config_data.setdefault("generation", {})
             config_data["generation"]["output_dir"] = output_dir
-        
+
         if package_name := os.getenv("PACKAGE_NAME"):
             config_data.setdefault("generation", {})
             config_data["generation"]["package_name"] = package_name
-        
+
         return config_data
-    
+
+    @staticmethod
+    def _parse_database_url(database_url: str) -> Dict[str, Any]:
+        """Convert a conventional DATABASE_URL into ``DatabaseConfig`` fields."""
+        parsed = urlparse(database_url)
+        scheme = parsed.scheme.lower()
+        scheme_aliases = {
+            "mysql": ("mysql", 3306),
+            "mysql+pymysql": ("mysql", 3306),
+            "postgres": ("postgresql", 5432),
+            "postgresql": ("postgresql", 5432),
+            "sqlite": ("sqlite", 0),
+        }
+        if scheme not in scheme_aliases:
+            raise ConfigurationError(
+                "DATABASE_URL scheme must be mysql, postgresql, postgres, or sqlite"
+            )
+
+        database_type, default_port = scheme_aliases[scheme]
+        query = parse_qs(parsed.query)
+        if database_type == "sqlite":
+            database = parsed.path or parsed.netloc
+            if database == "/:memory:":
+                database = ":memory:"
+            elif database.startswith("/") and not database.startswith("//"):
+                # sqlite:///relative.db is conventionally represented without the URL slash.
+                database = database[1:]
+            return {
+                "type": database_type,
+                "host": "",
+                "port": 0,
+                "database": database,
+                "username": "",
+                "password": "",
+            }
+
+        return {
+            "type": database_type,
+            "host": parsed.hostname or "",
+            "port": parsed.port or default_port,
+            "database": parsed.path.lstrip("/"),
+            "username": unquote(parsed.username or ""),
+            "password": unquote(parsed.password or ""),
+            **({"charset": query["charset"][0]} if query.get("charset") else {}),
+        }
+
     def save_config(self, config: AppConfig) -> None:
         """Save configuration to file"""
         try:
             # Ensure directory exists
             Path(self.config_path).parent.mkdir(parents=True, exist_ok=True)
-            
-            with open(self.config_path, 'w', encoding='utf-8') as f:
+
+            with open(self.config_path, "w", encoding="utf-8") as f:
                 yaml.dump(config.model_dump(), f, default_flow_style=False, allow_unicode=True)
-            
+
             self._config = config
-            
+
         except Exception as e:
             raise ConfigurationError(f"Failed to save configuration: {e}")
-    
+
     def create_default_config(self) -> AppConfig:
         """Create default configuration"""
         return AppConfig(
@@ -121,14 +167,8 @@ class ConfigManager:
                 port=3306,
                 database="test",
                 username="root",
-                password="password"
+                password="password",
             ),
-            ai=AIConfig(
-                provider="openai",
-                api_key="your-api-key-here"
-            ),
-            generation=GenerationConfig(
-                output_dir="./generated",
-                package_name="com.example"
-            )
+            ai=AIConfig(provider="openai", api_key="your-api-key-here"),
+            generation=GenerationConfig(output_dir="./generated", package_name="com.example"),
         )

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,8 +1,10 @@
 """
 Test configuration for DBJavaGenix
 """
+
 import pytest
 from dbjavagenix.config.config_manager import ConfigManager
+from dbjavagenix.core.exceptions import ConfigurationError
 from dbjavagenix.core.models import DatabaseType, AIProvider, CodeStyle
 
 
@@ -16,7 +18,59 @@ def test_create_default_config():
     """Test creating default configuration"""
     config_manager = ConfigManager()
     config = config_manager.create_default_config()
-    
+
     assert config.database.type == DatabaseType.MYSQL
     assert config.ai.provider == AIProvider.OPENAI
     assert config.generation.code_style == CodeStyle.SPRING_BOOT
+
+
+@pytest.mark.parametrize(
+    ("database_url", "database_type", "host", "port", "database", "username", "password"),
+    [
+        (
+            "mysql://reader:p%40ss@db.internal/app?charset=utf8mb4",
+            DatabaseType.MYSQL,
+            "db.internal",
+            3306,
+            "app",
+            "reader",
+            "p@ss",
+        ),
+        (
+            "postgresql://reader:p%40ss@db.internal/app",
+            DatabaseType.POSTGRESQL,
+            "db.internal",
+            5432,
+            "app",
+            "reader",
+            "p@ss",
+        ),
+        ("sqlite:///:memory:", DatabaseType.SQLITE, "", 0, ":memory:", "", ""),
+    ],
+)
+def test_database_url_override_is_parsed(
+    monkeypatch,
+    database_url,
+    database_type,
+    host,
+    port,
+    database,
+    username,
+    password,
+):
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    parsed = ConfigManager()._apply_env_overrides({"database": {}})["database"]
+
+    assert parsed["type"] == database_type.value
+    assert parsed["host"] == host
+    assert parsed["port"] == port
+    assert parsed["database"] == database
+    assert parsed["username"] == username
+    assert parsed["password"] == password
+
+
+def test_database_url_override_rejects_unknown_scheme(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "oracle://reader:secret@db.internal/app")
+
+    with pytest.raises(ConfigurationError, match="scheme"):
+        ConfigManager()._apply_env_overrides({"database": {}})


### PR DESCRIPTION
## 关联 Issue

Closes #17

## 背景

`ConfigManager._apply_env_overrides` 已经读取 `DATABASE_URL`，但此前只留下注释，没有解析或写回配置。在容器、CI 和托管平台中，这会让环境变量看似生效、实际仍使用配置文件里的数据库连接信息。

## 变更

- 使用标准库 URL 解析器将 `DATABASE_URL` 转换为 `DatabaseConfig` 字段。
- 支持 `mysql://`、`mysql+pymysql://`、`postgres://`、`postgresql://` 和 `sqlite:///`。
- 支持默认端口、URL 编码的用户名/密码，以及 MySQL `charset` 查询参数。
- SQLite 内存库 `sqlite:///:memory:` 映射为 `:memory:`，相对路径与绝对路径保持可用形式。
- 未知 scheme 返回明确的配置错误，不会静默回退。
- 新增覆盖三类数据库、编码凭据和非法 scheme 的单元测试。

## 没有做什么

- 不新增 Oracle/SQL Server 驱动；枚举虽保留这些类型，但连接实现仍未覆盖。
- 不改变配置文件写入逻辑，也不把环境变量持久化到磁盘。
- 不在 URL 解析层执行网络连接或数据库探测。

## 兼容性

- 未设置 `DATABASE_URL` 时，原有配置行为保持不变。
- 设置后只覆盖 `database` 节点，AI 和代码生成配置仍由原有环境变量处理。
- 密码只用于连接配置对象，不在本 PR 新增日志输出。

## 验证

```text
$env:PYTHONPATH='src'; python -m pytest tests/unit
571 passed，覆盖率 50%

ruff check src/ tests/ scripts/
All checks passed

ruff format --check src/dbjavagenix/config/config_manager.py tests/unit/test_config.py
2 files already formatted
```

## 实验与结果

使用固定输入验证：

- `mysql://reader:p%40ss@db.internal/app?charset=utf8mb4` -> MySQL、3306、密码 `p@ss`、charset `utf8mb4`。
- `postgresql://reader:p%40ss@db.internal/app` -> PostgreSQL、5432、密码 `p@ss`。
- `sqlite:///:memory:` -> SQLite、数据库 `:memory:`、端口 0。
- `oracle://...` -> 明确抛出 scheme 配置错误。

本 PR 是配置功能修复，没有性能基准或性能提升结论。

## 风险与后续工作

- 风险：DATABASE_URL 的非标准 scheme 或驱动专属参数不会被识别，会在加载阶段失败并提示 scheme 错误。
- 后续：如果新增数据库驱动，需同时扩展 scheme 映射、连接实现和集成测试。
- 回滚：还原本 PR 提交即可恢复原有“仅检测、不解析”的行为。