### PR TITLE
:bug: fix(cli): 对齐代码生成器调用契约

### DIFF
--- a/src/dbjavagenix/cli.py
+++ b/src/dbjavagenix/cli.py
@@ -53,6 +53,13 @@ def _extract_table_name(table: object) -> Optional[str]:
     return None
 
 
+def _codegen_result_succeeded(result: Optional[dict]) -> bool:
+    """Accept structured success and the legacy adapter's success report text."""
+    if not result:
+        return False
+    return bool(result.get("success") or "Code Generation Complete:" in result.get("error", ""))
+
+
 def show_ascii_icon():
     """Display the DBJavaGenix ASCII icon"""
     icon_path = Path(__file__).parent.parent / "config" / "ASCII_ICON.txt"
@@ -211,7 +218,7 @@ def generate(
             return
 
         # Generate code for each table
-        generated_files = []
+        generated_tables = []
         total_tables = len(target_tables)
 
         with console.status("[bold green]Generating code...") as status:
@@ -221,42 +228,24 @@ def generate(
                 )
 
                 try:
-                    # Analyze table structure
-                    analyze_result = handle_db_codegen_analyze(
-                        {
-                            "connection_id": connection_id,
-                            "table_name": table_name,
-                            "all_table_names": target_tables,
-                        }
-                    )
-
-                    if not analyze_result.get("success"):
-                        console.print(f"[red]Failed to analyze table {table_name}[/red]")
-                        continue
-
-                    analysis_data = analyze_result
-
                     # Generate code
                     generate_result = handle_db_codegen_generate(
                         {
-                            "table_analysis": analysis_data,
-                            "template_type": "Default",
-                            "options": {
-                                "useSwagger": True,
-                                "useLombok": True,
-                                "useMapStruct": False,
-                            },
-                            "output_dir": config.generation.output_dir,
+                            "connection_id": connection_id,
+                            "table_name": table_name,
+                            "database": db_config.database,
+                            "template_category": "Default",
+                            "author": config.generation.author,
                             "package_name": config.generation.package_name,
+                            "include_swagger": True,
+                            "include_lombok": True,
+                            "include_mapstruct": False,
                         }
                     )
 
-                    if generate_result and generate_result.get("success"):
-                        files = generate_result.get("generated_files", [])
-                        generated_files.extend(files)
-                        console.print(
-                            f"[green]✓[/green] Generated {len(files)} files for table {table_name}"
-                        )
+                    if _codegen_result_succeeded(generate_result):
+                        generated_tables.append(table_name)
+                        console.print(f"[green]✓[/green] Generated code for table {table_name}")
                     else:
                         console.print(
                             f"[red]✗[/red] Failed to generate code for table {table_name}: {generate_result.get('error')}"
@@ -268,16 +257,16 @@ def generate(
         # Clean up connection
         connection_manager.close_connection(connection_id)
 
-        if generated_files:
+        if generated_tables:
             console.print("\n[green]✓[/green] Code generation completed successfully!")
-            console.print(f"[green]Generated {len(generated_files)} files in total[/green]")
+            console.print(f"[green]Generated code for {len(generated_tables)} tables[/green]")
 
-            # Show generated files
-            console.print("\n[bold]Generated Files:[/bold]")
-            for file_path in generated_files[:10]:  # Show first 10 files
-                console.print(f"  - {file_path}")
-            if len(generated_files) > 10:
-                console.print(f"  ... and {len(generated_files) - 10} more files")
+            # Show generated tables
+            console.print("\n[bold]Generated Tables:[/bold]")
+            for generated_table in generated_tables[:10]:
+                console.print(f"  - {generated_table}")
+            if len(generated_tables) > 10:
+                console.print(f"  ... and {len(generated_tables) - 10} more tables")
         else:
             console.print("[yellow]No files were generated[/yellow]")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -55,6 +55,7 @@ def _fake_config():
             use_mybatis_plus=True,
             author="Test Author",
             package_name="com.example.generated",
+            output_dir="generated_output",
         ),
     )
 
@@ -221,3 +222,55 @@ def test_extract_table_name_accepts_current_and_legacy_table_shapes():
     assert _extract_table_name({"name": "audit_log"}) == "audit_log"
     assert _extract_table_name({"table_name": ""}) is None
     assert _extract_table_name(42) is None
+
+
+def test_codegen_result_succeeded_accepts_success_report():
+    from dbjavagenix.cli import _codegen_result_succeeded
+
+    assert _codegen_result_succeeded({"success": True}) is True
+    assert (
+        _codegen_result_succeeded({"success": False, "error": "Code Generation Complete: users"})
+        is True
+    )
+    assert _codegen_result_succeeded({"success": False, "error": "connection failed"}) is False
+    assert _codegen_result_succeeded(None) is False
+
+
+def test_generate_uses_current_codegen_contract(monkeypatch):
+    mod = importlib.import_module("dbjavagenix.cli")
+    calls = {"generate": [], "close": []}
+    monkeypatch.setattr(mod, "show_ascii_icon", lambda: None)
+    monkeypatch.setattr(
+        mod, "ConfigManager", lambda *_args, **_kwargs: SimpleNamespace(load_config=_fake_config)
+    )
+    monkeypatch.setattr(
+        mod,
+        "handle_db_connect_test",
+        lambda _args: {"success": True, "connection_id": "conn-1"},
+    )
+    monkeypatch.setattr(
+        mod,
+        "handle_db_query_tables",
+        lambda _args: {"success": True, "tables": ["users", "orders"]},
+    )
+
+    def fake_generate(arguments):
+        calls["generate"].append(arguments)
+        return {"success": True, "report": "Code Generation Complete"}
+
+    monkeypatch.setattr(mod, "handle_db_codegen_generate", fake_generate)
+    monkeypatch.setattr(mod.connection_manager, "close_connection", calls["close"].append)
+
+    mod.generate(
+        tables=None,
+        config_path=None,
+        output_dir=None,
+        package_name=None,
+        dry_run=False,
+    )
+
+    assert [call["table_name"] for call in calls["generate"]] == ["users", "orders"]
+    assert all(call["connection_id"] == "conn-1" for call in calls["generate"])
+    assert all(call["template_category"] == "Default" for call in calls["generate"])
+    assert all("table_analysis" not in call for call in calls["generate"])
+    assert calls["close"] == ["conn-1"]


### PR DESCRIPTION
## 问题
 CLI generate 传递了已废弃的 table_analysis/template_type/options 参数给当前要求 connection_id/table_name 的生成器，导致每张表都失败。同步适配器的文本成功报告也会被 CLI 误判为错误。

## 修改
- CLI 直接按当前生成器契约传入 connection_id、table_name、database、template_category 及生成选项。
- 删除重复的预分析步骤，避免同一张表重复访问元数据。
- CLI 在边界识别结构化 success 和现有文本报告，并按成功表数汇总。

## 验证
- 回归测试验证多表循环传参、旧参数不再出现、连接只关闭一次。
- 测试覆盖成功文本报告与无效结果。
- tests/unit/ + tests/test_cli.py：622 passed。
- Ruff lint 与格式检查通过。
- 性能：本次未测量；删除重复分析可能减少一次调用，但未做基准测试，不宣称性能收益。
 #71