### PR TITLE
:bug: fix(config): 保证数据库连接 URL 特殊字符可往返

### DIFF
--- a/src/dbjavagenix/config/config_manager.py
+++ b/src/dbjavagenix/config/config_manager.py
@@ -119,7 +119,7 @@ class ConfigManager:
         database_type, default_port = scheme_aliases[scheme]
         query = parse_qs(parsed.query)
         if database_type == "sqlite":
-            database = parsed.path or parsed.netloc
+            database = unquote(parsed.path or parsed.netloc)
             if database == "/:memory:":
                 database = ":memory:"
             elif database.startswith("/") and not database.startswith("//"):
@@ -138,7 +138,7 @@ class ConfigManager:
             "type": database_type,
             "host": parsed.hostname or "",
             "port": parsed.port or default_port,
-            "database": parsed.path.lstrip("/"),
+            "database": unquote(parsed.path.lstrip("/")),
             "username": unquote(parsed.username or ""),
             "password": unquote(parsed.password or ""),
             **({"charset": query["charset"][0]} if query.get("charset") else {}),

--- a/src/dbjavagenix/core/models.py
+++ b/src/dbjavagenix/core/models.py
@@ -1,14 +1,17 @@
 """
 Core data models for DBJavaGenix
 """
+
 from typing import Dict, List, Optional, Any
 from dataclasses import dataclass, field
 from enum import Enum
 from pydantic import BaseModel, Field
+from urllib.parse import quote
 
 
 class DatabaseType(str, Enum):
     """Supported database types"""
+
     MYSQL = "mysql"
     POSTGRESQL = "postgresql"
     SQLITE = "sqlite"
@@ -18,6 +21,7 @@ class DatabaseType(str, Enum):
 
 class AIProvider(str, Enum):
     """Supported AI providers"""
+
     OPENAI = "openai"
     QIANWEN = "qianwen"
     WENXIN = "wenxin"
@@ -26,12 +30,14 @@ class AIProvider(str, Enum):
 
 class TemplateEngine(str, Enum):
     """Supported template engines"""
+
     MUSTACHE = "mustache"
     VELOCITY = "velocity"  # For legacy support
 
 
 class CodeStyle(str, Enum):
     """Code generation styles"""
+
     TRADITIONAL = "traditional"  # 传统三层架构
     DDD = "ddd"  # Domain-Driven Design
     SPRING_BOOT = "spring_boot"  # Spring Boot风格
@@ -39,6 +45,7 @@ class CodeStyle(str, Enum):
 
 class MappingTool(str, Enum):
     """Object mapping tools"""
+
     MAPSTRUCT = "mapstruct"  # MapStruct (推荐)
     DOZER = "dozer"  # Dozer (传统)
     MANUAL = "manual"  # 手动映射
@@ -47,6 +54,7 @@ class MappingTool(str, Enum):
 @dataclass
 class ColumnInfo:
     """Database column information"""
+
     name: str
     data_type: str
     java_type: str
@@ -63,6 +71,7 @@ class ColumnInfo:
 @dataclass
 class TableInfo:
     """Database table information"""
+
     name: str
     schema: str
     columns: List[ColumnInfo] = field(default_factory=list)
@@ -70,21 +79,22 @@ class TableInfo:
     foreign_keys: Dict[str, str] = field(default_factory=dict)
     indexes: List[str] = field(default_factory=list)
     comment: Optional[str] = None
-    
+
     @property
     def entity_name(self) -> str:
         """Convert table name to Java class name"""
         return self._to_pascal_case(self.name)
-    
+
     @staticmethod
     def _to_pascal_case(snake_str: str) -> str:
         """Convert snake_case to PascalCase"""
-        components = snake_str.split('_')
-        return ''.join(word.capitalize() for word in components)
+        components = snake_str.split("_")
+        return "".join(word.capitalize() for word in components)
 
 
 class DatabaseConfig(BaseModel):
     """Database connection configuration"""
+
     type: DatabaseType = Field(..., description="Database type")
     host: str = Field(..., description="Database host")
     port: int = Field(..., description="Database port")
@@ -92,22 +102,30 @@ class DatabaseConfig(BaseModel):
     username: str = Field(..., description="Database username")
     password: str = Field(..., description="Database password")
     charset: str = Field(default="utf8mb4", description="Character set")
-    
+
     @property
     def connection_url(self) -> str:
         """Generate database connection URL"""
         if self.type == DatabaseType.MYSQL:
-            return f"mysql+pymysql://{self.username}:{self.password}@{self.host}:{self.port}/{self.database}?charset={self.charset}"
+            return (
+                f"mysql+pymysql://{quote(self.username, safe='')}:{quote(self.password, safe='')}"
+                f"@{self.host}:{self.port}/{quote(self.database, safe='')}"
+                f"?charset={quote(self.charset, safe='')}"
+            )
         elif self.type == DatabaseType.POSTGRESQL:
-            return f"postgresql://{self.username}:{self.password}@{self.host}:{self.port}/{self.database}"
+            return (
+                f"postgresql://{quote(self.username, safe='')}:{quote(self.password, safe='')}"
+                f"@{self.host}:{self.port}/{quote(self.database, safe='')}"
+            )
         elif self.type == DatabaseType.SQLITE:
-            return f"sqlite:///{self.database}"
+            return f"sqlite:///{quote(self.database, safe='/:')}"
         else:
             raise ValueError(f"Unsupported database type: {self.type}")
 
 
 class AIConfig(BaseModel):
     """AI service configuration"""
+
     provider: AIProvider = Field(..., description="AI service provider")
     api_key: str = Field(..., description="API key for AI service")
     base_url: Optional[str] = Field(None, description="Custom base URL")
@@ -118,44 +136,58 @@ class AIConfig(BaseModel):
 
 class GenerationConfig(BaseModel):
     """Code generation configuration"""
+
     output_dir: str = Field(..., description="Output directory")
     package_name: str = Field(..., description="Java package name")
-    code_style: CodeStyle = Field(default=CodeStyle.SPRING_BOOT, description="Code generation style")
-    template_engine: TemplateEngine = Field(default=TemplateEngine.MUSTACHE, description="Template engine")
-    mapping_tool: MappingTool = Field(default=MappingTool.MAPSTRUCT, description="Object mapping tool")
+    code_style: CodeStyle = Field(
+        default=CodeStyle.SPRING_BOOT, description="Code generation style"
+    )
+    template_engine: TemplateEngine = Field(
+        default=TemplateEngine.MUSTACHE, description="Template engine"
+    )
+    mapping_tool: MappingTool = Field(
+        default=MappingTool.MAPSTRUCT, description="Object mapping tool"
+    )
     author: str = Field(default="ZXP", description="Author name")
-    
+
     # Entity configuration
     entity_suffix: str = Field(default="", description="Entity class suffix")
     use_lombok: bool = Field(default=True, description="Use Lombok annotations")
     use_jpa: bool = Field(default=True, description="Use JPA annotations")
-    
+
     # DAO configuration
     dao_suffix: str = Field(default="Mapper", description="DAO interface suffix")
     use_mybatis_plus: bool = Field(default=True, description="Use MyBatis-Plus")
-    
+
     # Service configuration
     service_suffix: str = Field(default="Service", description="Service interface suffix")
-    service_impl_suffix: str = Field(default="ServiceImpl", description="Service implementation suffix")
-    
+    service_impl_suffix: str = Field(
+        default="ServiceImpl", description="Service implementation suffix"
+    )
+
     # Controller configuration
     controller_suffix: str = Field(default="Controller", description="Controller class suffix")
     use_swagger: bool = Field(default=True, description="Use Swagger annotations")
-    
+
     # Additional options
     generate_dto: bool = Field(default=True, description="Generate DTO classes")
     generate_vo: bool = Field(default=True, description="Generate VO classes")
     generate_tests: bool = Field(default=False, description="Generate unit tests")
-    
+
     # MapStruct configuration
-    mapstruct_component_model: str = Field(default="spring", description="MapStruct component model")
-    mapstruct_unmapped_target_policy: str = Field(default="IGNORE", description="MapStruct unmapped target policy")
+    mapstruct_component_model: str = Field(
+        default="spring", description="MapStruct component model"
+    )
+    mapstruct_unmapped_target_policy: str = Field(
+        default="IGNORE", description="MapStruct unmapped target policy"
+    )
     generate_mappers: bool = Field(default=True, description="Generate MapStruct mappers")
 
 
 @dataclass
 class AIAnalysisResult:
     """AI analysis result for table structure"""
+
     business_domain: str
     entity_suggestions: Dict[str, str]  # table_name -> suggested_class_name
     column_meanings: Dict[str, Dict[str, str]]  # table_name -> {column_name -> meaning}

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,25 +1,22 @@
 """
 Test core models for DBJavaGenix
 """
+
 import pytest
+from dbjavagenix.config.config_manager import ConfigManager
 from dbjavagenix.core.models import (
-    ColumnInfo, 
-    TableInfo, 
-    DatabaseConfig, 
+    ColumnInfo,
+    TableInfo,
+    DatabaseConfig,
     DatabaseType,
-    GenerationConfig
+    GenerationConfig,
 )
 
 
 def test_column_info_creation():
     """Test ColumnInfo creation"""
-    column = ColumnInfo(
-        name="user_id",
-        data_type="BIGINT",
-        java_type="Long",
-        primary_key=True
-    )
-    
+    column = ColumnInfo(name="user_id", data_type="BIGINT", java_type="Long", primary_key=True)
+
     assert column.name == "user_id"
     assert column.java_type == "Long"
     assert column.primary_key is True
@@ -39,8 +36,42 @@ def test_database_config_connection_url():
         port=3306,
         database="test",
         username="root",
-        password="password"
+        password="password",
     )
-    
+
     expected_url = "mysql+pymysql://root:password@localhost:3306/test?charset=utf8mb4"
     assert config.connection_url == expected_url
+
+
+def test_database_config_connection_url_round_trips_special_mysql_components():
+    config = DatabaseConfig(
+        type=DatabaseType.MYSQL,
+        host="db.internal",
+        port=3306,
+        database="app/core",
+        username="reader+svc",
+        password="p@ss/#?word",
+        charset="utf8mb4",
+    )
+
+    parsed = ConfigManager._parse_database_url(config.connection_url)
+
+    assert parsed["database"] == config.database
+    assert parsed["username"] == config.username
+    assert parsed["password"] == config.password
+    assert parsed["charset"] == config.charset
+
+
+def test_database_config_connection_url_round_trips_sqlite_path():
+    config = DatabaseConfig(
+        type=DatabaseType.SQLITE,
+        host="",
+        port=0,
+        database="fixtures/demo#1.db",
+        username="",
+        password="",
+    )
+
+    parsed = ConfigManager._parse_database_url(config.connection_url)
+
+    assert parsed["database"] == config.database


### PR DESCRIPTION
## 背景
`DatabaseConfig.connection_url` 原先直接拼接用户名、密码、数据库名和字符集。密码中的 `@`、`#`、`/` 等合法字符会改变 URL 解析边界，数据库名中的路径字符也无法被 `ConfigManager` 原样恢复。

## 变更
- 使用 `urllib.parse.quote` 编码 MySQL/PostgreSQL 的凭据、数据库名和字符集。
- SQLite 保留 `/` 与 `:` 的路径语义，同时编码片段标记等特殊字符。
- `ConfigManager._parse_database_url` 对数据库路径执行 `unquote`，实现生成/解析往返。
- 新增 MySQL 特殊凭据与数据库名、SQLite 特殊路径的回归测试。
- 按变更文件格式门禁统一相关 Python 文件排版。

## 验证
- `PYTHONPATH=src python -m pytest tests/unit -q`：585 passed
- `ruff check src tests`：通过
- 变更文件 `ruff format --check`：通过
- 实验：用包含 `reader+svc`、`p@ss/#?word`、`app/core` 和 `demo#1.db` 的配置生成 URL，再解析回字段，结果与原始值一致。

## 风险与回滚
简单凭据和 `:memory:` URL 行为保持不变；特殊字符现在会被正确编码。可回退提交 `6d20eb5`。本次未进行性能测量，不宣称性能收益。

Closes #43