### PR TITLE
:bug: fix(mcp): 统一工具异常结构化响应

### DIFF
--- a/src/dbjavagenix/server/mcp_server.py
+++ b/src/dbjavagenix/server/mcp_server.py
@@ -3,6 +3,7 @@ DBJavaGenix MCP Server
 Provides database analysis and Java code generation capabilities through MCP tools
 """
 import asyncio
+import json
 import logging
 from typing import Any, Callable, Sequence
 
@@ -62,7 +63,7 @@ from ..database.observability_tools import (
     handle_server_metrics,
 )
 from ..utils.metrics import GLOBAL_TOOL_METRICS
-from ..utils.security import redact_sensitive_data
+from ..utils.security import redact_sensitive_data, redact_sensitive_text
 from ..utils.logging_config import configure_logging
 from ..utils.tool_registry import filter_tools_for_listing
 
@@ -123,6 +124,17 @@ def _tool_handlers(tools: list[Tool] | None = None) -> dict[str, Callable[..., A
     return handlers
 
 
+def _tool_error_response(tool_name: str, error_code: str, error: object) -> list[TextContent]:
+    """Build the stable error envelope exposed at the MCP boundary."""
+    payload = {
+        "success": False,
+        "error": error_code,
+        "tool": tool_name,
+        "message": redact_sensitive_text(error),
+    }
+    return [TextContent(type="text", text=json.dumps(payload, ensure_ascii=False))]
+
+
 @server.list_tools()
 async def handle_list_tools() -> list[Tool]:
     """
@@ -164,16 +176,15 @@ async def handle_call_tool(name: str, arguments: dict[str, Any]) -> list[TextCon
     try:
         handler = _tool_handlers().get(name)
         if handler is None:
-            raise ValueError(f"Unknown tool: {name}")
+            _is_error = True
+            return _tool_error_response(name, "unknown_tool", f"Unknown tool: {name}")
         return await handler(arguments)
             
     except Exception as e:
         _is_error = True
-        logger.error(f"Tool execution failed: {e}")
-        return [TextContent(
-            type="text",
-            text=f"Tool execution failed: {str(e)}"
-        )]
+        safe_message = redact_sensitive_text(e)
+        logger.error("Tool execution failed for %s: %s", name, safe_message)
+        return _tool_error_response(name, "tool_execution_failed", safe_message)
     finally:
         _duration_ms = (_time_for_metrics.perf_counter() - _start_perf) * 1000
         GLOBAL_TOOL_METRICS.record(name, _duration_ms, _is_error)

--- a/tests/unit/test_server_dispatch.py
+++ b/tests/unit/test_server_dispatch.py
@@ -1,5 +1,7 @@
 """Contract tests for canonical MCP tool listing and dispatch."""
 
+import json
+
 from mcp.types import TextContent, Tool
 import pytest
 
@@ -31,6 +33,38 @@ async def test_dispatch_resolves_handler_from_canonical_name(monkeypatch):
 
     assert result[0].text == "ok"
     assert calls == [{"verbose": True}]
+
+
+@pytest.mark.asyncio
+async def test_unknown_tool_returns_structured_error(monkeypatch):
+    monkeypatch.setattr(mcp_server, "_tool_handlers", lambda: {})
+
+    result = await mcp_server.handle_call_tool("missing_tool", {})
+    payload = json.loads(result[0].text)
+
+    assert payload == {
+        "success": False,
+        "error": "unknown_tool",
+        "tool": "missing_tool",
+        "message": "Unknown tool: missing_tool",
+    }
+
+
+@pytest.mark.asyncio
+async def test_handler_exception_returns_redacted_structured_error(monkeypatch):
+    async def fail(_arguments):
+        raise RuntimeError("failed for jdbc:mysql://reader:db-secret@db/app")
+
+    monkeypatch.setattr(mcp_server, "_tool_handlers", lambda: {"failing_tool": fail})
+
+    result = await mcp_server.handle_call_tool("failing_tool", {})
+    payload = json.loads(result[0].text)
+
+    assert payload["success"] is False
+    assert payload["error"] == "tool_execution_failed"
+    assert payload["tool"] == "failing_tool"
+    assert payload["message"] == "failed for jdbc:mysql://reader:***@db/app"
+    assert "db-secret" not in result[0].text
 
 
 def test_handler_registry_rejects_duplicate_tool_names(monkeypatch):


### PR DESCRIPTION
## 背景

Closes #51。MCP server 的 handle_call_tool 对未知工具和 handler 异常只返回纯文本，调用方无法稳定解析错误类型、工具名和消息；异常消息也没有统一经过边界脱敏。

## 变更

- 新增统一错误信封：success、error、tool、message。
- 未知工具返回 error=unknown_tool。
- handler 异常返回 error=tool_execution_failed。
- 异常消息先通过现有 redact_sensitive_text 处理，再写入日志和响应。
- 正常 handler 响应和 GLOBAL_TOOL_METRICS 记录逻辑保持不变。
- 增加未知工具、handler 异常脱敏和正常 dispatch 回归测试。

## 验证

- python -m pytest tests/unit/test_server_dispatch.py tests/unit/test_security.py -q：15 passed。
- python -m ruff check src/dbjavagenix/server/mcp_server.py tests/unit/test_server_dispatch.py：通过。
- git diff --check：通过。
- scripts/validate_commit_title.py：提交标题通过。

## 实验与性能

使用不存在的工具和抛出 JDBC URL 异常的 fake handler 验证响应结构及 db-secret 脱敏；正常 server_health dispatch 仍返回原始 TextContent。此次是协议错误边界修复，未进行性能基准测试，也没有宣称性能收益。

## 风险与回滚

业务工具内部历史错误文案未改变，仅 server 最外层异常从纯文本变为 JSON；客户端应读取 message 字段。可回退提交 c9354ef。