### PR TITLE
:bug: fix(metadata): 保留 PostgreSQL 表达式索引

### DIFF
--- a/src/dbjavagenix/database/introspection.py
+++ b/src/dbjavagenix/database/introspection.py
@@ -391,7 +391,7 @@ class DatabaseIntrospector:
             rows = self.connection_manager.execute_query(
                 connection_id,
                 f"""
-                SELECT idx.relname AS key_name, att.attname AS column_name,
+                SELECT idx.relname AS key_name, COALESCE(att.attname, '') AS column_name,
                        i.indisunique AS is_unique, keys.ordinality AS seq_in_index,
                        am.amname AS index_type
                 FROM pg_class tbl
@@ -400,7 +400,7 @@ class DatabaseIntrospector:
                 JOIN pg_class idx ON idx.oid = i.indexrelid
                 JOIN pg_am am ON am.oid = idx.relam
                 CROSS JOIN LATERAL unnest(i.indkey) WITH ORDINALITY AS keys(attnum, ordinality)
-                JOIN pg_attribute att ON att.attrelid = tbl.oid AND att.attnum = keys.attnum
+                LEFT JOIN pg_attribute att ON att.attrelid = tbl.oid AND att.attnum = keys.attnum
                 WHERE ns.nspname NOT IN ('pg_catalog', 'information_schema')
                   AND tbl.relname = %s
                   {schema_filter}

--- a/tests/unit/test_database_introspection.py
+++ b/tests/unit/test_database_introspection.py
@@ -270,6 +270,40 @@ def test_postgresql_composite_foreign_keys_pair_columns_by_position():
     assert params == ("orders", "tenant_a")
 
 
+def test_postgresql_expression_indexes_are_preserved():
+    manager = RecordingManager()
+
+    def execute_query(connection_id, query, params=None):
+        manager.calls.append((query, params))
+        if "pg_index" in query:
+            return [
+                {
+                    "key_name": "users_lower_email_idx",
+                    "column_name": "",
+                    "is_unique": True,
+                    "seq_in_index": 1,
+                    "index_type": "btree",
+                }
+            ]
+        return []
+
+    manager.execute_query = execute_query
+    indexes = DatabaseIntrospector(manager).get_indexes("pg-1", "users")
+
+    assert indexes == [
+        {
+            "key_name": "users_lower_email_idx",
+            "column_name": "",
+            "unique": True,
+            "seq_in_index": 1,
+            "index_type": "btree",
+        }
+    ]
+    query, params = manager.calls[0]
+    assert "LEFT JOIN pg_attribute" in query
+    assert params == ("users",)
+
+
 def test_postgresql_get_table_rejects_ambiguous_schema():
     manager = RecordingManager()
 


### PR DESCRIPTION
## 关联 Issue
Closes #61

## 背景
PostgreSQL 表达式索引在 `pg_index.indkey` 中使用 `0` 表示表达式。原查询通过内连接 `pg_attribute`，表达式索引没有对应属性行，导致索引整体丢失。

## 修改
- 将 PostgreSQL 索引列解析改为 `LEFT JOIN pg_attribute`；
- 使用 `COALESCE` 将表达式列规范化为空字符串；
- 保留普通列索引、唯一性、索引类型和列序号；
- 增加表达式索引回归测试。

## 验证
- `python -m pytest tests/unit/test_database_introspection.py tests/unit/test_metadata_contract.py -q --no-cov`：12 项通过；
- `python -m ruff check src/ tests/ scripts/`：通过；
- 变更文件格式检查：通过；
- `git diff --check`：通过。

## 实验与结果
使用模拟 `indkey=0` 的表达式索引行验证：修复后保留索引，`column_name` 为约定的空字符串；修复前查询条件为内连接，无法保留该行。

## 性能与回滚
本次修复针对元数据正确性，未在真实 PostgreSQL 上进行性能测量，不报告性能提升数值。回滚提交 `1b66ed7` 即可恢复。