### PR TITLE
:bug: fix(generator): 保留项目依赖技术栈检测结果

### DIFF
--- a/src/dbjavagenix/generator/template_context.py
+++ b/src/dbjavagenix/generator/template_context.py
@@ -11,7 +11,7 @@ from ..database.dialect import DialectAdapter, get_dialect
 
 class TemplateContextBuilder:
     """模板上下文构建器"""
-    
+
     def __init__(
         self,
         author: str = "ZXP",
@@ -24,21 +24,30 @@ class TemplateContextBuilder:
         if dialect is not None:
             self.dialect = dialect
         else:
-            db_name = database_type.value if isinstance(database_type, DatabaseType) else str(database_type)
+            db_name = (
+                database_type.value
+                if isinstance(database_type, DatabaseType)
+                else str(database_type)
+            )
             self.dialect = get_dialect(db_name)
         self.date = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-    
-    def build_context(self, table_info: TableInfo, template_category: str = "Default",
-                     all_table_names: Optional[List[str]] = None, project_root: Optional[str] = None) -> Dict[str, Any]:
+
+    def build_context(
+        self,
+        table_info: TableInfo,
+        template_category: str = "Default",
+        all_table_names: Optional[List[str]] = None,
+        project_root: Optional[str] = None,
+    ) -> Dict[str, Any]:
         """
         构建模板上下文
-        
+
         Args:
             table_info: 表信息
             template_category: 模板分类 (Default, MybatisPlus, MybatisPlus-Mixed)
             all_table_names: 所有表名列表(用于前缀分析)
             project_root: 项目根目录，用于检测技术栈
-            
+
         Returns:
             模板上下文字典
         """
@@ -47,14 +56,15 @@ class TemplateContextBuilder:
         entity_name_lower = self._to_camel_case(table_info.name)
         primary_key_info = self._build_primary_key_context(table_info.columns)
         columns_context = self._build_columns_context(table_info.columns)
-        
+
         # 前缀分析 - 新增功能
         package_suffix = ""
         if all_table_names:
             from ..utils.table_prefix_analyzer import TablePrefixAnalyzer
+
             analyzer = TablePrefixAnalyzer()
             package_suffix = analyzer.get_table_package_suffix(table_info.name, all_table_names)
-        
+
         # 构建包名 (支持前缀子包)
         base_package = self.package_name
         if package_suffix:
@@ -73,16 +83,16 @@ class TemplateContextBuilder:
             dao_package = f"{base_package}.dao"
             dto_package = f"{base_package}.dto"
             vo_package = f"{base_package}.vo"
-        
+
         # 修复serviceImpl包路径问题
         if package_suffix:
             service_impl_package = f"{base_package}.service.impl.{package_suffix}"
         else:
             service_impl_package = f"{base_package}.service.impl"
-        
+
         # 检测技术栈信息
         tech_stack = self._detect_technology_stack(project_root, template_category)
-        
+
         context = {
             # 类和包相关
             "className": class_name,
@@ -95,10 +105,9 @@ class TemplateContextBuilder:
             "hasPackageName": bool(base_package),
             "packageSuffix": package_suffix if package_suffix else "",  # 前缀子包名，空时为空字符串
             "basePackage": base_package,  # 基础包名
-            
             # 不同组件的完整包名
             "controllerPackage": controller_package,
-            "servicePackage": service_package, 
+            "servicePackage": service_package,
             "entityPackage": entity_package,
             "daoPackage": dao_package,
             # 添加serviceImpl包路径
@@ -106,31 +115,29 @@ class TemplateContextBuilder:
             # 添加dto和vo包路径
             "dtoPackage": dto_package,
             "voPackage": vo_package,
-            
             # 表相关
             "tableName": table_info.name,
             "comment": table_info.comment or table_info.name,
-
             # 作者和日期
             "author": self.author,
             "date": self.date,
             "serialVersionUID": "1",
-            
             # 列相关
             "columns": columns_context,
             "primaryKey": primary_key_info,
             "nonPrimaryColumns": self._build_non_primary_columns_context(table_info.columns),
             "otherColumns": self._build_non_primary_columns_context(table_info.columns),  # 别名
-            
             # 主键相关 - 添加缺失的主键字段
             "primaryKeyName": primary_key_info["name"] if primary_key_info else "id",
             "primaryKeyType": primary_key_info["javaType"] if primary_key_info else "Long",
-            "primaryKeyColumn": primary_key_info["dbName"] if primary_key_info else "id",  # 数据库列名
-            "capitalizedPrimaryKeyName": primary_key_info["javaName"].capitalize() if primary_key_info else "Id",
-            
+            "primaryKeyColumn": primary_key_info["dbName"]
+            if primary_key_info
+            else "id",  # 数据库列名
+            "capitalizedPrimaryKeyName": primary_key_info["javaName"].capitalize()
+            if primary_key_info
+            else "Id",
             # 导入相关
             "imports": self._build_imports(table_info.columns, template_category),
-            
             # 特性标志
             "hasDateField": self._has_date_field(table_info.columns),
             "hasBigDecimalField": self._has_big_decimal_field(table_info.columns),
@@ -138,11 +145,10 @@ class TemplateContextBuilder:
             "useSwagger": True,
             "pagination": True,  # 启用分页
             "generateDto": False,  # 默认不生成DTO
-            "generateVo": False,   # 默认不生成VO
+            "generateVo": False,  # 默认不生成VO
             "hasDto": False,
             "hasVo": False,
             "hasMapStruct": True,
-            
             # 技术栈相关标志
             "hasJavax": tech_stack.has_javax,
             "hasJakarta": tech_stack.has_jakarta,
@@ -151,64 +157,74 @@ class TemplateContextBuilder:
             "hasSwagger2": tech_stack.has_swagger2,
             "hasSpringDoc": tech_stack.has_springdoc,
             "useModernStack": tech_stack.is_modern_stack,
-            
             # 模板分类相关
             "templateCategory": template_category,
             "isDefault": template_category == "Default",
             "isMybatisPlus": template_category == "MybatisPlus",
             "isMybatisPlusMixed": template_category == "MybatisPlus-Mixed",
-            
             # 自定义映射规则
             "customMappings": self._build_custom_mappings(table_info.columns),
         }
-        
+
         return context
-    
+
     def _detect_technology_stack(self, project_root: Optional[str], template_category: str) -> Any:
         """
         检测项目使用的技术栈类型
-        
+
         Args:
             project_root: 项目根目录
             template_category: 模板分类
-            
+
         Returns:
             TechnologyStack对象
         """
         # 如果没有提供项目根目录，使用默认的现代化技术栈
         if not project_root:
             from ..utils.pom_analyzer import TechnologyStack
+
             tech_stack = TechnologyStack()
             tech_stack.has_jakarta = True
-            tech_stack.has_mybatis = template_category in ["Default", "MybatisPlus", "MybatisPlus-Mixed"]
+            tech_stack.has_mybatis = template_category in [
+                "Default",
+                "MybatisPlus",
+                "MybatisPlus-Mixed",
+            ]
             tech_stack.has_springdoc = True
             tech_stack.is_modern_stack = True
             return tech_stack
-        
+
         # 使用PomAnalyzer检测技术栈
         try:
-            from ..utils.pom_analyzer import PomAnalyzer
+            from ..utils.pom_analyzer import PomAnalyzer, TechnologyStack
+
             analyzer = PomAnalyzer()
             analysis_result = analyzer.analyze_project_dependencies(
                 project_root=project_root,
                 template_category=template_category,
-                database_type=self.dialect.name
+                database_type=self.dialect.name,
             )
-            return analysis_result.get("technology_stack", TechnologyStack())
+            # Only construct the fallback when the analyzer did not return a stack.
+            return analysis_result.get("technology_stack") or TechnologyStack()
         except Exception:
             # 如果检测失败，使用默认的现代化技术栈
             from ..utils.pom_analyzer import TechnologyStack
+
             tech_stack = TechnologyStack()
             tech_stack.has_jakarta = True
-            tech_stack.has_mybatis = template_category in ["Default", "MybatisPlus", "MybatisPlus-Mixed"]
+            tech_stack.has_mybatis = template_category in [
+                "Default",
+                "MybatisPlus",
+                "MybatisPlus-Mixed",
+            ]
             tech_stack.has_springdoc = True
             tech_stack.is_modern_stack = True
             return tech_stack
-    
+
     def _build_columns_context(self, columns: List[ColumnInfo]) -> List[Dict[str, Any]]:
         """构建列上下文"""
         column_contexts = []
-        
+
         for i, column in enumerate(columns):
             java_name = self._to_camel_case(column.name)
             java_type = self._map_java_type(column.data_type)
@@ -221,23 +237,20 @@ class TemplateContextBuilder:
                 "javaType": java_type,
                 "jdbcType": self._map_jdbc_type(column.data_type),
                 "comment": column.comment or column.name,
-                
                 # 字段属性
                 "isPrimaryKey": column.primary_key,
                 "primaryKey": column.primary_key,  # 兼容两种写法
                 "isNullable": column.nullable,
                 "nullable": column.nullable,
-                "isAutoIncrement": getattr(column, 'auto_increment', False),
-                "autoIncrement": getattr(column, 'auto_increment', False),
+                "isAutoIncrement": getattr(column, "auto_increment", False),
+                "autoIncrement": getattr(column, "auto_increment", False),
                 "defaultValue": column.default_value,
-                "maxLength": getattr(column, 'max_length', None),
-                
+                "maxLength": getattr(column, "max_length", None),
                 # 验证相关
                 "required": not column.nullable and not column.primary_key,
                 "isString": self._is_string_type(column.data_type),
                 "stringType": self._is_string_type(column.data_type),  # 别名
                 "isStringType": self._is_string_type(column.data_type),  # 另一个别名
-                
                 # 循环标志
                 "hasNext": i < len(columns) - 1,
                 "isFirst": i == 0,
@@ -245,13 +258,13 @@ class TemplateContextBuilder:
                 "last": i == len(columns) - 1,  # 添加 last 别名
             }
             column_contexts.append(column_context)
-        
+
         return column_contexts
-    
+
     def _build_primary_key_context(self, columns: List[ColumnInfo]) -> Optional[Dict[str, Any]]:
         """构建主键上下文"""
         pk_column = next((col for col in columns if col.primary_key), None)
-        
+
         if pk_column:
             java_name = self._to_camel_case(pk_column.name)
             return {
@@ -262,14 +275,14 @@ class TemplateContextBuilder:
                 "jdbcType": self._map_jdbc_type(pk_column.data_type),
                 "comment": pk_column.comment or pk_column.name,
             }
-        
+
         return None
-    
+
     def _build_non_primary_columns_context(self, columns: List[ColumnInfo]) -> List[Dict[str, Any]]:
         """构建非主键列上下文"""
         non_pk_columns = [col for col in columns if not col.primary_key]
         column_contexts = []
-        
+
         for i, column in enumerate(non_pk_columns):
             java_name = self._to_camel_case(column.name)
             java_type = self._map_java_type(column.data_type)
@@ -282,23 +295,20 @@ class TemplateContextBuilder:
                 "javaType": java_type,
                 "jdbcType": self._map_jdbc_type(column.data_type),
                 "comment": column.comment or column.name,
-                
                 # 字段属性
                 "isPrimaryKey": column.primary_key,
                 "primaryKey": column.primary_key,  # 兼容两种写法
                 "isNullable": column.nullable,
                 "nullable": column.nullable,
-                "isAutoIncrement": getattr(column, 'auto_increment', False),
-                "autoIncrement": getattr(column, 'auto_increment', False),
+                "isAutoIncrement": getattr(column, "auto_increment", False),
+                "autoIncrement": getattr(column, "auto_increment", False),
                 "defaultValue": column.default_value,
-                "maxLength": getattr(column, 'max_length', None),
-                
+                "maxLength": getattr(column, "max_length", None),
                 # 验证相关
                 "required": not column.nullable and not column.primary_key,
                 "isString": self._is_string_type(column.data_type),
                 "stringType": self._is_string_type(column.data_type),  # 别名
                 "isStringType": self._is_string_type(column.data_type),  # 另一个别名
-
                 # 循环标志
                 "hasNext": i < len(non_pk_columns) - 1,
                 "isFirst": i == 0,
@@ -306,24 +316,24 @@ class TemplateContextBuilder:
                 "last": i == len(non_pk_columns) - 1,  # 添加 last 别名
             }
             column_contexts.append(column_context)
-        
+
         return column_contexts
-    
+
     def _build_custom_mappings(self, columns: List[ColumnInfo]) -> Dict[str, bool]:
         """构建自定义映射规则"""
         column_names = [self._to_camel_case(col.name) for col in columns]
-        
+
         return {
             "hasCreateTimeMapping": "createTime" in column_names,
             "hasUpdateTimeMapping": "updateTime" in column_names,
             "hasIdMapping": "id" in column_names,
         }
-    
+
     def _build_imports(self, columns: List[ColumnInfo], template_category: str) -> List[str]:
         """构建导入列表"""
         imports = []
         java_types = {self._map_java_type(col.data_type) for col in columns}
-        
+
         # 时间类型导入
         import_by_type = {
             "LocalDateTime": "java.time.LocalDateTime",
@@ -337,40 +347,38 @@ class TemplateContextBuilder:
             "UUID": "java.util.UUID",
         }
         imports.extend(
-            import_by_type[java_type]
-            for java_type in java_types
-            if java_type in import_by_type
+            import_by_type[java_type] for java_type in java_types if java_type in import_by_type
         )
-        
+
         return sorted(imports)
-    
+
     def _has_date_field(self, columns: List[ColumnInfo]) -> bool:
         """检查是否包含日期字段"""
         return any(self.dialect.is_date_type(col.data_type) for col in columns)
-    
+
     def _has_big_decimal_field(self, columns: List[ColumnInfo]) -> bool:
         """检查是否包含 BigDecimal 字段"""
         return any(self.dialect.is_decimal_type(col.data_type) for col in columns)
-    
+
     def _is_string_type(self, db_type: str) -> bool:
         """检查是否为字符串类型 (剥离 `(n)` 后比对, 修复 `VARCHAR(64)` 一直被判 False 的 bug)"""
         return self.dialect.is_string_type(db_type)
-    
+
     def _to_pascal_case(self, name: str) -> str:
         """转换为 PascalCase"""
         # 移除下划线并转换为 PascalCase
-        words = name.split('_')
-        return ''.join(word.capitalize() for word in words)
-    
+        words = name.split("_")
+        return "".join(word.capitalize() for word in words)
+
     def _to_camel_case(self, name: str) -> str:
         """转换为 camelCase"""
         pascal_case = self._to_pascal_case(name)
-        return pascal_case[0].lower() + pascal_case[1:] if pascal_case else ''
-    
+        return pascal_case[0].lower() + pascal_case[1:] if pascal_case else ""
+
     def _map_java_type(self, db_type: str) -> str:
         """映射数据库类型到 Java 类型"""
         return self.dialect.java_type_for(db_type)
-    
+
     def _map_jdbc_type(self, db_type: str) -> str:
         """映射数据库类型到 JDBC 类型"""
         return self.dialect.jdbc_type_for(db_type)
@@ -426,18 +434,14 @@ class TemplateConfigManager:
     @staticmethod
     def get_additional_templates() -> List[str]:
         """获取通用附加模板列表"""
-        return [
-            "dto.mustache",
-            "vo.mustache", 
-            "mapstruct_mapper.mustache"
-        ]
-    
+        return ["dto.mustache", "vo.mustache", "mapstruct_mapper.mustache"]
+
     @staticmethod
     def get_output_path_mapping() -> Dict[str, str]:
         """获取输出路径映射 - 支持前缀子包在组件类型之后"""
         return {
             "entity.mustache": "entity/{packageSuffix}/{className}.java",
-            "dao.mustache": "dao/{packageSuffix}/{className}Dao.java", 
+            "dao.mustache": "dao/{packageSuffix}/{className}Dao.java",
             "service.mustache": "service/{packageSuffix}/{className}Service.java",
             "serviceImpl.mustache": "service/impl/{packageSuffix}/{className}ServiceImpl.java",
             "controller.mustache": "controller/{packageSuffix}/{className}Controller.java",
@@ -445,6 +449,6 @@ class TemplateConfigManager:
             "mapper.mustache": "mapper/{className}Dao.xml",
             "dto.mustache": "dto/{packageSuffix}/{className}DTO.java",
             "vo.mustache": "vo/{packageSuffix}/{className}VO.java",
-            "mapstruct_mapper.mustache": "mapper/{packageSuffix}/{className}Mapper.java"
-            ,"mybatis_plus_config.mustache": "config/MybatisPlusConfig.java"
+            "mapstruct_mapper.mustache": "mapper/{packageSuffix}/{className}Mapper.java",
+            "mybatis_plus_config.mustache": "config/MybatisPlusConfig.java",
         }

--- a/tests/unit/test_template_context_builder.py
+++ b/tests/unit/test_template_context_builder.py
@@ -14,6 +14,7 @@ from dbjavagenix.generator.template_context import (
     TemplateConfigManager,
     TemplateContextBuilder,
 )
+from dbjavagenix.utils.pom_analyzer import PomAnalyzer, TechnologyStack
 
 
 @pytest.fixture
@@ -242,15 +243,38 @@ class TestBuildContextStructure:
     def test_with_prefix_analysis_creates_suffix(self, builder, rbac_user_table):
         # 提供同前缀的表名集合,前缀分析器应识别出 sys 前缀
         all_tables = ["sys_user", "sys_role", "sys_permission"]
-        ctx = builder.build_context(
-            rbac_user_table, "Default", all_table_names=all_tables
-        )
+        ctx = builder.build_context(rbac_user_table, "Default", all_table_names=all_tables)
         # packageSuffix 应当被设置 (具体值取决于 TablePrefixAnalyzer 实现,
         # 但应为非空字符串,且 packages 应包含该后缀)
         suffix = ctx["packageSuffix"]
         if suffix:
             assert ctx["controllerPackage"].endswith(f".{suffix}")
             assert ctx["serviceImplPackage"].endswith(f".{suffix}")
+
+    def test_project_stack_detection_preserves_analyzer_result(
+        self, builder, monkeypatch, tmp_path
+    ):
+        expected = TechnologyStack(
+            has_javax=True,
+            has_jakarta=False,
+            has_spring_data=True,
+            has_mybatis=False,
+            has_swagger2=True,
+            has_springdoc=False,
+            is_modern_stack=False,
+        )
+
+        def analyze_project_dependencies(_analyzer, **kwargs):
+            assert kwargs["project_root"] == str(tmp_path)
+            return {"technology_stack": expected}
+
+        monkeypatch.setattr(
+            PomAnalyzer, "analyze_project_dependencies", analyze_project_dependencies
+        )
+
+        actual = builder._detect_technology_stack(str(tmp_path), "Default")
+
+        assert actual is expected
 
 
 class TestTemplateConfigManager:


### PR DESCRIPTION
## 关联 Issue

Closes #77

## 背景（Situation）

传入 `project_root` 时，`TemplateContextBuilder` 会调用 `PomAnalyzer` 检测项目技术栈，但 `_detect_technology_stack` 在 `dict.get` 默认参数中提前构造未导入的 `TechnologyStack()`。即使分析成功，也会触发 `NameError`，被宽泛异常处理吞掉并回退到默认现代栈。

## 任务（Task）

保留成功的 POM/Gradle 技术栈检测结果；仅在缺少结果或分析失败时回退到默认现代栈，并用测试覆盖成功和失败分支。

## 行动（Action）

- 修复技术栈默认对象的导入和惰性回退路径。
- 保持 `javax`/Jakarta、Swagger 2/SpringDoc、Spring Data 等既有标志的映射。
- 新增成功分析路径回归测试，并保留失败降级测试。
- 没有做什么：不修改依赖扫描算法、模板文本、数据库查询或版本兼容策略；未测性能收益。

## 验证（Verification）

环境：Windows 11，Python 3.12.12。

- `PYTHONPATH=src python -m pytest tests/unit/ -q`：610 passed。
- 技术栈检测定向测试：通过。
- `ruff check src tests scripts`、变更文件格式检查和 `git diff --check`：通过。

## 实验与证据（Evidence）

使用包含 `javax.annotation-api` 和 Swagger 2 依赖的最小 Maven 项目调用 `_detect_technology_stack`：修复前返回默认 `has_javax=false`、`has_swagger2=false`、`has_jakarta=true`；修复后保留分析器返回的旧栈标志。缺少分析结果时仍返回现代栈默认值。未执行真实 Java 编译或性能基准。

## 兼容性、风险与回滚

- 公共 API / 数据格式 / 迁移：只修正项目依赖检测成功路径，模板 context 字段名保持不变。
- 风险与已知限制：未覆盖所有 Gradle 插件和依赖别名；分析器失败仍按默认栈生成。
- 回滚：revert 对应提交即可恢复旧回退行为，不涉及数据库或用户数据。
- 后续 Issue：增加更多真实 Maven/Gradle fixture 前，应先扩展技术栈检测契约。