### PR TITLE
:recycle: refactor(codegen): 清理生成阶段无效对象构造

### DIFF
--- a/src/dbjavagenix/database/codegen_tools.py
+++ b/src/dbjavagenix/database/codegen_tools.py
@@ -5,9 +5,8 @@
 
 from typing import Dict, List, Any, Optional
 from ..database.connection_manager import ConnectionManager
-from ..generator.java_generator import JavaCodeGenerator
 from ..generator.template_context import TemplateContextBuilder
-from ..core.models import TableInfo, ColumnInfo, DatabaseType, GenerationConfig
+from ..core.models import TableInfo, ColumnInfo, DatabaseType
 from .introspection import DatabaseIntrospector
 
 
@@ -247,42 +246,6 @@ class CodegenGenerator:
             raise ValueError(
                 f"不支持的模板分类: {template_category!r}；支持分类: {supported}"
             )
-
-        # 构建生成配置
-        config = GenerationConfig(
-            output_dir=generation_config.get("output_dir", "/tmp/generated")
-            if generation_config
-            else "/tmp/generated",
-            author=generation_config.get("author", "ZXP") if generation_config else "ZXP",
-            package_name=generation_config.get("package_name", "com.example.generated")
-            if generation_config
-            else "com.example.generated",
-        )
-
-        # 创建 Java 代码生成器
-        java_generator = JavaCodeGenerator(config)
-
-        # 构建 TableInfo 对象
-        table_info_dict = analysis_result["table_info"]
-        columns = []
-        for col_dict in table_info_dict["columns"]:
-            column = ColumnInfo(
-                name=col_dict["name"],
-                data_type=col_dict["type"],
-                java_type=col_dict.get("java_type", "String"),
-                nullable=col_dict["nullable"],
-                primary_key=col_dict["primary_key"],
-                default_value=col_dict["default_value"],
-                comment=col_dict["comment"],
-            )
-            columns.append(column)
-
-        table_info = TableInfo(
-            name=table_info_dict["name"],
-            schema="test1",  # 使用默认schema
-            comment=table_info_dict["comment"],
-            columns=columns,
-        )
 
         # 生成代码到内存中（不写入文件）
         generated_code = {}

--- a/tests/unit/test_codegen_analyzer.py
+++ b/tests/unit/test_codegen_analyzer.py
@@ -59,3 +59,30 @@ def test_analyzer_has_no_legacy_direct_metadata_methods():
 async def test_generator_rejects_unknown_category_before_reading_analysis():
     with pytest.raises(ValueError, match="不支持的模板分类"):
         await CodegenGenerator().generate_code({}, template_category="UnknownCategory")
+
+
+@pytest.mark.asyncio
+async def test_generator_does_not_require_unused_table_info(monkeypatch):
+    generator = CodegenGenerator()
+
+    async def render_template(_template_file, _context, _category):
+        return "// generated"
+
+    monkeypatch.setattr(generator, "_render_template", render_template)
+    result = await generator.generate_code(
+        {
+            "table_name": "users",
+            "template_context": {
+                "className": "User",
+                "package": "com.example",
+                "packageSuffix": "",
+            },
+        },
+        template_category="MybatisPlus",
+    )
+
+    assert result["generation_statistics"] == {
+        "total_files": 6,
+        "success_files": 6,
+        "error_files": 0,
+    }


### PR DESCRIPTION
## 背景

Closes #49。CodegenGenerator.generate_code 中存在一条未被使用的对象构造路径：每次生成都会实例化 JavaCodeGenerator，并把分析结果重建为 TableInfo（schema 还硬编码为 test1），但后续渲染完全不读取这两个对象。

## 变更

- 删除 CodegenGenerator 中未使用的 JavaCodeGenerator 实例化。
- 删除未被消费的 ColumnInfo/TableInfo 重建和硬编码 schema。
- 保留 CodegenGenerator 对 template_context、模板分类和输出映射的现有行为。
- 增加最小分析结果回归测试，验证只依赖声明的 table_name 与 template_context 即可完成渲染。

## 验证

- python -m pytest tests/unit/test_codegen_analyzer.py tests/unit/test_java_generator.py tests/unit/test_atomic_codegen_tools.py -q：49 passed。
- python -m pytest tests/unit/ -q：597 passed。
- python -m ruff check src/ tests/：通过。
- git diff --check：通过。
- scripts/validate_commit_title.py：提交标题通过。

## 实验与性能

实验使用不含 table_info 的最小分析结果，并替换模板渲染函数，验证生成统计仍为 MybatisPlus 六个文件且全部成功。该变更删除了未使用对象构造，但未建立前后基准，因此不宣称具体性能收益。

## 风险与回滚

模板内容、输出路径、分类和数据库 introspection 契约均未改变；变化仅限移除死代码。可回退提交 77b750a，恢复原对象构造路径。