### PR TITLE
:bug: fix(capabilities): 对齐实际数据库支持范围

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ graph LR
 
     MCP -->|返回 _meta| Apps[MCP Apps 渲染]
     Apps -->|mermaid / dashboard / code-diff / tree| Client
-    MCP -->|读取| Data[MySQL / SQLite + Mustache templates]
+    MCP -->|读取| Data[MySQL / PostgreSQL / SQLite + Mustache templates]
 ```
 
 ## 它解决什么问题
@@ -71,6 +71,12 @@ cd DBJavaGenix
 uv venv && uv pip install -e ".[dev]"
 PYTHONPATH=src python -m dbjavagenix.cli server
 ```
+
+### 数据库支持范围
+
+当前可连接、查询并读取元数据的数据库为 MySQL、PostgreSQL 和 SQLite。Oracle 与
+SQL Server 的类型映射保留为后续扩展准备，但尚未实现运行时驱动和元数据契约，不能作为
+当前可用数据库声明。
 
 ### 第一次使用
 
@@ -194,7 +200,7 @@ PYTHONPATH=src python -m dbjavagenix.cli server
 - [x] **v0.2.2**: MCP v3 + AI 工程化 (elicitation 表单 / sampling 借 LLM / 1h prompt caching / agentic-runner)
 
 下一步 (v0.3 候选):
-- DB 后端扩展: PostgreSQL / Oracle 完整支持
+- DB 后端扩展: Oracle / SQL Server 元数据契约与驱动支持
 - 抓取 Claude Desktop / Cursor 截图入仓 (P3.5 收尾)
 - 集成测试: 用 Testcontainers 把 MySQL 拉起跑端到端
 - 性能: 把规则推断与 LLM 路径合并为同一返回 schema (current LLM 路径输出格式与规则略不同)

--- a/src/dbjavagenix/cli.py
+++ b/src/dbjavagenix/cli.py
@@ -16,6 +16,7 @@ from .config.config_manager import ConfigManager
 from .core.exceptions import DBJavaGenixError
 from .core.models import DatabaseConfig, DatabaseType
 from .database.connection_manager import connection_manager
+from .database.capabilities import supported_database_display_names
 from .cli_helpers import (
     handle_db_connect_test,
     handle_db_query_databases,
@@ -71,7 +72,7 @@ def version():
     console.print("  - MCP server for LLM integration")
     console.print("  - Spring Boot project validation and config reading")
     console.print(
-        "\n[cyan]Supported Databases:[/cyan] MySQL, PostgreSQL, SQLite, Oracle, SQL Server"
+        f"\n[cyan]Supported Databases:[/cyan] {', '.join(supported_database_display_names())}"
     )
     console.print("[cyan]Supported Build Tools:[/cyan] Maven, Gradle")
 

--- a/src/dbjavagenix/database/capabilities.py
+++ b/src/dbjavagenix/database/capabilities.py
@@ -1,0 +1,26 @@
+"""Runtime database capabilities exposed by DBJavaGenix."""
+
+from ..core.models import DatabaseType
+
+
+SUPPORTED_DATABASE_TYPES: tuple[DatabaseType, ...] = (
+    DatabaseType.MYSQL,
+    DatabaseType.POSTGRESQL,
+    DatabaseType.SQLITE,
+)
+
+_DATABASE_DISPLAY_NAMES = {
+    DatabaseType.MYSQL: "MySQL",
+    DatabaseType.POSTGRESQL: "PostgreSQL",
+    DatabaseType.SQLITE: "SQLite",
+}
+
+
+def supported_database_type_values() -> list[str]:
+    """Return stable database type values for public tool schemas."""
+    return [database_type.value for database_type in SUPPORTED_DATABASE_TYPES]
+
+
+def supported_database_display_names() -> list[str]:
+    """Return user-facing names for the currently implemented databases."""
+    return [_DATABASE_DISPLAY_NAMES[database_type] for database_type in SUPPORTED_DATABASE_TYPES]

--- a/src/dbjavagenix/database/connection_manager.py
+++ b/src/dbjavagenix/database/connection_manager.py
@@ -11,6 +11,7 @@ from contextlib import contextmanager
 from ..core.models import DatabaseConfig, DatabaseType
 from ..core.exceptions import DatabaseConnectionError, DatabaseQueryError
 from ..utils.security import redact_sensitive_text
+from .capabilities import SUPPORTED_DATABASE_TYPES, supported_database_type_values
 
 logger = logging.getLogger(__name__)
 
@@ -36,6 +37,12 @@ class ConnectionManager:
             DatabaseConnectionError: If connection fails
         """
         connection_id = str(uuid.uuid4())
+        if config.type not in SUPPORTED_DATABASE_TYPES:
+            supported_types = ", ".join(supported_database_type_values())
+            raise DatabaseConnectionError(
+                f"Unsupported database type: {config.type.value}. "
+                f"Supported database types: {supported_types}"
+            )
         
         try:
             if config.type == DatabaseType.MYSQL:

--- a/src/dbjavagenix/database/mcp_tools.py
+++ b/src/dbjavagenix/database/mcp_tools.py
@@ -22,6 +22,7 @@ from ..core.exceptions import (
 from ..database.connection_manager import connection_manager
 from ..database.introspection import DatabaseIntrospector
 from ..database.sql_identifiers import quote_mysql_identifier
+from ..database.capabilities import supported_database_type_values
 from ..config.config_manager import ConfigManager
 from ..utils.pom_analyzer import PomAnalyzer
 from ..utils.security import redact_sensitive_data, redact_sensitive_text
@@ -208,7 +209,7 @@ def get_connection_tools() -> List[Tool]:
                     },
                     "database_type": {
                         "type": "string",
-                        "enum": ["mysql", "postgresql", "sqlite", "oracle", "sqlserver"],
+                        "enum": supported_database_type_values(),
                         "description": "Database type"
                     },
                     "charset": {

--- a/tests/unit/test_database_capabilities.py
+++ b/tests/unit/test_database_capabilities.py
@@ -1,0 +1,58 @@
+"""Tests for the public runtime database capability contract."""
+
+import pytest
+from typer.testing import CliRunner
+
+from dbjavagenix import cli
+from dbjavagenix.core.exceptions import DatabaseConnectionError
+from dbjavagenix.core.models import DatabaseConfig, DatabaseType
+from dbjavagenix.database.capabilities import (
+    SUPPORTED_DATABASE_TYPES,
+    supported_database_display_names,
+    supported_database_type_values,
+)
+from dbjavagenix.database.connection_manager import ConnectionManager
+from dbjavagenix.database.mcp_tools import get_connection_tools
+
+
+def test_public_database_capabilities_are_derived_from_one_list():
+    assert SUPPORTED_DATABASE_TYPES == (
+        DatabaseType.MYSQL,
+        DatabaseType.POSTGRESQL,
+        DatabaseType.SQLITE,
+    )
+    assert supported_database_type_values() == ["mysql", "postgresql", "sqlite"]
+    assert supported_database_display_names() == ["MySQL", "PostgreSQL", "SQLite"]
+
+
+def test_connection_tool_schema_only_advertises_implemented_databases():
+    connection_tool = next(
+        tool for tool in get_connection_tools() if tool.name == "db_connect_test"
+    )
+
+    assert connection_tool.inputSchema["properties"]["database_type"]["enum"] == (
+        supported_database_type_values()
+    )
+
+
+def test_cli_version_only_advertises_implemented_databases():
+    result = CliRunner().invoke(cli.app, ["version"])
+
+    assert result.exit_code == 0
+    assert "MySQL, PostgreSQL, SQLite" in result.output
+    assert "Oracle" not in result.output
+    assert "SQL Server" not in result.output
+
+
+def test_connection_manager_rejects_planned_but_unimplemented_database():
+    config = DatabaseConfig(
+        type=DatabaseType.ORACLE,
+        host="db.example",
+        port=1521,
+        database="app",
+        username="reader",
+        password="secret",
+    )
+
+    with pytest.raises(DatabaseConnectionError, match="Supported database types"):
+        ConnectionManager().create_connection(config)


### PR DESCRIPTION
## 背景
`DatabaseType`、MCP `db_connect_test` schema、CLI `version` 和 README 原先把 Oracle、SQL Server列为支持数据库，但连接管理、元数据 introspector 和 `DATABASE_URL` 解析实际只实现 MySQL、PostgreSQL、SQLite，用户选择未实现方言后才会在运行时失败。

## 变更
- 新增 `database.capabilities` 作为运行时数据库能力单一来源。
- MCP 连接工具的 `database_type` 枚举从能力清单派生。
- 连接管理器对规划中的未实现方言提前返回清晰错误。
- CLI 支持数据库输出和 README 与真实实现对齐。
- 保留 Oracle/SQL Server 枚举和类型映射，明确其为后续扩展。
- 增加能力清单、MCP schema、CLI 输出和未实现方言错误测试。

## 验证
- `PYTHONPATH=src python -m pytest tests/unit -q`：583 passed
- `ruff check src tests`：通过
- 变更文件格式检查：通过
- 本次未进行性能测量；目标是修正公开能力契约和失败时机。

## 风险与回滚
MySQL、PostgreSQL、SQLite运行行为不变；Oracle/SQL Server会在连接前得到更明确的“不支持”错误。可回退提交 `9dbfaa9`。

Closes #41