### PR TITLE
:recycle: refactor(visualization): 清理重复 ER 元数据查询实现

### DIFF
--- a/src/dbjavagenix/database/visualization_tools.py
+++ b/src/dbjavagenix/database/visualization_tools.py
@@ -94,10 +94,7 @@ async def handle_db_render_er_diagram(arguments: Dict[str, Any]) -> List[TextCon
         mermaid_source = render_er_diagram(er_tables, all_fks)
         summary = render_summary_text(er_tables, all_fks)
 
-        text = (
-            f"{summary}\n\n"
-            f"```mermaid\n{mermaid_source}\n```"
-        )
+        text = f"{summary}\n\n```mermaid\n{mermaid_source}\n```"
         content = TextContent(type="text", text=text)
         meta = build_mcp_app_meta(
             "mermaid",
@@ -107,16 +104,20 @@ async def handle_db_render_er_diagram(arguments: Dict[str, Any]) -> List[TextCon
         return [attach_meta(content, meta)]
 
     except (DatabaseConnectionError, MCPServiceError) as e:
-        return [TextContent(
-            type="text",
-            text=f"Failed to render ER diagram: {e}",
-        )]
+        return [
+            TextContent(
+                type="text",
+                text=f"Failed to render ER diagram: {e}",
+            )
+        ]
     except Exception as e:  # noqa: BLE001
         logger.error(f"db_render_er_diagram unexpected error: {e}")
-        return [TextContent(
-            type="text",
-            text=f"Unexpected error: {e}",
-        )]
+        return [
+            TextContent(
+                type="text",
+                text=f"Unexpected error: {e}",
+            )
+        ]
 
 
 def _collect_table_for_er(
@@ -137,12 +138,14 @@ def _collect_table_for_er(
         is_fk = c["name"] in fk_column_names
         if not include_non_pk and not (is_pk or is_fk):
             continue
-        er_columns.append(ERColumn(
-            name=c["name"],
-            type=c["type"],
-            is_primary=is_pk,
-            is_foreign=is_fk,
-        ))
+        er_columns.append(
+            ERColumn(
+                name=c["name"],
+                type=c["type"],
+                is_primary=is_pk,
+                is_foreign=is_fk,
+            )
+        )
 
     er_fks = [
         ERForeignKey(
@@ -154,75 +157,6 @@ def _collect_table_for_er(
         for fk in fks_raw
     ]
     return er_columns, er_fks
-
-
-def _query_columns(
-    connection_id: str, database: str, table: str, db_type: DatabaseType
-) -> List[Dict[str, Any]]:
-    """查询表列信息 (跨数据库简化版)"""
-    if db_type == DatabaseType.MYSQL:
-        query = """
-        SELECT COLUMN_NAME, COLUMN_TYPE, COLUMN_KEY
-        FROM information_schema.COLUMNS
-        WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s
-        ORDER BY ORDINAL_POSITION
-        """
-        rows = connection_manager.execute_query(connection_id, query, (database, table))
-        return [
-            {
-                "name": r["COLUMN_NAME"],
-                "type": r["COLUMN_TYPE"],
-                "is_primary": r["COLUMN_KEY"] == "PRI",
-            }
-            for r in rows
-        ]
-    if db_type == DatabaseType.SQLITE:
-        query = f"PRAGMA table_info('{table}')"
-        rows = connection_manager.execute_query(connection_id, query)
-        return [
-            {
-                "name": r.get("name", ""),
-                "type": r.get("type", ""),
-                "is_primary": r.get("pk", 0) > 0,
-            }
-            for r in rows
-        ]
-    raise MCPServiceError(f"ER column query not implemented for {db_type}")
-
-
-def _query_foreign_keys(
-    connection_id: str, database: str, table: str, db_type: DatabaseType
-) -> List[Dict[str, Any]]:
-    """查询表外键"""
-    if db_type == DatabaseType.MYSQL:
-        query = """
-        SELECT COLUMN_NAME, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME
-        FROM information_schema.KEY_COLUMN_USAGE
-        WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s
-          AND REFERENCED_TABLE_NAME IS NOT NULL
-        ORDER BY ORDINAL_POSITION
-        """
-        rows = connection_manager.execute_query(connection_id, query, (database, table))
-        return [
-            {
-                "column": r["COLUMN_NAME"],
-                "to_table": r["REFERENCED_TABLE_NAME"],
-                "to_column": r["REFERENCED_COLUMN_NAME"],
-            }
-            for r in rows
-        ]
-    if db_type == DatabaseType.SQLITE:
-        query = f"PRAGMA foreign_key_list('{table}')"
-        rows = connection_manager.execute_query(connection_id, query)
-        return [
-            {
-                "column": r.get("from", ""),
-                "to_table": r.get("table", ""),
-                "to_column": r.get("to", ""),
-            }
-            for r in rows
-        ]
-    return []
 
 
 def _query_columns(

--- a/tests/unit/test_visualization_introspection.py
+++ b/tests/unit/test_visualization_introspection.py
@@ -39,16 +39,47 @@ def test_postgresql_er_queries_use_shared_introspection(monkeypatch):
 
     monkeypatch.setattr(visualization_tools.connection_manager, "execute_query", execute_query)
 
-    columns = visualization_tools._query_columns(
-        "pg-1", "app", "orders", DatabaseType.POSTGRESQL
-    )
+    columns = visualization_tools._query_columns("pg-1", "app", "orders", DatabaseType.POSTGRESQL)
     foreign_keys = visualization_tools._query_foreign_keys(
         "pg-1", "app", "orders", DatabaseType.POSTGRESQL
     )
 
     assert columns == [{"name": "id", "type": "bigint", "is_primary": False}]
-    assert foreign_keys == [
-        {"column": "user_id", "to_table": "users", "to_column": "id"}
-    ]
+    assert foreign_keys == [{"column": "user_id", "to_table": "users", "to_column": "id"}]
     assert len(calls) == 2
     assert all("SHOW TABLES" not in query for query, _ in calls)
+
+
+def test_sqlite_er_queries_escape_special_table_names(monkeypatch):
+    calls = []
+    config = SimpleNamespace(type=DatabaseType.SQLITE, database=":memory:")
+
+    monkeypatch.setattr(
+        visualization_tools.connection_manager,
+        "get_connection_info",
+        lambda connection_id: config,
+    )
+
+    def execute_query(connection_id, query, params=None):
+        calls.append((query, params))
+        if query == "PRAGMA table_info('odd''table')":
+            return [{"name": "id", "type": "INTEGER", "pk": 1}]
+        if query == "PRAGMA foreign_key_list('odd''table')":
+            return []
+        raise AssertionError(f"unexpected query: {query}")
+
+    monkeypatch.setattr(visualization_tools.connection_manager, "execute_query", execute_query)
+
+    columns = visualization_tools._query_columns(
+        "sqlite-1", "app", "odd'table", DatabaseType.SQLITE
+    )
+    foreign_keys = visualization_tools._query_foreign_keys(
+        "sqlite-1", "app", "odd'table", DatabaseType.SQLITE
+    )
+
+    assert columns == [{"name": "id", "type": "INTEGER", "is_primary": True}]
+    assert foreign_keys == []
+    assert calls == [
+        ("PRAGMA table_info('odd''table')", None),
+        ("PRAGMA foreign_key_list('odd''table')", None),
+    ]


### PR DESCRIPTION
## 背景
`visualization_tools.py` 中存在两套同名 `_query_columns` 和 `_query_foreign_keys` 定义。后定义会覆盖前定义，旧实现不可达，却保留了独立的 MySQL/SQLite 查询路径，容易导致维护误判和规则漂移。

## 变更
- 删除不可达的旧版 ER 元数据查询实现。
- 保留通过 `DatabaseIntrospector` 的统一查询路径。
- 增加 SQLite 特殊表名回归测试，验证 ER 可视化查询复用共享 introspector 并正确转义。
- 按 CI 要求格式化本次变更涉及的 Python 文件。

## 验证
- `PYTHONPATH=src python -m pytest tests/unit -q`：579 passed
- `ruff check src tests`：通过
- 变更文件 `ruff format --check`：通过
- 本次未进行性能测量；目标是消除不可达实现和统一元数据查询路径。

## 风险与回滚
删除的两套函数从未被实际调用，运行时入口保持不变；SQLite 特殊表名测试覆盖共享实现的转义行为。可回退提交 `c039615`。

Closes #39