### PR TITLE
:bug: fix(cli): 修复批量生成表列表解析

### DIFF
--- a/src/dbjavagenix/cli.py
+++ b/src/dbjavagenix/cli.py
@@ -43,6 +43,16 @@ app = typer.Typer(
 console = Console()
 
 
+def _extract_table_name(table: object) -> Optional[str]:
+    """Normalize table entries returned by current and legacy MCP adapters."""
+    if isinstance(table, str):
+        return table
+    if isinstance(table, dict):
+        name = table.get("table_name") or table.get("name")
+        return str(name) if name else None
+    return None
+
+
 def show_ascii_icon():
     """Display the DBJavaGenix ASCII icon"""
     icon_path = Path(__file__).parent.parent / "config" / "ASCII_ICON.txt"
@@ -181,7 +191,9 @@ def generate(
 
             if tables_result.get("success"):
                 all_tables = tables_result["tables"]
-                target_tables = [t["table_name"] for t in all_tables]
+                target_tables = [
+                    table_name for table in all_tables if (table_name := _extract_table_name(table))
+                ]
                 console.print(
                     f"[cyan]Found {len(target_tables)} tables to generate:[/cyan] {', '.join(target_tables)}"
                 )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -211,3 +211,13 @@ def test_list_tables_forwards_schema_filter(monkeypatch):
 
     assert calls["args"] == {"connection_id": "pg-1", "database": "app", "schema": "tenant_a"}
     assert calls["close"] == "pg-1"
+
+
+def test_extract_table_name_accepts_current_and_legacy_table_shapes():
+    from dbjavagenix.cli import _extract_table_name
+
+    assert _extract_table_name("users") == "users"
+    assert _extract_table_name({"table_name": "orders"}) == "orders"
+    assert _extract_table_name({"name": "audit_log"}) == "audit_log"
+    assert _extract_table_name({"table_name": ""}) is None
+    assert _extract_table_name(42) is None


### PR DESCRIPTION
## 问题
 CLI generate 在未传 --tables 时读取 handle_db_query_tables 的 tables 字段。当前响应是字符串列表，旧代码按字典访问 table_name，导致 TypeError，批量生成无法开始。

## 修改
- 新增表项归一化函数，支持当前字符串形态与历史 table_name/name 字典形态。
- 过滤空值和不支持的条目，再交给后续生成流程。
- 不改变 MCP 响应结构或指定 --tables 的路径。

## 验证
- 新增 CLI 单元测试覆盖字符串、两种字典和无效输入。
- tests/unit/ + tests/test_cli.py：620 passed。
- Ruff lint 与格式检查通过。
- 性能：本次未测量，改动目标是修复批量生成入口的功能正确性。
 #69