### PR TITLE
:bug: fix(cli): 统一数据库和表列表响应为 JSON

### DIFF
--- a/src/dbjavagenix/database/mcp_tools.py
+++ b/src/dbjavagenix/database/mcp_tools.py
@@ -616,9 +616,14 @@ async def handle_db_query_databases(arguments: Dict[str, Any]) -> List[TextConte
             """
         elif config.type == DatabaseType.SQLITE:
             # SQLite doesn't have multiple databases concept
+            response = {
+                "success": True,
+                "databases": [config.database],
+                "count": 1,
+            }
             return [TextContent(
                 type="text",
-                text=f"SQLite databases: [{config.database}]\n\nRaw Response: {{'databases': ['{config.database}']}}"
+                text=f"SQLite databases: [{config.database}]\n\nRaw Response: {json.dumps(response, ensure_ascii=False)}"
             )]
         else:
             raise MCPServiceError(f"Listing databases not implemented for {config.type}")
@@ -643,7 +648,7 @@ async def handle_db_query_databases(arguments: Dict[str, Any]) -> List[TextConte
             type="text",
             text=f"Found {len(databases)} databases:\n" +
                  "\n".join(f"- {db}" for db in databases) +
-                 f"\n\nRaw Response: {response}"
+                 f"\n\nRaw Response: {json.dumps(response, ensure_ascii=False)}"
         )]
         
     except (DatabaseConnectionError, DatabaseQueryError) as e:
@@ -747,7 +752,7 @@ async def handle_db_query_tables(arguments: Dict[str, Any]) -> List[TextContent]
             text=f"Found {len(tables)} tables in database '{database}'" +
                  (f" schema '{schema}'" if schema else "") + ":\n" +
                  "\n".join(f"- {table}" for table in tables) +
-                 f"\n\nRaw Response: {response}"
+                 f"\n\nRaw Response: {json.dumps(response, ensure_ascii=False)}"
         )]
         
     except (DatabaseConnectionError, DatabaseQueryError) as e:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -176,6 +176,32 @@ def test_codegen_analysis_wrapper_parses_structured_response(monkeypatch):
     assert result == {"success": True, "table_name": "users"}
 
 
+def test_query_tables_wrapper_parses_json_response(monkeypatch):
+    from dbjavagenix import cli_helpers
+    from mcp.types import TextContent
+
+    async def fake_query(_arguments):
+        return [
+            TextContent(
+                type="text",
+                text=(
+                    "Found 1 tables in database 'app':\n- users\n\n"
+                    'Raw Response: {"success": true, "database": "app", '
+                    '"schema": null, "tables": ["users"], '
+                    '"table_references": [{"table_name": "users", "schema": null}], '
+                    '"count": 1}'
+                ),
+            )
+        ]
+
+    monkeypatch.setattr(cli_helpers, "async_handle_db_query_tables", fake_query)
+
+    result = cli_helpers.handle_db_query_tables({"connection_id": "conn-1", "database": "app"})
+
+    assert result["success"] is True
+    assert result["tables"] == ["users"]
+
+
 def test_list_tables_forwards_schema_filter(monkeypatch):
     mod = importlib.import_module("dbjavagenix.cli")
     calls = {}

--- a/tests/unit/test_postgresql_mcp_tools.py
+++ b/tests/unit/test_postgresql_mcp_tools.py
@@ -1,5 +1,6 @@
 """Unit coverage for PostgreSQL MCP discovery tools without a live database."""
 
+import json
 from types import SimpleNamespace
 
 import pytest
@@ -69,6 +70,19 @@ async def test_query_databases_uses_postgresql_catalog(monkeypatch, postgres_inf
 
 
 @pytest.mark.asyncio
+async def test_query_databases_sqlite_raw_response_is_json(monkeypatch):
+    sqlite_info = SimpleNamespace(type=DatabaseType.SQLITE, database="app.sqlite")
+    monkeypatch.setattr(
+        mcp_tools.connection_manager, "get_connection_info", lambda cid: sqlite_info
+    )
+
+    response = await mcp_tools.handle_db_query_databases({"connection_id": "sqlite-1"})
+
+    payload = json.loads(response[0].text.split("Raw Response:", 1)[1].strip())
+    assert payload == {"success": True, "databases": ["app.sqlite"], "count": 1}
+
+
+@pytest.mark.asyncio
 async def test_query_tables_uses_catalog_and_parameters(monkeypatch, postgres_info):
     calls = []
     monkeypatch.setattr(
@@ -90,6 +104,30 @@ async def test_query_tables_uses_catalog_and_parameters(monkeypatch, postgres_in
 
 
 @pytest.mark.asyncio
+async def test_query_tables_raw_response_is_json(monkeypatch, postgres_info):
+    monkeypatch.setattr(
+        mcp_tools.connection_manager, "get_connection_info", lambda cid: postgres_info
+    )
+    monkeypatch.setattr(
+        mcp_tools.connection_manager,
+        "execute_query",
+        lambda *args, **kwargs: [{"table_name": "users"}],
+    )
+
+    response = await mcp_tools.handle_db_query_tables({"connection_id": "pg-1", "database": "app"})
+
+    payload = json.loads(response[0].text.split("Raw Response:", 1)[1].strip())
+    assert payload == {
+        "success": True,
+        "database": "app",
+        "schema": None,
+        "tables": ["users"],
+        "table_references": [{"table_name": "users", "schema": None}],
+        "count": 1,
+    }
+
+
+@pytest.mark.asyncio
 async def test_query_tables_returns_schema_identity_for_postgresql(monkeypatch, postgres_info):
     monkeypatch.setattr(
         mcp_tools.connection_manager, "get_connection_info", lambda cid: postgres_info
@@ -108,10 +146,11 @@ async def test_query_tables_returns_schema_identity_for_postgresql(monkeypatch, 
     payload = response[0].text
     assert "tenant_a" in payload
     assert "tenant_b" in payload
-    assert (
-        "'table_references': [{'table_name': 'users', 'schema': 'tenant_a'}, {'table_name': 'users', 'schema': 'tenant_b'}]"
-        in payload
-    )
+    raw_response = json.loads(payload.split("Raw Response:", 1)[1].strip())
+    assert raw_response["table_references"] == [
+        {"table_name": "users", "schema": "tenant_a"},
+        {"table_name": "users", "schema": "tenant_b"},
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 变更
修复数据库和表列表 MCP 工具的 `Raw Response` 契约：使用合法 JSON 序列化替代 Python `dict` repr，并统一 SQLite 数据库列表的 `success`、`databases`、`count` 字段。

## 用户影响
CLI wrapper 现在可以正确解析 MySQL、PostgreSQL、SQLite 的列表响应。此前数据库查询虽成功，CLI 却因单引号和 `True/False` 无法 JSON 解码而误报失败，导致无法列出表或自动批量生成。

## 验证
- 新增 PostgreSQL 表列表 JSON 契约测试。
- 新增 SQLite 数据库列表字段与 JSON 测试。
- 新增 CLI wrapper 端到端解析回归测试。
- `pytest tests/unit/ --no-cov -q`：612 passed。
- Ruff lint、format 和 diff 检查通过。
- 性能未测量：仅调整响应序列化和字段契约，不改变数据库查询。

Closes #79