### PR TITLE
:bug: fix(cli): 修复表列表展示解析

### DIFF
--- a/src/dbjavagenix/cli.py
+++ b/src/dbjavagenix/cli.py
@@ -53,6 +53,19 @@ def _extract_table_name(table: object) -> Optional[str]:
     return None
 
 
+def _table_display_row(table: object) -> tuple[str, str, str]:
+    """Return table name, engine, and comment for current or legacy responses."""
+    if isinstance(table, str):
+        return table, "", ""
+    if isinstance(table, dict):
+        return (
+            str(table.get("table_name") or table.get("name") or ""),
+            str(table.get("engine") or ""),
+            str(table.get("comment") or ""),
+        )
+    return "", "", ""
+
+
 def _codegen_result_succeeded(result: Optional[dict]) -> bool:
     """Accept structured success and the legacy adapter's success report text."""
     if not result:
@@ -357,11 +370,7 @@ def list_tables(
                     table.add_column("Comment", style="green")
 
                     for table_info in tables:
-                        table.add_row(
-                            table_info.get("table_name", ""),
-                            table_info.get("engine", ""),
-                            table_info.get("comment", ""),
-                        )
+                        table.add_row(*_table_display_row(table_info))
 
                     console.print(table)
                     console.print(f"[green]Found {len(tables)} tables[/green]")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -202,7 +202,7 @@ def test_list_tables_forwards_schema_filter(monkeypatch):
     monkeypatch.setattr(
         mod,
         "handle_db_query_tables",
-        lambda args: calls.update(args=args) or {"success": True, "tables": []},
+        lambda args: calls.update(args=args) or {"success": True, "tables": ["users"]},
     )
     monkeypatch.setattr(
         mod.connection_manager, "close_connection", lambda cid: calls.update(close=cid)
@@ -222,6 +222,18 @@ def test_extract_table_name_accepts_current_and_legacy_table_shapes():
     assert _extract_table_name({"name": "audit_log"}) == "audit_log"
     assert _extract_table_name({"table_name": ""}) is None
     assert _extract_table_name(42) is None
+
+
+def test_table_display_row_accepts_current_and_legacy_table_shapes():
+    from dbjavagenix.cli import _table_display_row
+
+    assert _table_display_row("users") == ("users", "", "")
+    assert _table_display_row({"table_name": "orders", "engine": "InnoDB", "comment": "订单"}) == (
+        "orders",
+        "InnoDB",
+        "订单",
+    )
+    assert _table_display_row(42) == ("", "", "")
 
 
 def test_codegen_result_succeeded_accepts_success_report():


### PR DESCRIPTION
## 问题
 CLI list_tables 在收到当前 MCP 返回的字符串表名时，仍调用 table_info.get(...)，非空列表会触发 AttributeError，无法展示表目录。

## 修改
- 新增表展示行归一化，字符串响应显示表名。
- 历史字典响应继续展示 table_name/name、engine 和 comment。
- 未知条目安全降级为空字段，不影响整个列表。

## 验证
- 将非空字符串列表纳入 CLI schema 过滤测试。
- 新增当前与历史响应形态的归一化单元测试。
- tests/unit/ + tests/test_cli.py：624 passed。
- Ruff lint 与格式检查通过。
- 性能：本次未测量，改动目标是响应兼容性和功能正确性。
 #75