### PR TITLE
:lock: security(metadata): 校验 MySQL 索引查询标识符

### DIFF
--- a/src/dbjavagenix/database/introspection.py
+++ b/src/dbjavagenix/database/introspection.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, List
 
 from ..core.exceptions import DatabaseAnalysisError, DatabaseConnectionError
 from ..core.models import DatabaseConfig, DatabaseType
+from .sql_identifiers import quote_mysql_identifier
 
 
 class DatabaseIntrospector:
@@ -46,6 +47,14 @@ class DatabaseIntrospector:
     def _sqlite_identifier(value: str) -> str:
         """Quote a SQLite identifier used by PRAGMA statements."""
         return value.replace("'", "''")
+
+    @staticmethod
+    def _mysql_identifier(value: str) -> str:
+        """Quote a MySQL identifier using the metadata error contract."""
+        try:
+            return quote_mysql_identifier(value)
+        except ValueError as exc:
+            raise DatabaseAnalysisError(str(exc)) from exc
 
     def list_tables(self, connection_id: str) -> List[str]:
         config = self._config(connection_id)
@@ -353,7 +362,7 @@ class DatabaseIntrospector:
         config = self._config(connection_id)
         if config.type == DatabaseType.MYSQL:
             rows = self.connection_manager.execute_query(
-                connection_id, f"SHOW INDEX FROM `{table_name.replace('`', '``')}`"
+                connection_id, f"SHOW INDEX FROM {self._mysql_identifier(table_name)}"
             )
             return [
                 {

--- a/src/dbjavagenix/database/mcp_tools.py
+++ b/src/dbjavagenix/database/mcp_tools.py
@@ -21,6 +21,7 @@ from ..core.exceptions import (
 )
 from ..database.connection_manager import connection_manager
 from ..database.introspection import DatabaseIntrospector
+from ..database.sql_identifiers import quote_mysql_identifier
 from ..config.config_manager import ConfigManager
 from ..utils.pom_analyzer import PomAnalyzer
 from ..utils.security import redact_sensitive_data, redact_sensitive_text
@@ -163,12 +164,11 @@ def _has_top_level_limit_clause(query: str) -> bool:
 
 
 def _quote_mysql_identifier(identifier: Any) -> str:
-    """Quote one MySQL identifier and reject control characters."""
-    if not isinstance(identifier, str) or not identifier:
-        raise MCPServiceError("MySQL identifier must be a non-empty string")
-    if any(ord(char) < 32 or ord(char) == 127 for char in identifier):
-        raise MCPServiceError("MySQL identifier must not contain control characters")
-    return f"`{identifier.replace('`', '``')}`"
+    """Adapt shared identifier validation to the MCP error contract."""
+    try:
+        return quote_mysql_identifier(identifier)
+    except ValueError as exc:
+        raise MCPServiceError(str(exc)) from exc
 
 
 def get_connection_tools() -> List[Tool]:

--- a/src/dbjavagenix/database/sql_identifiers.py
+++ b/src/dbjavagenix/database/sql_identifiers.py
@@ -1,0 +1,12 @@
+"""Helpers for safely embedding database identifiers in dialect SQL."""
+
+from typing import Any
+
+
+def quote_mysql_identifier(identifier: Any) -> str:
+    """Quote one MySQL identifier and reject control characters."""
+    if not isinstance(identifier, str) or not identifier:
+        raise ValueError("MySQL identifier must be a non-empty string")
+    if any(ord(char) < 32 or ord(char) == 127 for char in identifier):
+        raise ValueError("MySQL identifier must not contain control characters")
+    return f"`{identifier.replace('`', '``')}`"

--- a/tests/unit/test_database_introspection.py
+++ b/tests/unit/test_database_introspection.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import pytest
+
+from dbjavagenix.core.exceptions import DatabaseAnalysisError
 from dbjavagenix.core.models import DatabaseConfig, DatabaseType
 from dbjavagenix.database.connection_manager import ConnectionManager
 from dbjavagenix.database.introspection import DatabaseIntrospector
@@ -123,6 +126,43 @@ class RecordingManager:
         if "pg_index" in query:
             return [{"key_name": "users_pkey", "column_name": "id", "is_unique": True}]
         return []
+
+
+class MySQLIndexManager:
+    def __init__(self):
+        self.config = DatabaseConfig(
+            type=DatabaseType.MYSQL,
+            host="db.example",
+            port=3306,
+            database="app",
+            username="reader",
+            password="secret",
+        )
+        self.calls = []
+
+    def get_connection_info(self, connection_id):
+        return self.config
+
+    def execute_query(self, connection_id, query, params=None):
+        self.calls.append((query, params))
+        return []
+
+
+def test_mysql_index_introspection_quotes_identifier():
+    manager = MySQLIndexManager()
+
+    DatabaseIntrospector(manager).get_indexes("mysql-1", "odd`table")
+
+    assert manager.calls == [("SHOW INDEX FROM `odd``table`", None)]
+
+
+def test_mysql_index_introspection_rejects_control_character():
+    manager = MySQLIndexManager()
+
+    with pytest.raises(DatabaseAnalysisError, match="control characters"):
+        DatabaseIntrospector(manager).get_indexes("mysql-1", "odd\ntable")
+
+    assert manager.calls == []
 
 
 def test_postgresql_introspection_uses_catalog_queries():


### PR DESCRIPTION
## 背景
`DatabaseIntrospector.get_indexes()` 的 MySQL 分支在 `SHOW INDEX FROM` 中拼接 `table_name`，原实现虽转义反引号，但没有拒绝控制字符。该参数会从元数据描述和代码生成链路进入查询。

## 变更
- 新增数据库层共享的 MySQL 标识符引用函数。
- MCP 表列表和元数据索引查询统一使用相同校验规则。
- 拒绝空值、非字符串和 ASCII 控制字符；反引号按 MySQL 规则加倍转义。
- 新增索引查询合法转义和危险输入拒绝的回归测试。

## 验证
- `PYTHONPATH=src python -m pytest tests/unit -q`：578 passed
- `ruff check src tests`：通过
- 变更文件 `ruff format --check`：通过
- 本次未进行性能测量，目标是统一 SQL 标识符输入边界，不宣称性能收益。

## 风险与回滚
仅影响 MySQL 索引元数据查询中 `table_name` 的构造；合法名称的 SQL 语义保持不变，异常输入现在会在数据库调用前失败。可回退提交 `b1b9b79`。

Closes #37