### PR TITLE
:bug: fix(codegen): 修复 PostgreSQL schema 代码生成转发

### DIFF
--- a/src/dbjavagenix/database/atomic_codegen_tools.py
+++ b/src/dbjavagenix/database/atomic_codegen_tools.py
@@ -73,6 +73,10 @@ def get_atomic_codegen_tools() -> List[Tool]:
                         "type": "string",
                         "description": "Database name (optional, uses connection default)",
                     },
+                    "schema": {
+                        "type": "string",
+                        "description": "PostgreSQL schema (optional; required for ambiguous table names)",
+                    },
                     "template_category": {
                         "type": "string",
                         "enum": ["Default", "MybatisPlus", "MybatisPlus-Mixed", "sb35-java21"],
@@ -168,6 +172,7 @@ async def handle_codegen_build_context(arguments: Dict[str, Any]) -> List[TextCo
         connection_id = arguments["connection_id"]
         table_name = arguments["table_name"]
         database = arguments.get("database")
+        schema = arguments.get("schema") or None
         template_category = arguments.get("template_category", "MybatisPlus-Mixed")
         author = arguments.get("author", "ZXP")
         package_name = arguments.get("package_name", "com.example.generated")
@@ -199,6 +204,7 @@ async def handle_codegen_build_context(arguments: Dict[str, Any]) -> List[TextCo
             all_table_names=all_table_names,
             template_category=template_category,
             project_root=project_path,
+            schema=schema,
         )
 
         context = analysis["template_context"]

--- a/src/dbjavagenix/database/codegen_tools.py
+++ b/src/dbjavagenix/database/codegen_tools.py
@@ -24,18 +24,19 @@ class CodegenAnalyzer:
         all_table_names: Optional[List[str]] = None,
         template_category: str = "Default",
         project_root: Optional[str] = None,
+        schema: Optional[str] = None,
     ) -> Dict[str, Any]:
         """分析单个表的结构，返回代码生成所需的完整信息"""
 
         # 获取表基本信息
         config = self.introspector.get_config(connection_id)
-        table_info = self.introspector.get_table(connection_id, table_name)
+        table_info = self.introspector.get_table(connection_id, table_name, schema)
 
         # 获取列信息
-        columns = self.introspector.get_columns(connection_id, table_name)
+        columns = self.introspector.get_columns(connection_id, table_name, schema)
 
         # 获取主键信息
-        primary_keys = self.introspector.get_primary_keys(connection_id, table_name)
+        primary_keys = self.introspector.get_primary_keys(connection_id, table_name, schema)
         primary_key_set = set(primary_keys)
         for column in columns:
             column["primary_key"] = (
@@ -43,13 +44,13 @@ class CodegenAnalyzer:
             )
 
         # 获取外键信息
-        foreign_keys = self.introspector.get_foreign_keys(connection_id, table_name)
+        foreign_keys = self.introspector.get_foreign_keys(connection_id, table_name, schema)
 
         # 获取索引信息
-        indexes = self.introspector.get_indexes(connection_id, table_name)
+        indexes = self.introspector.get_indexes(connection_id, table_name, schema)
 
         # 获取数据库名称
-        database_name = config.database or table_info.get("schema") or "unknown"
+        database_name = table_info.get("schema") or config.database or "unknown"
 
         # 构建 TableInfo 对象
         table_obj = self._build_table_info(
@@ -243,9 +244,7 @@ class CodegenGenerator:
         supported_categories = TemplateConfigManager.get_supported_categories()
         if template_category not in supported_categories:
             supported = ", ".join(supported_categories)
-            raise ValueError(
-                f"不支持的模板分类: {template_category!r}；支持分类: {supported}"
-            )
+            raise ValueError(f"不支持的模板分类: {template_category!r}；支持分类: {supported}")
 
         # 生成代码到内存中（不写入文件）
         generated_code = {}

--- a/src/dbjavagenix/database/mcp_tools.py
+++ b/src/dbjavagenix/database/mcp_tools.py
@@ -1689,6 +1689,10 @@ def get_codegen_tools() -> List[Tool]:
                         "type": "string",
                         "description": "Database name (optional, uses connection default if not specified)"
                     },
+                    "schema": {
+                        "type": "string",
+                        "description": "PostgreSQL schema (optional; required for ambiguous table names)"
+                    },
                     "template_category": {
                         "type": "string",
                         "description": "Template category to use for context building",
@@ -1736,6 +1740,10 @@ def get_codegen_tools() -> List[Tool]:
                     "database": {
                         "type": "string",
                         "description": "Database name (optional, uses connection default if not specified)"
+                    },
+                    "schema": {
+                        "type": "string",
+                        "description": "PostgreSQL schema (optional; required for ambiguous table names)"
                     },
                     "template_category": {
                         "type": "string",
@@ -1796,6 +1804,7 @@ async def handle_db_codegen_analyze(arguments: Dict[str, Any]) -> List[TextConte
         connection_id = arguments["connection_id"]
         table_name = arguments["table_name"]
         database = arguments.get("database")
+        schema = arguments.get("schema") or None
         template_category = arguments.get("template_category", "MybatisPlus-Mixed")
         author = arguments.get("author", "ZXP")
         package_name = arguments.get("package_name", "com.example.generated")
@@ -1819,7 +1828,8 @@ async def handle_db_codegen_analyze(arguments: Dict[str, Any]) -> List[TextConte
             connection_id,
             table_name,
             template_category=template_category,
-            project_root=project_root
+            project_root=project_root,
+            schema=schema,
         )
         
         # Update template context with user-provided values
@@ -1930,6 +1940,7 @@ async def handle_db_codegen_generate(arguments: Dict[str, Any]) -> List[TextCont
         connection_id = arguments["connection_id"]
         table_name = arguments["table_name"]
         database = arguments.get("database")
+        schema = arguments.get("schema") or None
         template_category = arguments.get("template_category", "MybatisPlus-Mixed")
         author = arguments.get("author", "ZXP")
         package_name = arguments.get("package_name", "com.example.generated")
@@ -2042,7 +2053,8 @@ async def handle_db_codegen_generate(arguments: Dict[str, Any]) -> List[TextCont
             table_name,
             all_table_names=all_table_names,  # 传递所有表名用于前缀分析
             template_category=template_category,
-            project_root=str(_ps["project_root"]) if _ps.get("project_root") else None
+            project_root=str(_ps["project_root"]) if _ps.get("project_root") else None,
+            schema=schema,
         )
         
         # Step 2: Update template context with user preferences

--- a/tests/unit/test_codegen_analyzer.py
+++ b/tests/unit/test_codegen_analyzer.py
@@ -1,13 +1,59 @@
 """Unit tests for the public code-generation analysis workflow."""
 
+from types import SimpleNamespace
+
 import pytest
 
+from dbjavagenix.core.models import DatabaseType
 from dbjavagenix.database.codegen_tools import CodegenAnalyzer, CodegenGenerator
+from dbjavagenix.database.atomic_codegen_tools import get_atomic_codegen_tools
+from dbjavagenix.database.mcp_tools import get_codegen_tools
 
 
 class _FakeIntrospector:
     def list_tables(self, _connection_id):
         return ["users", "broken"]
+
+
+class _SchemaAwareIntrospector:
+    """Record metadata calls so schema forwarding stays observable in one test."""
+
+    def __init__(self):
+        self.calls = []
+
+    def get_config(self, _connection_id):
+        return SimpleNamespace(type=DatabaseType.POSTGRESQL, database="app")
+
+    def get_table(self, connection_id, table_name, schema=None):
+        self.calls.append(("table", connection_id, table_name, schema))
+        return {"name": table_name, "schema": schema, "comment": "Users"}
+
+    def get_columns(self, connection_id, table_name, schema=None):
+        self.calls.append(("columns", connection_id, table_name, schema))
+        return [
+            {
+                "name": "id",
+                "type": "integer",
+                "nullable": False,
+                "primary_key": False,
+                "default_value": None,
+                "comment": "Primary key",
+                "auto_increment": False,
+                "max_length": None,
+            }
+        ]
+
+    def get_primary_keys(self, connection_id, table_name, schema=None):
+        self.calls.append(("primary_keys", connection_id, table_name, schema))
+        return ["id"]
+
+    def get_foreign_keys(self, connection_id, table_name, schema=None):
+        self.calls.append(("foreign_keys", connection_id, table_name, schema))
+        return []
+
+    def get_indexes(self, connection_id, table_name, schema=None):
+        self.calls.append(("indexes", connection_id, table_name, schema))
+        return []
 
 
 class _BatchAnalyzer(CodegenAnalyzer):
@@ -40,6 +86,43 @@ async def test_batch_analysis_keeps_success_and_error_accounting():
     }
     assert result["tables"]["users"]["table_name"] == "users"
     assert result["tables"]["broken"]["error"] == "metadata unavailable"
+
+
+@pytest.mark.asyncio
+async def test_table_analysis_forwards_schema_to_all_metadata_queries():
+    analyzer = CodegenAnalyzer(object())
+    introspector = _SchemaAwareIntrospector()
+    analyzer.introspector = introspector
+
+    result = await analyzer.analyze_table_for_codegen(
+        "pg-1", "users", template_category="Default", schema="tenant_a"
+    )
+
+    assert [call[0] for call in introspector.calls] == [
+        "table",
+        "columns",
+        "primary_keys",
+        "foreign_keys",
+        "indexes",
+    ]
+    assert {call[3] for call in introspector.calls} == {"tenant_a"}
+    assert result["table_info"]["schema"] == "tenant_a"
+    assert result["relationships"]["primary_keys"] == ["id"]
+
+
+def test_codegen_entrypoints_expose_optional_schema():
+    atomic = next(
+        tool for tool in get_atomic_codegen_tools() if tool.name == "codegen_build_context"
+    )
+    legacy = {
+        tool.name: tool
+        for tool in get_codegen_tools()
+        if tool.name in {"db_codegen_analyze", "db_codegen_generate"}
+    }
+
+    assert "schema" in atomic.inputSchema["properties"]
+    assert {"db_codegen_analyze", "db_codegen_generate"} == set(legacy)
+    assert all("schema" in tool.inputSchema["properties"] for tool in legacy.values())
 
 
 def test_analyzer_has_no_legacy_direct_metadata_methods():


### PR DESCRIPTION
## 问题
 PostgreSQL 中同名表可能位于多个 schema，代码生成入口此前无法把调用方选择的 schema 传递给元数据分析器。

## 修改
- CodegenAnalyzer 增加可选 schema 参数，并转发给表、列、主键、外键和索引查询。
- atomic codegen_build_context 与 legacy db_codegen_analyze / db_codegen_generate 公开并转发 schema。
- 保留解析得到的 schema，避免生成上下文回退到数据库名。

## 验证
- 回归测试断言五类元数据查询均收到 tenant_a，并验证返回上下文 schema。
- 工具契约测试断言三个代码生成入口公开可选 schema。
- tests/unit/：606 passed。
- Ruff lint、格式检查通过。
- 性能：本次未测量，改动仅修复参数传递，不宣称性能收益。
 #63