### PR TITLE
:bug: fix(codegen): 保留 PostgreSQL 批量 schema 标识

### DIFF
--- a/src/dbjavagenix/database/codegen_tools.py
+++ b/src/dbjavagenix/database/codegen_tools.py
@@ -97,20 +97,40 @@ class CodegenAnalyzer:
     ) -> Dict[str, Any]:
         """分析整个数据库，返回所有表的代码生成信息"""
 
-        # 获取所有表
-        all_tables = self.introspector.list_tables(connection_id)
+        # PostgreSQL table names are scoped by schema. Keep that identity through
+        # batch analysis so equally named tables cannot become ambiguous or overwrite
+        # one another in the returned mapping.
+        all_table_references = self.introspector.list_table_references(connection_id)
 
-        tables_to_analyze = [t for t in all_tables if not table_filter or t in table_filter]
+        def table_key(reference: Dict[str, str | None]) -> str:
+            return (
+                f"{reference['schema']}.{reference['name']}"
+                if reference["schema"]
+                else reference["name"]
+            )
+
+        tables_to_analyze = [
+            reference
+            for reference in all_table_references
+            if not table_filter
+            or reference["name"] in table_filter
+            or table_key(reference) in table_filter
+        ]
         analysis_results = {}
-        for name in tables_to_analyze:
+        for reference in tables_to_analyze:
+            name = reference["name"]
+            schema = reference["schema"]
+            result_key = table_key(reference)
             try:
-                analysis_results[name] = await self.analyze_table_for_codegen(connection_id, name)
+                analysis_results[result_key] = await self.analyze_table_for_codegen(
+                    connection_id, name, schema=schema
+                )
             except Exception as exc:
-                analysis_results[name] = {"error": str(exc)}
+                analysis_results[result_key] = {"error": str(exc)}
 
         return {
             "database_info": {
-                "total_tables": len(all_tables),
+                "total_tables": len(all_table_references),
                 "analyzed_tables": len(tables_to_analyze),
                 "success_count": sum("error" not in item for item in analysis_results.values()),
                 "error_count": sum("error" in item for item in analysis_results.values()),

--- a/src/dbjavagenix/database/introspection.py
+++ b/src/dbjavagenix/database/introspection.py
@@ -85,6 +85,37 @@ class DatabaseIntrospector:
             for row in rows
         ]
 
+    def list_table_references(self, connection_id: str) -> List[Dict[str, str | None]]:
+        """Return table names with their schema when the database supports schemas."""
+        config = self._config(connection_id)
+        if config.type != DatabaseType.POSTGRESQL:
+            return [
+                {
+                    "name": table_name,
+                    "schema": None,
+                }
+                for table_name in self.list_tables(connection_id)
+            ]
+
+        rows = self.connection_manager.execute_query(
+            connection_id,
+            """
+            SELECT table_name, table_schema
+            FROM information_schema.tables
+            WHERE table_catalog = current_database()
+              AND table_type = 'BASE TABLE'
+              AND table_schema NOT IN ('pg_catalog', 'information_schema')
+            ORDER BY table_schema, table_name
+            """,
+        )
+        return [
+            {
+                "name": str(self._value(row, "table_name", "name", default="")),
+                "schema": str(self._value(row, "table_schema", default="")) or None,
+            }
+            for row in rows
+        ]
+
     def get_table(
         self, connection_id: str, table_name: str, schema: str | None = None
     ) -> Dict[str, Any]:

--- a/tests/unit/test_codegen_analyzer.py
+++ b/tests/unit/test_codegen_analyzer.py
@@ -14,6 +14,12 @@ class _FakeIntrospector:
     def list_tables(self, _connection_id):
         return ["users", "broken"]
 
+    def list_table_references(self, _connection_id):
+        return [
+            {"name": "users", "schema": None},
+            {"name": "broken", "schema": None},
+        ]
+
 
 class _SchemaAwareIntrospector:
     """Record metadata calls so schema forwarding stays observable in one test."""
@@ -68,6 +74,7 @@ class _BatchAnalyzer(CodegenAnalyzer):
         all_table_names=None,
         template_category="Default",
         project_root=None,
+        schema=None,
     ):
         if table_name == "broken":
             raise RuntimeError("metadata unavailable")
@@ -86,6 +93,53 @@ async def test_batch_analysis_keeps_success_and_error_accounting():
     }
     assert result["tables"]["users"]["table_name"] == "users"
     assert result["tables"]["broken"]["error"] == "metadata unavailable"
+
+
+class _PostgresBatchAnalyzer(CodegenAnalyzer):
+    def __init__(self):
+        super().__init__(connection_manager=object())
+        self.introspector = type(
+            "PostgresIntrospector",
+            (),
+            {
+                "list_table_references": lambda _self, _connection_id: [
+                    {"name": "users", "schema": "tenant_a"},
+                    {"name": "users", "schema": "tenant_b"},
+                ]
+            },
+        )()
+        self.calls = []
+
+    async def analyze_table_for_codegen(
+        self,
+        connection_id,
+        table_name,
+        all_table_names=None,
+        template_category="Default",
+        project_root=None,
+        schema=None,
+    ):
+        self.calls.append((connection_id, table_name, schema))
+        return {"table_name": table_name, "table_info": {"schema": schema}}
+
+
+@pytest.mark.asyncio
+async def test_batch_analysis_keeps_postgresql_schema_identity():
+    analyzer = _PostgresBatchAnalyzer()
+
+    result = await analyzer.analyze_database_for_codegen("pg-1")
+
+    assert analyzer.calls == [
+        ("pg-1", "users", "tenant_a"),
+        ("pg-1", "users", "tenant_b"),
+    ]
+    assert result["database_info"] == {
+        "total_tables": 2,
+        "analyzed_tables": 2,
+        "success_count": 2,
+        "error_count": 0,
+    }
+    assert set(result["tables"]) == {"tenant_a.users", "tenant_b.users"}
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_database_introspection.py
+++ b/tests/unit/test_database_introspection.py
@@ -179,6 +179,14 @@ def test_postgresql_introspection_uses_catalog_queries():
     assert all("SHOW TABLES" not in query for query, _ in manager.calls)
 
 
+def test_postgresql_table_references_keep_schema():
+    manager = RecordingManager()
+
+    references = DatabaseIntrospector(manager).list_table_references("pg-1")
+
+    assert references == [{"name": "users", "schema": "public"}]
+
+
 class SchemaAwarePostgresManager(RecordingManager):
     def execute_query(self, connection_id, query, params=None):
         self.calls.append((query, params))


### PR DESCRIPTION
## 问题
 PostgreSQL 的表目录查询可能返回多个 schema 下的同名表，但批量代码生成原先只按裸表名处理，导致元数据查询歧义或结果覆盖。

## 修改
- 新增 list_table_references，保留 PostgreSQL 表名与 schema 的关联。
- 批量代码生成将 schema 转发到单表分析，并使用 schema.table 作为 PostgreSQL 结果键。
- MySQL 与 SQLite 继续返回裸表名键；表过滤同时支持裸表名和 schema.table。

## 验证
- 新增跨 schema 同名表回归测试，断言两次分析分别收到 tenant_a、tenant_b 且结果不覆盖。
- 新增 introspection 表引用测试。
- tests/unit/：608 passed。
- Ruff lint 与格式检查通过。
- 性能：本次未测量，改动关注正确性与结果身份保持。
 #65