### PR TITLE
:bug: fix(cli): 修复 Spring Boot 配置响应解析

### DIFF
--- a/src/dbjavagenix/database/mcp_tools.py
+++ b/src/dbjavagenix/database/mcp_tools.py
@@ -3157,7 +3157,8 @@ async def handle_springboot_read_config(arguments: Dict[str, Any]) -> List[TextC
 
         return [TextContent(
             type="text",
-            text='\n'.join(text_lines) + f"\n\nRaw Response: {response}"
+            text='\n'.join(text_lines)
+            + f"\n\nRaw Response: {json.dumps(response, ensure_ascii=False)}"
         )]
 
     except Exception as e:
@@ -3168,6 +3169,6 @@ async def handle_springboot_read_config(arguments: Dict[str, Any]) -> List[TextC
         }
         return [TextContent(
             type="text",
-            text=f"Failed to read Spring Boot config: {e}\n\nRaw Response: {err}"
+            text=f"Failed to read Spring Boot config: {e}\n\nRaw Response: {json.dumps(err, ensure_ascii=False)}"
         )]
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -202,6 +202,30 @@ def test_query_tables_wrapper_parses_json_response(monkeypatch):
     assert result["tables"] == ["users"]
 
 
+def test_spring_config_wrapper_parses_json_response(monkeypatch):
+    from dbjavagenix import cli_helpers
+    from mcp.types import TextContent
+
+    async def fake_read_config(_arguments):
+        return [
+            TextContent(
+                type="text",
+                text=(
+                    "Spring Boot Project Configuration\n\n"
+                    'Raw Response: {"success": true, "project_root": "demo", '
+                    '"effective": {"spring": {"application": {"name": "demo"}}}}'
+                ),
+            )
+        ]
+
+    monkeypatch.setattr(cli_helpers, "async_handle_springboot_read_config", fake_read_config)
+
+    result = cli_helpers.handle_springboot_read_config({"project_path": "demo"})
+
+    assert result["success"] is True
+    assert result["project_root"] == "demo"
+
+
 def test_list_tables_forwards_schema_filter(monkeypatch):
     mod = importlib.import_module("dbjavagenix.cli")
     calls = {}

--- a/tests/unit/test_security.py
+++ b/tests/unit/test_security.py
@@ -1,5 +1,6 @@
 """Regression tests for secret redaction at logging and MCP response boundaries."""
 
+import json
 import logging
 
 import pytest
@@ -139,7 +140,8 @@ async def test_spring_config_response_redacts_credentials(tmp_path, monkeypatch)
 
     assert "db-secret" not in text
     assert "llm-secret" not in text
-    assert "'password': '***'" in text
-    assert "'api-token': '***'" in text
+    payload = json.loads(text.split("Raw Response:", 1)[1].strip())
+    assert payload["effective"]["spring"]["datasource"]["password"] == "***"
+    assert payload["raw_config"]["custom"]["api-token"] == "***"
     assert "reader:***@db/demo" in text
     assert "name=demo" in text


### PR DESCRIPTION
## 变更
修复 `handle_springboot_read_config` 的 `Raw Response` 序列化：成功和失败路径统一输出合法 JSON，CLI wrapper 可以恢复结构化配置结果。

## 用户影响
此前 `read_config` CLI 调用虽然完成了配置扫描，但因 Python repr 无法被 `json.loads` 解码而被误报为失败；现在可以正常返回项目根目录、构建工具、profile 和脱敏后的配置。

## 验证
- 更新敏感信息回归测试，解析 JSON 后确认 datasource 密码和 API token 仍为 `***`。
- 新增 CLI wrapper 成功解析测试。
- `pytest tests/unit/ --no-cov -q`：612 passed。
- Ruff lint、format 和 diff 检查通过。
- 性能未测量：仅调整响应序列化，不改变配置扫描、合并或脱敏逻辑。

Closes #81