### PR TITLE
:books: docs(architecture): 补充元数据契约决策

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ PYTHONPATH=src python -m dbjavagenix.cli server
 | [docs/screenshots/README.md](docs/screenshots/README.md) | MCP Apps 4 组件客户端兼容性 |
 | [docs/algorithms-overview.md](docs/algorithms-overview.md) | v0.2.1 schema 图算法 (topo / cluster / cycle) |
 | [docs/design-patterns-catalog.md](docs/design-patterns-catalog.md) | 生成器与生成代码中的设计模式 |
-| [docs/adr/](docs/adr/) | 10 个 ADR (架构 / 原子 / 渐进 / 规则 / 不引依赖 / schema 算法 / 规范配置 / MCP v3 / 1h 缓存 / agentic) |
+| [docs/adr/](docs/adr/) | 14 个 ADR (架构 / 原子 / 渐进 / 规则 / 不引依赖 / schema 算法 / 规范配置 / MCP v3 / 1h 缓存 / agentic / 多方言 / SDK 契约 / 工具契约 / 元数据契约) |
 | [.claude/skills/java-codegen-from-db/SKILL.md](.claude/skills/java-codegen-from-db/SKILL.md) | 主 Skill: 代码生成 5 阶段工作流 |
 | [.claude/skills/springboot-migration/SKILL.md](.claude/skills/springboot-migration/SKILL.md) | 第二 Skill: Spring Boot 2.7→3.x 迁移 |
 

--- a/docs/adr/014-metadata-introspection-contract.md
+++ b/docs/adr/014-metadata-introspection-contract.md
@@ -1,0 +1,42 @@
+# ADR-014: 统一数据库元数据描述契约
+
+- **状态**: Accepted
+- **日期**: 2026-09-07
+- **关联 Issue**: #18
+- **关联实现**: `src/dbjavagenix/database/introspection.py`
+
+## 背景
+
+代码生成、MCP 表工具和 ER 可视化都需要读取表、列、主键、外键和索引。早期实现把 MySQL、PostgreSQL 和 SQLite 查询分散在调用方，导致同一字段在不同数据库中的名称、空值和顺序不一致。PostgreSQL schema 同名表和 SQLite 特殊表名还会让“看似成功”的结果指向错误对象。
+
+## 决策
+
+以 `DatabaseIntrospector` 作为数据库元数据的唯一读取边界：
+
+1. 对外返回统一字典结构：`name`、`schema`、`comment`、`columns`、`primary_keys`、`foreign_keys`、`indexes`。
+2. 方言 SQL 只保留在 introspector 内部；调用方不再根据数据库类型拼接 catalog/PRAGMA 查询。
+3. PostgreSQL 查询在提供 schema 时必须对所有 catalog 查询加同一 schema 条件；未提供 schema 且存在歧义时明确要求调用方指定 schema。
+4. SQLite PRAGMA 标识符统一转义单引号，并保留复合索引的列顺序和表达式索引占位信息。
+5. 新增字段必须先更新跨数据库契约测试，再被代码生成或 MCP 工具消费。
+
+## 备选方案
+
+- 让每个 MCP 工具维护自己的查询：实现重复、修复无法同步，已拒绝。
+- 使用 SQLAlchemy Inspector 直接暴露厂商结果：无法稳定覆盖注释、原生类型和 SQLite PRAGMA 的项目契约，且会把方言差异泄漏给上层，已拒绝。
+- 只返回最小的表/列列表：无法满足代码生成所需的约束、索引和注释信息，已拒绝。
+
+## 影响
+
+- 代码生成、MCP 表详情和 ER 图共享同一元数据语义，新增数据库方言只需扩展边界模块和契约测试。
+- `describe_table` 会按表、列、主键、外键、索引读取多组元数据；查询往返次数由 `docs/benchmarks/introspection.md` 的可重放基准持续记录。
+- 返回结构稳定优先于厂商字段一一映射；厂商独有字段可以保留在标准字段中，但不能改变必需字段的含义。
+
+## 验证
+
+- `tests/unit/test_metadata_contract.py` 验证 MySQL、PostgreSQL、SQLite 的共同字段和主键/索引语义。
+- `tests/unit/test_database_introspection.py` 验证 PostgreSQL schema 隔离、歧义检测、SQLite 特殊标识符及复合索引顺序。
+- PostgreSQL/SQLite 具体行为由相应集成测试和 MCP 工具回归测试覆盖。
+
+## 后续
+
+新增 Oracle 或 SQL Server 支持时，必须实现同一契约并补充真实数据库集成测试；在此之前不在 README 中宣称其元数据读取已完成。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,3 +22,6 @@
 - [ADR-011: Multi-dialect strategy](011-multi-dialect-strategy.md)
 - [ADR-012: Pin MCP SDK to the 1.x API contract](012-mcp-sdk-compatibility.md)
 - [ADR-013: Canonical MCP tool contract](013-canonical-mcp-tool-contract.md)
+
+### v0.3 (数据库元数据契约)
+- [ADR-014: 统一数据库元数据描述契约](014-metadata-introspection-contract.md)

--- a/src/dbjavagenix/config/config_manager.py
+++ b/src/dbjavagenix/config/config_manager.py
@@ -1,10 +1,12 @@
 """
 Configuration management for DBJavaGenix
 """
+
 import os
 import yaml
 from pathlib import Path
 from typing import Optional, Dict, Any
+from urllib.parse import parse_qs, unquote, urlparse
 from pydantic import BaseModel, Field
 
 from ..core.models import DatabaseConfig, AIConfig, GenerationConfig
@@ -13,10 +15,11 @@ from ..core.exceptions import ConfigurationError
 
 class AppConfig(BaseModel):
     """Main application configuration"""
+
     database: DatabaseConfig
     ai: AIConfig
     generation: GenerationConfig
-    
+
     # Global settings
     debug: bool = Field(default=False, description="Enable debug mode")
     log_level: str = Field(default="INFO", description="Logging level")
@@ -25,93 +28,136 @@ class AppConfig(BaseModel):
 
 class ConfigManager:
     """Configuration manager"""
-    
+
     def __init__(self, config_path: Optional[str] = None):
         self.config_path = config_path or self._find_config_file()
         self._config: Optional[AppConfig] = None
-    
+
     def _find_config_file(self) -> str:
         """Find configuration file"""
         # Priority order: env var -> current dir -> home dir -> default
         paths = [
             os.getenv("DBJAVAGENIX_CONFIG"),
             "./config.yaml",
-            "./config.yml", 
+            "./config.yml",
             os.path.expanduser("~/.dbjavagenix/config.yaml"),
             os.path.expanduser("~/.dbjavagenix/config.yml"),
         ]
-        
+
         for path in paths:
             if path and Path(path).exists():
                 return path
-        
+
         # Return default path if none found
         return "./config.yaml"
-    
+
     def load_config(self) -> AppConfig:
         """Load configuration from file"""
         if self._config is not None:
             return self._config
-        
+
         try:
             if not Path(self.config_path).exists():
                 raise ConfigurationError(f"Configuration file not found: {self.config_path}")
-            
-            with open(self.config_path, 'r', encoding='utf-8') as f:
+
+            with open(self.config_path, "r", encoding="utf-8") as f:
                 config_data = yaml.safe_load(f)
-            
+
             # Override with environment variables
             config_data = self._apply_env_overrides(config_data)
-            
+
             self._config = AppConfig(**config_data)
             return self._config
-            
+
         except Exception as e:
             raise ConfigurationError(f"Failed to load configuration: {e}")
-    
+
     def _apply_env_overrides(self, config_data: Dict[str, Any]) -> Dict[str, Any]:
         """Apply environment variable overrides"""
         # Database overrides
         if db_url := os.getenv("DATABASE_URL"):
             config_data.setdefault("database", {})
-            # Parse DATABASE_URL and update config_data["database"]
-            # Format: mysql://user:pass@host:port/db
-            # This is a simplified implementation
-        
+            config_data["database"].update(self._parse_database_url(db_url))
+
         # AI service overrides
         if api_key := os.getenv("AI_API_KEY"):
             config_data.setdefault("ai", {})
             config_data["ai"]["api_key"] = api_key
-        
+
         if ai_provider := os.getenv("AI_PROVIDER"):
             config_data.setdefault("ai", {})
             config_data["ai"]["provider"] = ai_provider
-        
+
         # Generation overrides
         if output_dir := os.getenv("OUTPUT_DIR"):
             config_data.setdefault("generation", {})
             config_data["generation"]["output_dir"] = output_dir
-        
+
         if package_name := os.getenv("PACKAGE_NAME"):
             config_data.setdefault("generation", {})
             config_data["generation"]["package_name"] = package_name
-        
+
         return config_data
-    
+
+    @staticmethod
+    def _parse_database_url(database_url: str) -> Dict[str, Any]:
+        """Convert a conventional DATABASE_URL into ``DatabaseConfig`` fields."""
+        parsed = urlparse(database_url)
+        scheme = parsed.scheme.lower()
+        scheme_aliases = {
+            "mysql": ("mysql", 3306),
+            "mysql+pymysql": ("mysql", 3306),
+            "postgres": ("postgresql", 5432),
+            "postgresql": ("postgresql", 5432),
+            "sqlite": ("sqlite", 0),
+        }
+        if scheme not in scheme_aliases:
+            raise ConfigurationError(
+                "DATABASE_URL scheme must be mysql, postgresql, postgres, or sqlite"
+            )
+
+        database_type, default_port = scheme_aliases[scheme]
+        query = parse_qs(parsed.query)
+        if database_type == "sqlite":
+            database = parsed.path or parsed.netloc
+            if database == "/:memory:":
+                database = ":memory:"
+            elif database.startswith("/") and not database.startswith("//"):
+                # sqlite:///relative.db is conventionally represented without the URL slash.
+                database = database[1:]
+            return {
+                "type": database_type,
+                "host": "",
+                "port": 0,
+                "database": database,
+                "username": "",
+                "password": "",
+            }
+
+        return {
+            "type": database_type,
+            "host": parsed.hostname or "",
+            "port": parsed.port or default_port,
+            "database": parsed.path.lstrip("/"),
+            "username": unquote(parsed.username or ""),
+            "password": unquote(parsed.password or ""),
+            **({"charset": query["charset"][0]} if query.get("charset") else {}),
+        }
+
     def save_config(self, config: AppConfig) -> None:
         """Save configuration to file"""
         try:
             # Ensure directory exists
             Path(self.config_path).parent.mkdir(parents=True, exist_ok=True)
-            
-            with open(self.config_path, 'w', encoding='utf-8') as f:
+
+            with open(self.config_path, "w", encoding="utf-8") as f:
                 yaml.dump(config.model_dump(), f, default_flow_style=False, allow_unicode=True)
-            
+
             self._config = config
-            
+
         except Exception as e:
             raise ConfigurationError(f"Failed to save configuration: {e}")
-    
+
     def create_default_config(self) -> AppConfig:
         """Create default configuration"""
         return AppConfig(
@@ -121,14 +167,8 @@ class ConfigManager:
                 port=3306,
                 database="test",
                 username="root",
-                password="password"
+                password="password",
             ),
-            ai=AIConfig(
-                provider="openai",
-                api_key="your-api-key-here"
-            ),
-            generation=GenerationConfig(
-                output_dir="./generated",
-                package_name="com.example"
-            )
+            ai=AIConfig(provider="openai", api_key="your-api-key-here"),
+            generation=GenerationConfig(output_dir="./generated", package_name="com.example"),
         )

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,8 +1,10 @@
 """
 Test configuration for DBJavaGenix
 """
+
 import pytest
 from dbjavagenix.config.config_manager import ConfigManager
+from dbjavagenix.core.exceptions import ConfigurationError
 from dbjavagenix.core.models import DatabaseType, AIProvider, CodeStyle
 
 
@@ -16,7 +18,59 @@ def test_create_default_config():
     """Test creating default configuration"""
     config_manager = ConfigManager()
     config = config_manager.create_default_config()
-    
+
     assert config.database.type == DatabaseType.MYSQL
     assert config.ai.provider == AIProvider.OPENAI
     assert config.generation.code_style == CodeStyle.SPRING_BOOT
+
+
+@pytest.mark.parametrize(
+    ("database_url", "database_type", "host", "port", "database", "username", "password"),
+    [
+        (
+            "mysql://reader:p%40ss@db.internal/app?charset=utf8mb4",
+            DatabaseType.MYSQL,
+            "db.internal",
+            3306,
+            "app",
+            "reader",
+            "p@ss",
+        ),
+        (
+            "postgresql://reader:p%40ss@db.internal/app",
+            DatabaseType.POSTGRESQL,
+            "db.internal",
+            5432,
+            "app",
+            "reader",
+            "p@ss",
+        ),
+        ("sqlite:///:memory:", DatabaseType.SQLITE, "", 0, ":memory:", "", ""),
+    ],
+)
+def test_database_url_override_is_parsed(
+    monkeypatch,
+    database_url,
+    database_type,
+    host,
+    port,
+    database,
+    username,
+    password,
+):
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    parsed = ConfigManager()._apply_env_overrides({"database": {}})["database"]
+
+    assert parsed["type"] == database_type.value
+    assert parsed["host"] == host
+    assert parsed["port"] == port
+    assert parsed["database"] == database
+    assert parsed["username"] == username
+    assert parsed["password"] == password
+
+
+def test_database_url_override_rejects_unknown_scheme(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "oracle://reader:secret@db.internal/app")
+
+    with pytest.raises(ConfigurationError, match="scheme"):
+        ConfigManager()._apply_env_overrides({"database": {}})


### PR DESCRIPTION
## 关联 Issue

Closes #18

## 背景

数据库元数据读取已经在 #21/#22/#23 中形成统一实现，但架构文档没有记录这一边界；根 README 仍写着只有 10 个 ADR，读者无法从索引追踪 schema 隔离、SQLite 标识符转义和跨数据库契约测试。

## 变更

- 新增 ADR-014，记录 `DatabaseIntrospector` 的统一元数据契约、方言边界、schema 歧义处理和 SQLite 复合索引语义。
- 记录被拒绝的替代方案，明确为什么不让 MCP 工具各自拼接 catalog SQL，也不直接暴露厂商结果。
- 在 ADR 索引中登记 ADR-014。
- 根 README 的 ADR 数量和主题更新为当前 14 个，并覆盖多方言、SDK/工具契约和元数据契约。

## 没有做什么

- 不改变运行时代码、MCP 响应或数据库查询。
- 不在文档中宣称 Oracle/SQL Server 元数据支持已完成。
- 不修改历史研究稿与演示稿中的阶段性 ADR 数量描述。

## 兼容性

仅新增/修正文档，不影响安装、调用和数据格式。ADR-014 的验证章节链接到现有单元、集成和基准测试。

## 验证

```text
git diff --check
通过

python -m pytest tests/unit
571 passed（基于 main 的现有测试集）

python scripts/validate_commit_title.py --title ':books: docs(architecture): 补充元数据契约决策'
OK
```

## 实验与结果

本 PR 为架构记录，不涉及性能实验。文档中的 `describe_table` 查询往返数据引用 `docs/benchmarks/introspection.md`，该基准仍按原始脚本复现，不新增未经测量的数字。

## 风险与后续工作

- 风险：ADR 索引与历史演示文档存在不同阶段的数量描述，历史文档保留原文可能让读者看到不同数字。
- 后续：新增数据库方言时同步更新 ADR-014、契约测试和集成测试。
- 回滚：删除 ADR-014 并还原索引/README 行即可。