### PR TITLE
:bug: fix(mcp): 返回 PostgreSQL 表 schema 身份

### DIFF
--- a/src/dbjavagenix/database/mcp_tools.py
+++ b/src/dbjavagenix/database/mcp_tools.py
@@ -698,7 +698,7 @@ async def handle_db_query_tables(arguments: Dict[str, Any]) -> List[TextContent]
 
         elif config.type == DatabaseType.POSTGRESQL:
             query = """
-            SELECT table_name
+            SELECT table_name, table_schema
             FROM information_schema.tables
             WHERE table_catalog = %s
               AND table_type = 'BASE TABLE'
@@ -720,17 +720,25 @@ async def handle_db_query_tables(arguments: Dict[str, Any]) -> List[TextContent]
         
         # Extract table names
         tables = []
+        table_references = []
         for row in results:
             if isinstance(row, dict):
                 # Get the first column value (table name)
-                table_name = list(row.values())[0]
+                table_name = row.get("table_name", list(row.values())[0])
                 tables.append(table_name)
+                table_references.append(
+                    {
+                        "table_name": table_name,
+                        "schema": row.get("table_schema"),
+                    }
+                )
         
         response = {
             "success": True,
             "database": database,
             "schema": schema,
             "tables": tables,
+            "table_references": table_references,
             "count": len(tables)
         }
         

--- a/tests/unit/test_postgresql_mcp_tools.py
+++ b/tests/unit/test_postgresql_mcp_tools.py
@@ -85,7 +85,33 @@ async def test_query_tables_uses_catalog_and_parameters(monkeypatch, postgres_in
 
     assert "users" in response[0].text
     assert "information_schema.tables" in calls[0][1]
+    assert "table_schema" in calls[0][1]
     assert calls[0][2] == ("app",)
+
+
+@pytest.mark.asyncio
+async def test_query_tables_returns_schema_identity_for_postgresql(monkeypatch, postgres_info):
+    monkeypatch.setattr(
+        mcp_tools.connection_manager, "get_connection_info", lambda cid: postgres_info
+    )
+
+    def execute_query(connection_id, query, params=None):
+        return [
+            {"table_name": "users", "table_schema": "tenant_a"},
+            {"table_name": "users", "table_schema": "tenant_b"},
+        ]
+
+    monkeypatch.setattr(mcp_tools.connection_manager, "execute_query", execute_query)
+
+    response = await mcp_tools.handle_db_query_tables({"connection_id": "pg-1", "database": "app"})
+
+    payload = response[0].text
+    assert "tenant_a" in payload
+    assert "tenant_b" in payload
+    assert (
+        "'table_references': [{'table_name': 'users', 'schema': 'tenant_a'}, {'table_name': 'users', 'schema': 'tenant_b'}]"
+        in payload
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 问题
 PostgreSQL 的 db_query_tables 原先只返回裸表名。跨 schema 存在同名表时，客户端无法从响应确认真实对象。

## 修改
- PostgreSQL 目录查询同时读取 table_name 与 table_schema。
- 响应新增 table_references，逐项包含 table_name 与 schema。
- 保留原 tables 字符串列表，兼容既有 MCP 客户端。

## 验证
- 新增同名表跨 schema 回归测试，断言 tenant_a 与 tenant_b 均保留。
- 既有 schema 过滤与参数绑定测试继续通过。
- tests/unit/：609 passed。
- Ruff lint 与格式检查通过。
- 性能：本次未测量，改动目标是响应身份完整性，不宣称性能收益。
 #67