### PR TITLE
:lock: security(metadata): 防护 MySQL 标识符拼接

### DIFF
--- a/src/dbjavagenix/database/mcp_tools.py
+++ b/src/dbjavagenix/database/mcp_tools.py
@@ -162,6 +162,15 @@ def _has_top_level_limit_clause(query: str) -> bool:
     return False
 
 
+def _quote_mysql_identifier(identifier: Any) -> str:
+    """Quote one MySQL identifier and reject control characters."""
+    if not isinstance(identifier, str) or not identifier:
+        raise MCPServiceError("MySQL identifier must be a non-empty string")
+    if any(ord(char) < 32 or ord(char) == 127 for char in identifier):
+        raise MCPServiceError("MySQL identifier must not contain control characters")
+    return f"`{identifier.replace('`', '``')}`"
+
+
 def get_connection_tools() -> List[Tool]:
     """
     Get list of database connection and basic query MCP tools
@@ -658,7 +667,7 @@ async def handle_db_query_tables(arguments: Dict[str, Any]) -> List[TextContent]
         # Query tables based on database type
         schema_filter = "AND table_schema = %s" if schema else ""
         if config.type == DatabaseType.MYSQL:
-            query = f"SHOW TABLES FROM `{database}`"
+            query = f"SHOW TABLES FROM {_quote_mysql_identifier(database)}"
             params = None
 
         elif config.type == DatabaseType.POSTGRESQL:

--- a/tests/unit/test_mcp_identifier_safety.py
+++ b/tests/unit/test_mcp_identifier_safety.py
@@ -1,0 +1,52 @@
+"""Regression tests for database identifier boundaries in MCP tools."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from dbjavagenix.core.models import DatabaseType
+from dbjavagenix.database import mcp_tools
+
+
+@pytest.fixture
+def mysql_info():
+    return SimpleNamespace(type=DatabaseType.MYSQL, database="app")
+
+
+@pytest.mark.asyncio
+async def test_mysql_table_listing_quotes_identifier(monkeypatch, mysql_info):
+    calls = []
+    monkeypatch.setattr(
+        mcp_tools.connection_manager, "get_connection_info", lambda _cid: mysql_info
+    )
+    monkeypatch.setattr(
+        mcp_tools.connection_manager,
+        "execute_query",
+        lambda connection_id, query, params=None: (
+            calls.append((connection_id, query, params)) or []
+        ),
+    )
+
+    await mcp_tools.handle_db_query_tables({"connection_id": "mysql-1", "database": "app`archive"})
+
+    assert calls == [("mysql-1", "SHOW TABLES FROM `app``archive`", None)]
+
+
+@pytest.mark.asyncio
+async def test_mysql_table_listing_rejects_control_character(monkeypatch, mysql_info):
+    calls = []
+    monkeypatch.setattr(
+        mcp_tools.connection_manager, "get_connection_info", lambda _cid: mysql_info
+    )
+    monkeypatch.setattr(
+        mcp_tools.connection_manager,
+        "execute_query",
+        lambda *args: calls.append(args) or [],
+    )
+
+    response = await mcp_tools.handle_db_query_tables(
+        {"connection_id": "mysql-1", "database": "app\narchive"}
+    )
+
+    assert "control characters" in response[0].text
+    assert calls == []


### PR DESCRIPTION
## 背景
`db_query_tables` 在 MySQL 分支直接拼接数据库标识符。数据库名来自调用参数时，反引号或控制字符可能改变 SQL 语义，形成标识符注入风险。

## 变更
- 新增统一的 MySQL 标识符引用函数。
- 拒绝空值、非字符串和控制字符。
- 按 MySQL 规则将反引号转义为两个反引号。
- 保持普通数据库名的查询行为不变。
- 增加带反引号和控制字符的回归测试。

## 验证
- `PYTHONPATH=src python -m pytest tests/unit -q`：576 passed
- `ruff check src tests`：通过
- `ruff format --check`：通过
- 本次变更未进行性能测量，目标是输入边界安全性，不宣称性能收益。

## 风险与回滚
仅影响 MySQL `SHOW TABLES FROM` 的数据库标识符构造；异常输入现在会被拒绝。若需回滚，可回退本 PR 的单一提交。

Closes #35