### PR TITLE
:sparkles: feat(cli): 支持代码生成 schema 选择

### DIFF
--- a/src/dbjavagenix/cli.py
+++ b/src/dbjavagenix/cli.py
@@ -135,6 +135,7 @@ def generate(
     config_path: Optional[str] = typer.Option(
         None, "--config", "-c", help="Configuration file path"
     ),
+    schema: Optional[str] = typer.Option(None, "--schema", "-s", help="Database schema"),
     output_dir: Optional[str] = typer.Option(None, "--output", "-o", help="Output directory"),
     package_name: Optional[str] = typer.Option(None, "--package", "-p", help="Java package name"),
     dry_run: bool = typer.Option(False, "--dry-run", help="Preview what would be generated"),
@@ -192,9 +193,10 @@ def generate(
         if tables:
             target_tables = tables
         else:
-            tables_result = handle_db_query_tables(
-                {"connection_id": connection_id, "database": db_config.database}
-            )
+            table_query = {"connection_id": connection_id, "database": db_config.database}
+            if schema:
+                table_query["schema"] = schema
+            tables_result = handle_db_query_tables(table_query)
 
             if tables_result.get("success"):
                 all_tables = tables_result["tables"]
@@ -229,19 +231,20 @@ def generate(
 
                 try:
                     # Generate code
-                    generate_result = handle_db_codegen_generate(
-                        {
-                            "connection_id": connection_id,
-                            "table_name": table_name,
-                            "database": db_config.database,
-                            "template_category": "Default",
-                            "author": config.generation.author,
-                            "package_name": config.generation.package_name,
-                            "include_swagger": True,
-                            "include_lombok": True,
-                            "include_mapstruct": False,
-                        }
-                    )
+                    generation_args = {
+                        "connection_id": connection_id,
+                        "table_name": table_name,
+                        "database": db_config.database,
+                        "template_category": "Default",
+                        "author": config.generation.author,
+                        "package_name": config.generation.package_name,
+                        "include_swagger": True,
+                        "include_lombok": True,
+                        "include_mapstruct": False,
+                    }
+                    if schema:
+                        generation_args["schema"] = schema
+                    generate_result = handle_db_codegen_generate(generation_args)
 
                     if _codegen_result_succeeded(generate_result):
                         generated_tables.append(table_name)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -274,3 +274,45 @@ def test_generate_uses_current_codegen_contract(monkeypatch):
     assert all(call["template_category"] == "Default" for call in calls["generate"])
     assert all("table_analysis" not in call for call in calls["generate"])
     assert calls["close"] == ["conn-1"]
+
+
+def test_generate_forwards_schema_to_listing_and_generation(monkeypatch):
+    mod = importlib.import_module("dbjavagenix.cli")
+    calls = {"query": [], "generate": [], "close": []}
+    monkeypatch.setattr(mod, "show_ascii_icon", lambda: None)
+    monkeypatch.setattr(
+        mod, "ConfigManager", lambda *_args, **_kwargs: SimpleNamespace(load_config=_fake_config)
+    )
+    monkeypatch.setattr(
+        mod,
+        "handle_db_connect_test",
+        lambda _args: {"success": True, "connection_id": "conn-1"},
+    )
+
+    def fake_query(arguments):
+        calls["query"].append(arguments)
+        return {"success": True, "tables": ["users"]}
+
+    monkeypatch.setattr(mod, "handle_db_query_tables", fake_query)
+
+    def fake_generate(arguments):
+        calls["generate"].append(arguments)
+        return {"success": True}
+
+    monkeypatch.setattr(mod, "handle_db_codegen_generate", fake_generate)
+    monkeypatch.setattr(mod.connection_manager, "close_connection", calls["close"].append)
+
+    mod.generate(
+        tables=None,
+        config_path=None,
+        schema="tenant_a",
+        output_dir=None,
+        package_name=None,
+        dry_run=False,
+    )
+
+    assert calls["query"] == [
+        {"connection_id": "conn-1", "database": ":memory:", "schema": "tenant_a"}
+    ]
+    assert calls["generate"][0]["schema"] == "tenant_a"
+    assert calls["close"] == ["conn-1"]


### PR DESCRIPTION
## 问题
 PostgreSQL 跨 schema 存在同名表时，CLI generate 没有 schema 选择参数。底层 MCP 与代码生成器虽已支持 schema，命令行仍无法指定目标对象。

## 修改
- generate 增加 --schema/-s 选项。
- 未指定表时将 schema 转发到 db_query_tables。
- 每张表生成时将同一 schema 转发到 db_codegen_generate。
- 未提供 schema 时保持原有默认行为。

## 验证
- 回归测试断言列表查询和生成调用均收到 tenant_a。
- tests/unit/ + tests/test_cli.py：623 passed。
- Ruff lint 与格式检查通过。
- 性能：本次未测量，改动是参数透传与功能闭环，不宣称性能收益。
 #73