### PR TITLE
:bug: fix(server): 注册 schema 图算法工具

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,11 @@ graph LR
     Skills[".claude/skills/<br/>java-codegen-from-db<br/>springboot-migration"]
     Skills -->|按需调用| MCP
 
-    subgraph MCP[MCP Server 29 工具]
+    subgraph MCP[MCP Server 32 工具]
         direction TB
         DB[db_* 连接 / 查询 / 描述]
         Atom[codegen_build_context<br/>codegen_render_entity/dao/service/<br/>controller/mapper]
+        Graph[schema_topo_order<br/>schema_cluster_tables<br/>schema_check_cycles]
         AI[ai_infer_business_names<br/>ai_recommend_template<br/>ai_summarize_schema]
         Vis[db_render_er_diagram]
         Obs[server_metrics / server_health<br/>ai_metrics / search_tools]
@@ -129,12 +130,13 @@ SQL Server 的类型映射保留为后续扩展准备，但尚未实现运行时
 - 结构化日志: `DBJAVAGENIX_LOG_FORMAT=json` 可输出单行 JSON,适合 Loki/ELK
 - [部署手册](docs/deployment.md): 3 种部署模式 + 6 个排障场景
 
-## 工具总览 (29 个)
+## 工具总览 (32 个)
 
 | 类别 | 工具 |
 |------|------|
 | 连接 / 查询 | db_connect_test / db_query_databases / db_query_tables / db_query_table_exists / db_query_execute |
 | 表结构 | db_table_describe / db_table_columns / db_table_primary_keys / db_table_foreign_keys / db_table_indexes |
+| Schema 图算法 | schema_topo_order / schema_cluster_tables / schema_check_cycles |
 | 代码生成 (atomic) | codegen_build_context / codegen_render_entity / codegen_render_dao / codegen_render_service / codegen_render_controller / codegen_render_mapper |
 | 代码生成 (legacy) | db_codegen_analyze / db_codegen_generate |
 | Spring Boot 项目 | springboot_validate_project / springboot_analyze_dependencies / springboot_read_config |
@@ -164,7 +166,7 @@ SQL Server 的类型映射保留为后续扩展准备，但尚未实现运行时
 ```
 [ Skills 层 ]  定义"怎么做" — .claude/skills/*.md  显式 5 阶段工作流
        ↓
-[ MCP 层 ]     提供"能做什么" — 29 个原子工具  context 显式传递
+[ MCP 层 ]     提供"能做什么" — 32 个原子工具  context 显式传递
        ↓
 [ Apps 层 ]    让结果"看得见" — 4 个 UI 组件 (mermaid/dashboard/code-diff/tree)
 ```

--- a/docs/adr/001-three-layer-architecture.md
+++ b/docs/adr/001-three-layer-architecture.md
@@ -33,7 +33,7 @@ DBJavaGenix v0.1 把所有逻辑塞进 `db_codegen_generate` 单个 MCP 工具:
                   - 显式 5 阶段工作流
                   - LLM 加载后照做,不自由发挥
 
-[ MCP 层 ]      原子工具 (29 个)
+[ MCP 层 ]      原子工具 (32 个)
                   - 每个工具职责单一 (build_context / render_entity / ...)
                   - context 显式参数传递,无 server 内部状态
                   - 每个工具单元可测
@@ -69,7 +69,7 @@ DBJavaGenix v0.1 把所有逻辑塞进 `db_codegen_generate` 单个 MCP 工具:
 - MCP Apps 让结果可视化 (4 个 UI 组件)
 
 **坏**:
-- 注册工具数从 15 涨到 29 → 默认模式 token 反而增加 (3304 vs 2450)
+- 注册工具数从 15 涨到 32 → 默认模式 token 反而增加 (具体 token 数随工具 schema 变化)
 - 通过 progressive mode (ADR-003) 缓解
 
 **待办**:

--- a/docs/demo-script.md
+++ b/docs/demo-script.md
@@ -49,7 +49,7 @@
 ```
 
 **说**:
-> "29 个工具就绪,modules 全部 OK。注意 progressive 模式 — 初始只暴露 6 个 always-visible 工具,启动 token 从 3300 降到 985。"
+> "32 个工具就绪,modules 全部 OK。注意 progressive 模式 — 初始只暴露 6 个 always-visible 工具,启动 token 从 3300 降到 985。"
 
 ### [0:45] 任务输入 (10 秒)
 
@@ -99,7 +99,7 @@
 **做**: `server_metrics` 看一下累积调用。
 
 **说**:
-> "整个流程透明可观测,29 个工具,5 阶段 Skill 编排,4 个 MCP App 组件。代码在 [github.com/ZhaoXingPeng/DBJavaGenix](https://github.com/ZhaoXingPeng/DBJavaGenix),完整迭代方案在 iteration-plan/ 目录。"
+> "整个流程透明可观测,32 个工具,5 阶段 Skill 编排,4 个 MCP App 组件。代码在 [github.com/ZhaoXingPeng/DBJavaGenix](https://github.com/ZhaoXingPeng/DBJavaGenix),完整迭代方案在 iteration-plan/ 目录。"
 
 ---
 
@@ -116,7 +116,7 @@
 
 打开 README.md 的 mermaid 架构图,讲三层:
 - **Skills**: `.claude/skills/java-codegen-from-db/SKILL.md` — 看一眼"5 阶段工作流"
-- **MCP 29 工具**: 强调 atomic 拆分 (db_codegen_generate → 6 个原子工具)
+- **MCP 32 工具**: 强调 atomic 拆分 (db_codegen_generate → 6 个原子工具) 与 schema 图算法
 - **Apps**: 4 个 UI 组件,客户端按 _meta 渲染
 
 提一句:

--- a/src/dbjavagenix/database/schema_algorithms_tools.py
+++ b/src/dbjavagenix/database/schema_algorithms_tools.py
@@ -174,6 +174,12 @@ SCHEMA_ALGORITHM_TOOLS = [
     SCHEMA_CYCLE_TOOL,
 ]
 
+
+def get_schema_algorithm_tools() -> list[Tool]:
+    """Return the schema graph tools for canonical MCP registration."""
+    return list(SCHEMA_ALGORITHM_TOOLS)
+
+
 SCHEMA_ALGORITHM_HANDLERS = {
     "schema_topo_order": handle_schema_topo_order,
     "schema_cluster_tables": handle_schema_cluster_tables,

--- a/src/dbjavagenix/server/mcp_server.py
+++ b/src/dbjavagenix/server/mcp_server.py
@@ -62,6 +62,12 @@ from ..database.observability_tools import (
     handle_server_health,
     handle_server_metrics,
 )
+from ..database.schema_algorithms_tools import (
+    get_schema_algorithm_tools,
+    handle_schema_topo_order,
+    handle_schema_cluster_tables,
+    handle_schema_check_cycles,
+)
 from ..utils.metrics import GLOBAL_TOOL_METRICS
 from ..utils.security import redact_sensitive_data, redact_sensitive_text
 from ..utils.logging_config import configure_logging
@@ -86,6 +92,7 @@ _TOOL_FACTORIES: tuple[ToolFactory, ...] = (
     get_visualization_tools,
     get_ai_tools,
     get_observability_tools,
+    get_schema_algorithm_tools,
     get_discovery_tools,
 )
 

--- a/src/dbjavagenix/utils/tool_registry.py
+++ b/src/dbjavagenix/utils/tool_registry.py
@@ -24,6 +24,7 @@ from mcp.types import Tool
 @dataclass
 class ToolMetadata:
     """单个工具的元数据"""
+
     name: str
     tags: Set[str] = field(default_factory=set)
     category: str = "misc"
@@ -100,6 +101,25 @@ _REGISTRY: Dict[str, ToolMetadata] = {
         tags={"index", "indexes", "btree"},
         category="schema",
         description_brief="获取表的索引信息",
+    ),
+    # ---- Schema 图算法 ----
+    "schema_topo_order": ToolMetadata(
+        name="schema_topo_order",
+        tags={"schema", "graph", "topological", "sort", "dependency", "ddl"},
+        category="schema-algorithms",
+        description_brief="按外键依赖生成确定性的表创建顺序",
+    ),
+    "schema_cluster_tables": ToolMetadata(
+        name="schema_cluster_tables",
+        tags={"schema", "graph", "cluster", "module", "union-find"},
+        category="schema-algorithms",
+        description_brief="使用 Union-Find 按外键连通性聚类业务表",
+    ),
+    "schema_check_cycles": ToolMetadata(
+        name="schema_check_cycles",
+        tags={"schema", "graph", "cycle", "foreign-key", "dependency"},
+        category="schema-algorithms",
+        description_brief="检测外键依赖环并返回不可排序的表",
     ),
     # ---- 代码生成 (legacy) ----
     "db_codegen_analyze": ToolMetadata(
@@ -250,9 +270,8 @@ def is_progressive_mode_enabled() -> bool:
 # 搜索逻辑
 # ============================================================
 
-def search_tools_by_query(
-    query: str, limit: int = 10
-) -> List[Dict[str, str]]:
+
+def search_tools_by_query(query: str, limit: int = 10) -> List[Dict[str, str]]:
     """按 query 搜索匹配的工具元数据。
 
     匹配规则 (case-insensitive):
@@ -270,9 +289,7 @@ def search_tools_by_query(
     """
     if not query or not query.strip():
         # 空 query → 返回 always_visible + 类别样例
-        candidates = [
-            m for m in _REGISTRY.values() if m.always_visible
-        ]
+        candidates = [m for m in _REGISTRY.values() if m.always_visible]
         return [
             {
                 "name": m.name,

--- a/tests/unit/test_server_dispatch.py
+++ b/tests/unit/test_server_dispatch.py
@@ -20,6 +20,25 @@ async def test_every_listed_tool_has_a_handler():
 
 
 @pytest.mark.asyncio
+async def test_schema_algorithm_tools_are_listed_and_dispatchable():
+    tools = await mcp_server.handle_list_tools()
+    names = {tool.name for tool in tools}
+
+    assert {
+        "schema_topo_order",
+        "schema_cluster_tables",
+        "schema_check_cycles",
+    } <= names
+
+    result = await mcp_server.handle_call_tool(
+        "schema_topo_order",
+        {"tables": ["parent", "child"], "fks": [["child", "parent"]]},
+    )
+    payload = json.loads(result[0].text)
+    assert payload["order"] == ["parent", "child"]
+
+
+@pytest.mark.asyncio
 async def test_dispatch_resolves_handler_from_canonical_name(monkeypatch):
     calls = []
 

--- a/tests/unit/test_tool_registry.py
+++ b/tests/unit/test_tool_registry.py
@@ -75,6 +75,10 @@ class TestSearchQuery:
         names = {r["name"] for r in results}
         assert "db_table_foreign_keys" in names
 
+    def test_schema_algorithm_search(self):
+        results = search_tools_by_query("topological")
+        assert results[0]["name"] == "schema_topo_order"
+
     def test_multi_token_search(self):
         results = search_tools_by_query("render entity")
         names = [r["name"] for r in results]


### PR DESCRIPTION
## 关联 Issue
Closes #59

## 背景
已有 schema 图算法实现和单元测试，但没有接入 MCP server canonical factory 或工具元数据注册表。

## 修改
- 注册 3 个 schema 算法工具和 handler；
- 加入 progressive discovery 元数据；
- 增加 listing、dispatch、关键词搜索测试；
- 同步 README、ADR 和演示脚本中的工具数量。

## 验证
- 工具与元数据均为 32 项，集合无缺失；
- 相关单元测试 43 项通过；
- Ruff、格式检查和 diff 检查通过。

## 风险与回滚
新增 3 个公开工具，progressive 模式仍通过 search_tools 发现；回滚提交 `2b888c9` 与 `42671c8`。