### PR TITLE
:lock: security(codegen): 防止生成文件路径穿越

### DIFF
--- a/src/dbjavagenix/database/mcp_tools.py
+++ b/src/dbjavagenix/database/mcp_tools.py
@@ -6,7 +6,7 @@ import logging
 import os
 import re
 from functools import lru_cache
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import Dict, Any, List, Optional
 
 from mcp.types import Tool, TextContent, ImageContent, EmbeddedResource
@@ -43,6 +43,31 @@ _READ_ONLY_FORBIDDEN_WORDS = {
     "TRUNCATE",
     "UPDATE",
 }
+
+
+def _resolve_codegen_output_path(base_dir: Path, relative_path: object) -> Path:
+    """Resolve a generated filename while keeping it inside its output directory."""
+    if not isinstance(relative_path, str) or not relative_path.strip():
+        raise ValueError("generated filename must be a non-empty string")
+
+    # Treat Windows separators consistently on every platform and reject rooted paths.
+    normalized_path = relative_path.replace("\\", "/")
+    windows_path = PureWindowsPath(relative_path)
+    if (
+        Path(normalized_path).is_absolute()
+        or windows_path.is_absolute()
+        or windows_path.root
+        or windows_path.drive
+    ):
+        raise ValueError("generated filename must be relative")
+
+    resolved_base = base_dir.resolve()
+    resolved_output = (resolved_base / normalized_path).resolve()
+    try:
+        resolved_output.relative_to(resolved_base)
+    except ValueError as exc:
+        raise ValueError("generated filename escapes the output directory") from exc
+    return resolved_output
 
 
 def _tokenize_read_only_sql(query: str) -> List[tuple[str, str]]:
@@ -2108,23 +2133,48 @@ async def handle_db_codegen_generate(arguments: Dict[str, Any]) -> List[TextCont
         for template_file, file_info in generated_files.items():
             if "error" not in file_info:
                 # 获取相对文件路径（包含包结构）
-                relative_path = file_info["filename"]
+                raw_relative_path = file_info.get("filename")
+                normalized_relative_path = (
+                    raw_relative_path.replace("\\", "/")
+                    if isinstance(raw_relative_path, str)
+                    else raw_relative_path
+                )
                 
                 # 判断文件类型并选择正确的输出目录
                 if (
-                    relative_path.endswith(('.xml', '.yml', '.yaml', '.properties'))
-                    or relative_path.startswith('resources/')
-                    or relative_path.startswith('mapper/')
-                    or '/mapper/' in relative_path
+                    isinstance(normalized_relative_path, str)
+                    and (
+                        normalized_relative_path.endswith(('.xml', '.yml', '.yaml', '.properties'))
+                        or normalized_relative_path.startswith('resources/')
+                        or normalized_relative_path.startswith('mapper/')
+                        or '/mapper/' in normalized_relative_path
+                    )
                 ):
                     # 资源文件放到resources目录
-                    if relative_path.startswith('resources/'):
-                        relative_path = relative_path[10:]  # 移除 'resources/' 前缀
-                    full_output_path = resources_dir / relative_path
-                    resource_files.append(str(full_output_path))
+                    if normalized_relative_path.startswith('resources/'):
+                        normalized_relative_path = normalized_relative_path[10:]
+                    output_dir = resources_dir
                 else:
                     # Java文件：路径已包含包结构，直接写入源码目录
-                    full_output_path = java_source_dir / relative_path
+                    output_dir = java_source_dir
+
+                try:
+                    full_output_path = _resolve_codegen_output_path(
+                        output_dir, normalized_relative_path
+                    )
+                except ValueError as path_error:
+                    file_info["write_error"] = f"Unsafe output path: {path_error}"
+                    logger.warning(
+                        "Rejected generated file path %r for %s: %s",
+                        raw_relative_path,
+                        output_dir,
+                        path_error,
+                    )
+                    continue
+
+                if output_dir == resources_dir:
+                    resource_files.append(str(full_output_path))
+                else:
                     written_files.append(str(full_output_path))
                 
                 # 确保父目录存在

--- a/tests/unit/test_security.py
+++ b/tests/unit/test_security.py
@@ -12,6 +12,32 @@ from dbjavagenix.database import mcp_tools
 from dbjavagenix.utils.security import redact_sensitive_data, redact_sensitive_text
 
 
+def test_codegen_output_path_stays_inside_base_directory(tmp_path):
+    base_dir = tmp_path / "src" / "main" / "java"
+
+    resolved = mcp_tools._resolve_codegen_output_path(base_dir, "com/example/Demo.java")
+
+    assert resolved == base_dir.resolve() / "com" / "example" / "Demo.java"
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "../outside.java",
+        "C:\\outside.java",
+        "C:outside.java",
+        "\\\\server\\share\\outside.java",
+    ],
+)
+def test_codegen_output_path_rejects_escape_and_rooted_paths(tmp_path, filename):
+    base_dir = tmp_path / "missing" / "java"
+
+    with pytest.raises(ValueError):
+        mcp_tools._resolve_codegen_output_path(base_dir, filename)
+
+    assert not base_dir.exists()
+
+
 def test_redact_sensitive_data_handles_nested_values_without_mutating_input():
     payload = {
         "username": "reader",


### PR DESCRIPTION
## 关联 Issue

Closes #45

## 背景（Situation）

`db_codegen_generate` 的生成文件名可以来自模板或工具输入。若只拼接路径，`../`、盘符路径、UNC 路径或绝对路径可能让写入越过指定项目目录。

## 任务（Task）

在写盘前把所有相对输出路径解析到受控根目录，拒绝穿越和 rooted path，同时保留合法 Java/resources 输出。

## 行动（Action）

- 新增路径规范化、Windows/POSIX rooted path 检查和解析后 containment 校验。
- 将不安全路径写为明确 `write_error`，且不创建目录或文件。
- 保留合法模板映射的原始相对输出行为。
- 没有做什么：不允许通过该工具导出到项目目录之外，不改变模板布局。

## 验证（Verification）

2026-09-08 在当前主线重跑 `tests/unit/test_security.py` 和关联元数据回归集，共 `43 passed`。其中 `test_codegen_output_path_rejects_escape_and_rooted_paths` 覆盖 `../outside.java`、`C:\\outside.java`、drive-relative、UNC 路径；`test_codegen_output_path_stays_inside_base_directory` 验证合法 Java 相对路径解析在基目录内。该结果验证当前代码，不替代合并时的历史 CI 记录。

## 实验与证据（Evidence）

实验使用 pytest 的临时目录，不接触真实用户项目或生产文件：危险路径在数据库或文件写入前抛出 `ValueError`，合法 `com/example/Demo.java` 的 resolved path 保持在测试根目录。没有性能实验。

## 兼容性、风险与回滚

- 公共 API / 数据格式 / 迁移：成功输出格式保持不变；危险路径从可能写入变为明确失败。
- 风险：依赖目录外写入的非受支持调用会失败，必须改为受控导出流程。
- 回滚：回退 containment 校验会重新引入路径穿越风险，不应作为常规兼容手段。
- 后续：新增输出入口时复用同一 resolver，并补充测试。