### PR TITLE
:bug: fix(metadata): 支持 PostgreSQL schema 表列表过滤

### DIFF
--- a/src/dbjavagenix/cli.py
+++ b/src/dbjavagenix/cli.py
@@ -337,9 +337,10 @@ def list_tables(
 
         # Get table list
         if db_config.database:
-            tables_result = handle_db_query_tables(
-                {"connection_id": connection_id, "database": db_config.database}
-            )
+            table_query = {"connection_id": connection_id, "database": db_config.database}
+            if schema:
+                table_query["schema"] = schema
+            tables_result = handle_db_query_tables(table_query)
 
             if tables_result.get("success"):
                 tables = tables_result["tables"]

--- a/src/dbjavagenix/database/mcp_tools.py
+++ b/src/dbjavagenix/database/mcp_tools.py
@@ -240,6 +240,10 @@ def get_connection_tools() -> List[Tool]:
                     "database": {
                         "type": "string",
                         "description": "Database name"
+                    },
+                    "schema": {
+                        "type": "string",
+                        "description": "PostgreSQL schema (optional)"
                     }
                 },
                 "required": ["connection_id", "database"]
@@ -644,6 +648,7 @@ async def handle_db_query_tables(arguments: Dict[str, Any]) -> List[TextContent]
     try:
         connection_id = arguments["connection_id"]
         database = arguments["database"]
+        schema = arguments.get("schema")
         
         # Get connection info to determine database type
         config = connection_manager.get_connection_info(connection_id)
@@ -651,6 +656,7 @@ async def handle_db_query_tables(arguments: Dict[str, Any]) -> List[TextContent]
             raise DatabaseConnectionError(f"Connection {connection_id} not found")
         
         # Query tables based on database type
+        schema_filter = "AND table_schema = %s" if schema else ""
         if config.type == DatabaseType.MYSQL:
             query = f"SHOW TABLES FROM `{database}`"
             params = None
@@ -662,9 +668,10 @@ async def handle_db_query_tables(arguments: Dict[str, Any]) -> List[TextContent]
             WHERE table_catalog = %s
               AND table_type = 'BASE TABLE'
               AND table_schema NOT IN ('pg_catalog', 'information_schema')
+              {schema_filter}
             ORDER BY table_schema, table_name
-            """
-            params = (database,)
+            """.format(schema_filter=schema_filter)
+            params = (database, schema) if schema else (database,)
         elif config.type == DatabaseType.SQLITE:
             query = "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'"
             params = None
@@ -687,13 +694,15 @@ async def handle_db_query_tables(arguments: Dict[str, Any]) -> List[TextContent]
         response = {
             "success": True,
             "database": database,
+            "schema": schema,
             "tables": tables,
             "count": len(tables)
         }
         
         return [TextContent(
             type="text",
-            text=f"Found {len(tables)} tables in database '{database}':\n" +
+            text=f"Found {len(tables)} tables in database '{database}'" +
+                 (f" schema '{schema}'" if schema else "") + ":\n" +
                  "\n".join(f"- {table}" for table in tables) +
                  f"\n\nRaw Response: {response}"
         )]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -173,3 +173,41 @@ def test_codegen_analysis_wrapper_parses_structured_response(monkeypatch):
     result = cli_helpers.handle_db_codegen_analyze({"connection_id": "conn-1"})
 
     assert result == {"success": True, "table_name": "users"}
+
+
+def test_list_tables_forwards_schema_filter(monkeypatch):
+    mod = importlib.import_module("dbjavagenix.cli")
+    calls = {}
+    config = SimpleNamespace(
+        database=SimpleNamespace(
+            type="postgresql",
+            host="db.example",
+            port=5432,
+            username="reader",
+            password="secret",
+            database="app",
+            charset="utf8mb4",
+        )
+    )
+    monkeypatch.setattr(mod, "show_ascii_icon", lambda: None)
+    monkeypatch.setattr(
+        mod, "ConfigManager", lambda *_args, **_kwargs: SimpleNamespace(load_config=lambda: config)
+    )
+    monkeypatch.setattr(
+        mod,
+        "handle_db_connect_test",
+        lambda _args: {"success": True, "connection_id": "pg-1", "server_info": "PostgreSQL"},
+    )
+    monkeypatch.setattr(
+        mod,
+        "handle_db_query_tables",
+        lambda args: calls.update(args=args) or {"success": True, "tables": []},
+    )
+    monkeypatch.setattr(
+        mod.connection_manager, "close_connection", lambda cid: calls.update(close=cid)
+    )
+
+    mod.list_tables(schema="tenant_a")
+
+    assert calls["args"] == {"connection_id": "pg-1", "database": "app", "schema": "tenant_a"}
+    assert calls["close"] == "pg-1"

--- a/tests/unit/test_postgresql_mcp_tools.py
+++ b/tests/unit/test_postgresql_mcp_tools.py
@@ -89,6 +89,28 @@ async def test_query_tables_uses_catalog_and_parameters(monkeypatch, postgres_in
 
 
 @pytest.mark.asyncio
+async def test_query_tables_applies_schema_filter_with_bound_parameter(monkeypatch, postgres_info):
+    calls = []
+    monkeypatch.setattr(
+        mcp_tools.connection_manager, "get_connection_info", lambda cid: postgres_info
+    )
+
+    def execute_query(connection_id, query, params=None):
+        calls.append((connection_id, query, params))
+        return [{"table_name": "tenant_users"}]
+
+    monkeypatch.setattr(mcp_tools.connection_manager, "execute_query", execute_query)
+
+    response = await mcp_tools.handle_db_query_tables(
+        {"connection_id": "pg-1", "database": "app", "schema": "tenant_a"}
+    )
+
+    assert "tenant_users" in response[0].text
+    assert "table_schema = %s" in calls[0][1]
+    assert calls[0][2] == ("app", "tenant_a")
+
+
+@pytest.mark.asyncio
 async def test_table_exists_uses_postgresql_catalog(monkeypatch, postgres_info):
     calls = []
     monkeypatch.setattr(


### PR DESCRIPTION
Closes #31

## 背景
`list_tables --schema` 参数之前没有生效，PostgreSQL MCP 表查询也不能限制业务 schema。

## 变更
- 为 `db_query_tables` 增加可选 `schema` 输入和结构化响应字段。
- PostgreSQL 查询按 `table_schema = %s` 使用参数绑定。
- CLI `list_tables` 仅在提供 `--schema` 时透传过滤条件。
- 保持 MySQL、SQLite 和未传 schema 时的查询行为。
- 增加 PostgreSQL SQL 参数测试及 CLI 透传测试。

## 验证
- `PYTHONPATH=src python -m pytest tests/unit/test_postgresql_mcp_tools.py tests/test_cli.py -q`：18 passed。
- `ruff check src tests`：通过。
- `ruff format --check src/dbjavagenix/cli.py tests/test_cli.py tests/unit/test_postgresql_mcp_tools.py`：通过。

## 限制
schema 过滤仅对 PostgreSQL 生效；MySQL 当前仍使用 database 级 `SHOW TABLES`，SQLite 没有 schema 概念。本次没有性能测量，也不声称性能提升。