### PR TITLE
:construction_worker: ci: 增加 Python 打包安装门禁

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,10 +206,41 @@ jobs:
             -c "import dbjavagenix; print(dbjavagenix.__version__)"
           test "$(docker run --rm --entrypoint id dbjavagenix:ci -u)" != "0"
 
+  package:
+    name: Python package build smoke test
+    runs-on: ubuntu-latest
+    env:
+      PYTHONPATH: src
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Build wheel and source distribution
+        run: |
+          uv venv --python 3.12
+          uv pip install -e ".[dev]" "build>=1.2"
+          uv run python -m build --sdist --wheel
+
+      - name: Install wheel in an isolated environment
+        run: |
+          smoke_venv="$(mktemp -d)"
+          uv venv "$smoke_venv" --python 3.12
+          uv pip install --python "$smoke_venv/bin/python" dist/*.whl
+          "$smoke_venv/bin/python" -c "import dbjavagenix; print(dbjavagenix.__version__)"
+          "$smoke_venv/bin/dbjavagenix" --help >/dev/null
+
   ci-success:
     name: Required CI status
     if: always()
-    needs: [metadata, quality, format, integration, templates, docker]
+    needs: [metadata, quality, format, integration, templates, docker, package]
     runs-on: ubuntu-latest
     steps:
       - name: Fail when any required job failed or was cancelled

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ PYTHONPATH=src python -m dbjavagenix.cli server
 
 ### Phase 1 现代化基础
 - Python ≥ 3.11 / mcp ≥ 1.6 / Spring Boot 3.5 + Java 21 模板
-- 单元测试 360+,GitHub Actions CI 三 Job (lint / template-render / docker-build)
+- 单元测试 360+，GitHub Actions 分层 CI（提交策略、三版本质量、格式、数据库集成、模板、Docker、打包安装）
 - 多阶段 Dockerfile (`python:3.11-slim` + 非 root 用户)
 
 ### Phase 2 Skills 层与原子工具

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -171,7 +171,7 @@ PYTHONPATH=src python -m dbjavagenix.cli server
 - [ ] **数据库**: 提供给 `db_connect_test` 的凭据可读 (`db_query_tables` 返回非空)
 - [ ] **模板**: `templates/java/sb35-java21/` 等目录存在 (Docker 镜像内已包含)
 - [ ] **凭据**: `ANTHROPIC_API_KEY` 通过环境变量而非镜像内置 (避免泄露)
-- [ ] **CI**: GitHub Actions 全绿 (lint + unit + docker build)
+- [ ] **CI**: GitHub Actions 全绿（提交策略、质量矩阵、格式、数据库集成、模板、Docker、打包安装）
 
 ## 六、常见排障
 


### PR DESCRIPTION
## 关联 Issue

Closes #19

## 背景

现有 CI 已覆盖 lint、单元测试、模板渲染、数据库集成和 Docker 非 root smoke，但没有验证 Python 包能否从构建产物安装。`pyproject.toml`、包数据或 entry point 的回归可能在源码测试通过后才被发现。

## 变更

- 新增独立的 `Python package build smoke test` job。
- 在 Python 3.12 环境构建 sdist 和 wheel。
- 在全新虚拟环境安装 wheel，验证 `import dbjavagenix` 和 `dbjavagenix --help`。
- 将 package job 纳入 `Required CI status`，构建或安装失败会阻断合并。
- README 与部署检查清单更新为当前分层 CI 能力。

## 没有做什么

- 不增加性能阈值、外部数据库服务或与项目无关的扫描器。
- 不修改运行时代码、依赖版本或发布流程。
- 不把本机 Windows shell 的 glob 行为作为 CI 结论；workflow 在 Ubuntu runner 上执行。

## 兼容性

仅增加 CI 门禁和文档说明。wheel 安装在隔离环境执行，不会污染其他质量 job。

## 验证

```text
python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"
workflow YAML parsed

$env:PYTHONPATH='src'; python -m pytest tests/unit
571 passed

ruff check src/ tests/ scripts/
All checks passed

uv run python -m build --sdist --wheel
Successfully built dbjavagenix-0.1.0.tar.gz and dbjavagenix-0.1.0-py3-none-any.whl

隔离环境安装 wheel 后：import dbjavagenix -> 0.1.0；dbjavagenix --help 正常输出 Usage
```

## 实验与结果

本 PR 的实验目标是验证构建产物可安装，而不是测量性能。CI job 会在干净 Ubuntu 环境复现同样的构建、隔离安装和 CLI smoke；未引入性能数字或 STAR 结论。

## 风险与后续工作

- 风险：构建依赖 `setuptools` 当前会提示 license 元数据弃用警告，但不影响构建结果；可在单独维护任务中迁移 SPDX 配置。
- 后续：发布 PyPI 前可在此 job 后追加 artifact 检查或 TestPyPI 发布演练。
- 回滚：移除 package job 并从 required needs 中删除即可，不影响其他 CI 层。