### PR TITLE
:bug: fix(metadata): 修正 PostgreSQL 复合外键映射

### DIFF
--- a/src/dbjavagenix/database/introspection.py
+++ b/src/dbjavagenix/database/introspection.py
@@ -305,30 +305,41 @@ class DatabaseIntrospector:
                 (config.database, table_name),
             )
         elif config.type == DatabaseType.POSTGRESQL:
-            schema_filter = "AND tc.table_schema = %s" if schema else ""
+            schema_filter = "AND src_ns.nspname = %s" if schema else ""
             params = (table_name, schema) if schema else (table_name,)
             rows = self.connection_manager.execute_query(
                 connection_id,
                 f"""
-                SELECT tc.constraint_name, kcu.column_name,
-                       ccu.table_name AS referenced_table_name,
-                       ccu.column_name AS referenced_column_name
-                FROM information_schema.table_constraints tc
-                JOIN information_schema.key_column_usage kcu
-                  ON tc.constraint_catalog = kcu.constraint_catalog
-                 AND tc.constraint_schema = kcu.constraint_schema
-                 AND tc.constraint_name = kcu.constraint_name
-                 AND tc.table_name = kcu.table_name
-                JOIN information_schema.constraint_column_usage ccu
-                  ON tc.constraint_catalog = ccu.constraint_catalog
-                 AND tc.constraint_schema = ccu.constraint_schema
-                 AND tc.constraint_name = ccu.constraint_name
-                WHERE tc.table_catalog = current_database()
-                  AND tc.constraint_type = 'FOREIGN KEY'
-                  AND tc.table_schema NOT IN ('pg_catalog', 'information_schema')
-                  AND tc.table_name = %s
+                SELECT con.conname AS constraint_name,
+                       src_att.attname AS column_name,
+                       tgt_tbl.relname AS referenced_table_name,
+                       tgt_att.attname AS referenced_column_name,
+                       src_keys.ordinality AS column_position
+                FROM pg_catalog.pg_constraint con
+                JOIN pg_catalog.pg_class src_tbl
+                  ON src_tbl.oid = con.conrelid
+                JOIN pg_catalog.pg_namespace src_ns
+                  ON src_ns.oid = src_tbl.relnamespace
+                JOIN pg_catalog.pg_class tgt_tbl
+                  ON tgt_tbl.oid = con.confrelid
+                JOIN pg_catalog.pg_namespace tgt_ns
+                  ON tgt_ns.oid = tgt_tbl.relnamespace
+                CROSS JOIN LATERAL unnest(con.conkey)
+                  WITH ORDINALITY AS src_keys(attnum, ordinality)
+                JOIN LATERAL unnest(con.confkey)
+                  WITH ORDINALITY AS tgt_keys(attnum, ordinality)
+                  ON tgt_keys.ordinality = src_keys.ordinality
+                JOIN pg_catalog.pg_attribute src_att
+                  ON src_att.attrelid = src_tbl.oid
+                 AND src_att.attnum = src_keys.attnum
+                JOIN pg_catalog.pg_attribute tgt_att
+                  ON tgt_att.attrelid = tgt_tbl.oid
+                 AND tgt_att.attnum = tgt_keys.attnum
+                WHERE con.contype = 'f'
+                  AND src_ns.nspname NOT IN ('pg_catalog', 'information_schema')
+                  AND src_tbl.relname = %s
                   {schema_filter}
-                ORDER BY tc.constraint_name, kcu.ordinal_position
+                ORDER BY con.conname, src_keys.ordinality
                 """,
                 params,
             )

--- a/tests/unit/test_database_introspection.py
+++ b/tests/unit/test_database_introspection.py
@@ -222,6 +222,56 @@ def test_postgresql_describe_table_scopes_all_catalog_queries_to_schema():
     assert all(params == ("users", "tenant_a") for _, params in manager.calls if params)
 
 
+def test_postgresql_composite_foreign_keys_pair_columns_by_position():
+    manager = RecordingManager()
+    original_execute_query = manager.execute_query
+
+    def execute_query(connection_id, query, params=None):
+        manager.calls.append((query, params))
+        if "pg_catalog.pg_constraint" in query:
+            return [
+                {
+                    "constraint_name": "orders_customer_fk",
+                    "column_name": "tenant_id",
+                    "referenced_table_name": "customers",
+                    "referenced_column_name": "tenant_id",
+                    "column_position": 1,
+                },
+                {
+                    "constraint_name": "orders_customer_fk",
+                    "column_name": "customer_id",
+                    "referenced_table_name": "customers",
+                    "referenced_column_name": "id",
+                    "column_position": 2,
+                },
+            ]
+        return original_execute_query(connection_id, query, params)
+
+    manager.execute_query = execute_query
+    foreign_keys = DatabaseIntrospector(manager).get_foreign_keys(
+        "pg-1", "orders", "tenant_a"
+    )
+
+    assert foreign_keys == [
+        {
+            "constraint_name": "orders_customer_fk",
+            "column_name": "tenant_id",
+            "referenced_table": "customers",
+            "referenced_column": "tenant_id",
+        },
+        {
+            "constraint_name": "orders_customer_fk",
+            "column_name": "customer_id",
+            "referenced_table": "customers",
+            "referenced_column": "id",
+        },
+    ]
+    assert len(manager.calls) == 1
+    query, params = manager.calls[0]
+    assert "tgt_keys.ordinality = src_keys.ordinality" in query
+    assert params == ("orders", "tenant_a")
+
+
 def test_postgresql_get_table_rejects_ambiguous_schema():
     manager = RecordingManager()
 

--- a/tests/unit/test_database_introspection.py
+++ b/tests/unit/test_database_introspection.py
@@ -248,9 +248,7 @@ def test_postgresql_composite_foreign_keys_pair_columns_by_position():
         return original_execute_query(connection_id, query, params)
 
     manager.execute_query = execute_query
-    foreign_keys = DatabaseIntrospector(manager).get_foreign_keys(
-        "pg-1", "orders", "tenant_a"
-    )
+    foreign_keys = DatabaseIntrospector(manager).get_foreign_keys("pg-1", "orders", "tenant_a")
 
     assert foreign_keys == [
         {


### PR DESCRIPTION
## 关联 Issue

Closes #53

## 背景（Situation）

PostgreSQL 复合外键的本地列与引用列必须依约束数组位置配对。旧的 information schema 行查询可能错配多列关系，使 MCP 外键工具、ER 图和代码生成得到错误的列映射。

## 任务（Task）

从 PostgreSQL catalog 恢复有序的复合外键关系，保留约束、schema、引用表和列信息，并不改变其他方言的契约。

## 行动（Action）

- 使用 PostgreSQL 约束 metadata 的本地与引用列位置建立一对一映射。
- 传递 schema 参数，避免同名表跨 schema 串扰。
- 让 MCP 外键工具与可视化继续消费统一 introspector 输出。
- 没有做什么：不引入跨库外键、外键 DDL 修改或其他数据库方言重写。

## 验证（Verification）

2026-09-08 在当前主线重跑 `tests/unit/test_database_introspection.py`、`test_postgresql_mcp_tools.py` 与相关回归集，共 `43 passed`。`test_postgresql_composite_foreign_keys_pair_columns_by_position` 使用 PostgreSQL stub 验证 `(tenant_id, customer_id)` 按位置映射到引用列，而不是按返回行偶然顺序匹配；MCP schema 转发测试同时通过。

## 实验与证据（Evidence）

测试使用确定性 catalog 行和 `tenant_a` schema，不需要真实 PostgreSQL 服务。它证明 SQL 结果转换和参数传递契约；没有测量查询延迟、吞吐或执行计划，因此不作性能结论。

## 兼容性、风险与回滚

- 公共 API / 数据格式 / 迁移：单列外键与 MySQL/SQLite 输出保持不变；复合外键现在返回正确的有序列配对。
- 风险：PostgreSQL catalog 字段依赖版本语义，新增特性需要真实数据库集成测试。
- 回滚：回退该修复会恢复可能错配的复合外键，不建议作为兼容方案。
- 后续：将真实 PostgreSQL Testcontainers 结果附加到独立集成验证 PR。