### PR TITLE
:recycle: refactor(codegen): 统一模板分类契约

### DIFF
--- a/src/dbjavagenix/database/atomic_codegen_tools.py
+++ b/src/dbjavagenix/database/atomic_codegen_tools.py
@@ -174,6 +174,15 @@ async def handle_codegen_build_context(arguments: Dict[str, Any]) -> List[TextCo
         include_mapstruct = arguments.get("include_mapstruct", True)
         project_path = arguments.get("project_path")
 
+        from ..generator.template_context import TemplateConfigManager
+
+        supported_categories = TemplateConfigManager.get_supported_categories()
+        if template_category not in supported_categories:
+            supported = ", ".join(supported_categories)
+            raise MCPServiceError(
+                f"不支持的模板分类: {template_category!r}；支持分类: {supported}"
+            )
+
         config = connection_manager.get_connection_info(connection_id)
         if not config:
             raise DatabaseConnectionError(f"Connection {connection_id} not found")
@@ -331,8 +340,24 @@ async def _render_single_layer(
 
     category = context.get("templateCategory") or "MybatisPlus-Mixed"
 
-    from ..generator.mustache_engine import MustacheTemplateEngine
     from ..generator.template_context import TemplateConfigManager
+
+    supported_categories = TemplateConfigManager.get_supported_categories()
+    if category not in supported_categories:
+        return [TextContent(
+            type="text",
+            text=json.dumps(
+                {
+                    "error": "unsupported template category",
+                    "template_category": category,
+                    "supported_categories": supported_categories,
+                },
+                ensure_ascii=False,
+                indent=2,
+            ),
+        )]
+
+    from ..generator.mustache_engine import MustacheTemplateEngine
     from pathlib import Path
 
     template_base = Path(__file__).parent.parent / "templates" / "java"

--- a/src/dbjavagenix/database/codegen_tools.py
+++ b/src/dbjavagenix/database/codegen_tools.py
@@ -239,6 +239,15 @@ class CodegenGenerator:
     ) -> Dict[str, Any]:
         """根据分析结果生成代码"""
 
+        from ..generator.template_context import TemplateConfigManager
+
+        supported_categories = TemplateConfigManager.get_supported_categories()
+        if template_category not in supported_categories:
+            supported = ", ".join(supported_categories)
+            raise ValueError(
+                f"不支持的模板分类: {template_category!r}；支持分类: {supported}"
+            )
+
         # 构建生成配置
         config = GenerationConfig(
             output_dir=generation_config.get("output_dir", "/tmp/generated")
@@ -279,8 +288,6 @@ class CodegenGenerator:
         generated_code = {}
 
         # 获取模板文件列表
-        from ..generator.template_context import TemplateConfigManager
-
         template_config = TemplateConfigManager()
         base_templates = template_config.get_template_files(template_category)
         template_files = list(base_templates)

--- a/src/dbjavagenix/database/mcp_tools.py
+++ b/src/dbjavagenix/database/mcp_tools.py
@@ -1667,6 +1667,9 @@ def get_codegen_tools() -> List[Tool]:
     Returns:
         List of code generation MCP Tool objects
     """
+    from ..generator.template_context import TemplateConfigManager
+
+    template_categories = TemplateConfigManager.get_supported_categories()
     return [
         Tool(
             name="db_codegen_analyze",
@@ -1689,7 +1692,7 @@ def get_codegen_tools() -> List[Tool]:
                     "template_category": {
                         "type": "string",
                         "description": "Template category to use for context building",
-                        "enum": ["Default", "MybatisPlus", "MybatisPlus-Mixed"],
+                        "enum": template_categories,
                         "default": "MybatisPlus-Mixed"
                     },
                     "author": {
@@ -1737,7 +1740,7 @@ def get_codegen_tools() -> List[Tool]:
                     "template_category": {
                         "type": "string",
                         "description": "Template category to use for code generation",
-                        "enum": ["Default", "MybatisPlus", "MybatisPlus-Mixed"],
+                        "enum": template_categories,
                         "default": "MybatisPlus-Mixed"
                     },
                     "author": {
@@ -1828,6 +1831,7 @@ async def handle_db_codegen_analyze(arguments: Dict[str, Any]) -> List[TextConte
             "isDefault": template_category == "Default",
             "isMybatisPlus": template_category == "MybatisPlus",
             "isMybatisPlusMixed": template_category == "MybatisPlus-Mixed",
+            "isSb35Java21": template_category == "sb35-java21",
         })
         
         # Format response text
@@ -2048,6 +2052,7 @@ async def handle_db_codegen_generate(arguments: Dict[str, Any]) -> List[TextCont
             "hasPackageName": bool(package_name),
             "templateCategory": template_category,
             "isDefault": template_category == "Default",
+            "isSb35Java21": template_category == "sb35-java21",
             "isMybatisPlus": template_category == "MybatisPlus",
             "isMybatisPlusMixed": template_category == "MybatisPlus-Mixed",
             "useSwagger": include_swagger,
@@ -2413,6 +2418,9 @@ def get_springboot_project_tools() -> List[Tool]:
     Returns:
         List of SpringBoot project MCP Tool objects
     """
+    from ..generator.template_context import TemplateConfigManager
+
+    template_categories = TemplateConfigManager.get_supported_categories()
     return [
         Tool(
             name="springboot_validate_project",
@@ -2433,7 +2441,7 @@ def get_springboot_project_tools() -> List[Tool]:
                     "template_category": {
                         "type": "string",
                         "description": "Template category to check dependencies for",
-                        "enum": ["Default", "MybatisPlus", "MybatisPlus-Mixed"],
+                        "enum": template_categories,
                         "default": "MybatisPlus-Mixed"
                     }
                 },
@@ -2449,7 +2457,7 @@ def get_springboot_project_tools() -> List[Tool]:
                     "template_category": {
                         "type": "string",
                         "description": "Template category for dependency analysis",
-                        "enum": ["Default", "MybatisPlus", "MybatisPlus-Mixed"],
+                        "enum": template_categories,
                         "default": "MybatisPlus-Mixed"
                     },
                     "database_type": {

--- a/src/dbjavagenix/generator/java_generator.py
+++ b/src/dbjavagenix/generator/java_generator.py
@@ -154,7 +154,7 @@ class JavaCodeGenerator:
     
     def get_supported_categories(self) -> List[str]:
         """获取支持的模板分类"""
-        return ["Default", "MybatisPlus", "MybatisPlus-Mixed", "sb35-java21"]
+        return self.template_config.get_supported_categories()
     
     def validate_template_category(self, category: str) -> bool:
         """验证模板分类是否支持"""

--- a/src/dbjavagenix/generator/template_context.py
+++ b/src/dbjavagenix/generator/template_context.py
@@ -378,46 +378,51 @@ class TemplateContextBuilder:
 
 class TemplateConfigManager:
     """模板配置管理器"""
-    
-    @staticmethod
-    def get_template_files(category: str) -> List[str]:
+
+    _TEMPLATE_FILES: Dict[str, List[str]] = {
+        "Default": [
+            "entity.mustache",
+            "dao.mustache",
+            "service.mustache",
+            "serviceImpl.mustache",
+            "controller.mustache",
+            "mapper.xml.mustache",
+        ],
+        "MybatisPlus": [
+            "entity.mustache",
+            "dao.mustache",
+            "service.mustache",
+            "serviceImpl.mustache",
+            "controller.mustache",
+        ],
+        "MybatisPlus-Mixed": [
+            "entity.mustache",
+            "dao.mustache",
+            "service.mustache",
+            "serviceImpl.mustache",
+            "controller.mustache",
+            "mapper.mustache",
+        ],
+        "sb35-java21": [
+            "entity.mustache",
+            "dao.mustache",
+            "service.mustache",
+            "serviceImpl.mustache",
+            "controller.mustache",
+            "dto.mustache",
+        ],
+    }
+
+    @classmethod
+    def get_supported_categories(cls) -> List[str]:
+        """Return the canonical template categories exposed by the generator."""
+        return list(cls._TEMPLATE_FILES)
+
+    @classmethod
+    def get_template_files(cls, category: str) -> List[str]:
         """获取指定分类的模板文件列表"""
-        template_files = {
-            "Default": [
-                "entity.mustache",
-                "dao.mustache", 
-                "service.mustache",
-                "serviceImpl.mustache",
-                "controller.mustache",
-                "mapper.xml.mustache"  # 使用 mapper.xml.mustache
-            ],
-            "MybatisPlus": [
-                "entity.mustache",
-                "dao.mustache",
-                "service.mustache", 
-                "serviceImpl.mustache",
-                "controller.mustache"
-            ],
-            "MybatisPlus-Mixed": [
-                "entity.mustache",
-                "dao.mustache",
-                "service.mustache",
-                "serviceImpl.mustache",
-                "controller.mustache",
-                "mapper.mustache"
-            ],
-            "sb35-java21": [
-                "entity.mustache",
-                "dao.mustache",
-                "service.mustache",
-                "serviceImpl.mustache",
-                "controller.mustache",
-                "dto.mustache"
-            ]
-        }
-        
-        return template_files.get(category, [])
-    
+        return list(cls._TEMPLATE_FILES.get(category, []))
+
     @staticmethod
     def get_additional_templates() -> List[str]:
         """获取通用附加模板列表"""

--- a/tests/unit/test_atomic_codegen_tools.py
+++ b/tests/unit/test_atomic_codegen_tools.py
@@ -27,6 +27,7 @@ from dbjavagenix.database.atomic_codegen_tools import (
     handle_codegen_render_entity,
     handle_codegen_render_mapper,
     handle_codegen_render_service,
+    handle_codegen_build_context,
 )
 from dbjavagenix.core.models import ColumnInfo, TableInfo
 from dbjavagenix.generator.template_context import TemplateContextBuilder
@@ -233,6 +234,32 @@ class TestRenderMapper:
 # ============================================================
 
 class TestErrorHandling:
+    def test_build_context_rejects_unknown_category_before_connection_lookup(self):
+        result = asyncio.run(
+            handle_codegen_build_context(
+                {
+                    "connection_id": "not-used",
+                    "table_name": "users",
+                    "template_category": "UnknownCategory",
+                }
+            )
+        )
+        payload = json.loads(result[0].text)
+
+        assert payload["stage"] == "build_context"
+        assert "不支持的模板分类" in payload["error"]
+
+    def test_render_rejects_unknown_category(self):
+        result = asyncio.run(
+            handle_codegen_render_entity(
+                {"context": {"templateCategory": "UnknownCategory"}}
+            )
+        )
+        payload = json.loads(result[0].text)
+
+        assert payload["error"] == "unsupported template category"
+        assert payload["supported_categories"][-1] == "sb35-java21"
+
     def test_render_without_context_returns_error(self):
         result = asyncio.run(handle_codegen_render_entity({}))
         payload = json.loads(result[0].text)

--- a/tests/unit/test_codegen_analyzer.py
+++ b/tests/unit/test_codegen_analyzer.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from dbjavagenix.database.codegen_tools import CodegenAnalyzer
+from dbjavagenix.database.codegen_tools import CodegenAnalyzer, CodegenGenerator
 
 
 class _FakeIntrospector:
@@ -53,3 +53,9 @@ def test_analyzer_has_no_legacy_direct_metadata_methods():
         "_get_indexes",
     ):
         assert not hasattr(analyzer, method_name)
+
+
+@pytest.mark.asyncio
+async def test_generator_rejects_unknown_category_before_reading_analysis():
+    with pytest.raises(ValueError, match="不支持的模板分类"):
+        await CodegenGenerator().generate_code({}, template_category="UnknownCategory")

--- a/tests/unit/test_template_context_builder.py
+++ b/tests/unit/test_template_context_builder.py
@@ -6,6 +6,10 @@
 import pytest
 
 from dbjavagenix.core.models import ColumnInfo, DatabaseType, TableInfo
+from dbjavagenix.database.mcp_tools import (
+    get_codegen_tools,
+    get_springboot_project_tools,
+)
 from dbjavagenix.generator.template_context import (
     TemplateConfigManager,
     TemplateContextBuilder,
@@ -250,6 +254,33 @@ class TestBuildContextStructure:
 
 
 class TestTemplateConfigManager:
+    def test_supported_categories_are_canonical_and_ordered(self):
+        assert TemplateConfigManager.get_supported_categories() == [
+            "Default",
+            "MybatisPlus",
+            "MybatisPlus-Mixed",
+            "sb35-java21",
+        ]
+
+    def test_template_file_lists_are_copied(self):
+        files = TemplateConfigManager.get_template_files("Default")
+        files.clear()
+
+        assert "entity.mustache" in TemplateConfigManager.get_template_files("Default")
+
+    def test_public_tool_schemas_use_canonical_categories(self):
+        expected = TemplateConfigManager.get_supported_categories()
+        tools = get_codegen_tools() + get_springboot_project_tools()
+
+        category_enums = [
+            tool.inputSchema["properties"]["template_category"]["enum"]
+            for tool in tools
+            if "template_category" in tool.inputSchema.get("properties", {})
+        ]
+
+        assert category_enums
+        assert all(categories == expected for categories in category_enums)
+
     def test_default_files(self):
         files = TemplateConfigManager.get_template_files("Default")
         assert "entity.mustache" in files


### PR DESCRIPTION
## 背景

Closes #47。模板分类在多个模块重复维护，导致 sb35-java21 未完整出现在 legacy MCP schema，未知分类还会静默返回 0 个文件，调用方无法判断输入是否有效。

## 变更

- 在 TemplateConfigManager 集中维护四种模板分类及对应模板文件，并提供 get_supported_categories。
- JavaCodeGenerator、CodegenGenerator 和 atomic codegen 共用该分类来源。
- CodegenGenerator 与 atomic build_context 在数据库访问前拒绝未知分类；atomic render 在渲染前返回结构化错误和支持列表。
- legacy codegen 与 Spring Boot 项目工具 schema 动态读取同一分类列表，补齐 sb35-java21。
- legacy 生成上下文补充 isSb35Java21 标志。
- 为模板列表返回副本，避免调用方修改全局配置。

## 验证

- python -m pytest tests/unit/test_template_context_builder.py tests/unit/test_atomic_codegen_tools.py tests/unit/test_codegen_analyzer.py tests/unit/test_java_generator.py -q：107 passed。
- python -m pytest tests/unit/ -q：596 passed。
- python -m ruff check 变更相关文件：通过。
- git diff --check：通过。
- scripts/validate_commit_title.py：提交标题通过。

## 实验与性能

实验覆盖四种已支持分类的模板列表、legacy 与 Spring Boot 工具 schema 一致性、未知分类提前失败、atomic render 结构化错误和列表副本隔离。该变更是契约与错误处理修复，未进行性能基准测试，也没有宣称性能收益。

## 风险与回滚

不改变既有模板内容和四种分类的生成文件；唯一行为变化是未知分类从静默空结果变为显式错误。可通过回退提交 6cb8d66 回滚；回滚后会恢复分类重复和静默失败问题。