### PR TITLE
:bug: fix(project): 统一 project_path 项目边界解析

### DIFF
--- a/src/dbjavagenix/database/mcp_tools.py
+++ b/src/dbjavagenix/database/mcp_tools.py
@@ -1835,7 +1835,8 @@ async def handle_db_codegen_analyze(arguments: Dict[str, Any]) -> List[TextConte
         analyzer = CodegenAnalyzer(connection_manager)
         
         # Analyze table for code generation (with project stack detection)
-        proj_struct = detect_springboot_project_structure()
+        project_path = arguments.get("project_path")
+        proj_struct = _detect_project_structure(project_path)
         project_root = str(proj_struct["project_root"]) if proj_struct.get("project_root") else None
         analysis_result = await analyzer.analyze_table_for_codegen(
             connection_id,
@@ -1960,6 +1961,7 @@ async def handle_db_codegen_generate(arguments: Dict[str, Any]) -> List[TextCont
         include_swagger = arguments.get("include_swagger", True)
         include_lombok = arguments.get("include_lombok", True)
         include_mapstruct = arguments.get("include_mapstruct", True)
+        project_path = arguments.get("project_path")
         
         # Validate connection exists
         config = connection_manager.get_connection_info(connection_id)
@@ -1977,6 +1979,8 @@ async def handle_db_codegen_generate(arguments: Dict[str, Any]) -> List[TextCont
             "create_missing_dirs": True,
             "template_category": template_category
         }
+        if project_path:
+            validation_args["project_path"] = project_path
         
         validation_result = await handle_springboot_validate_project(validation_args)
         validation_text = validation_result[0].text if validation_result else "Validation failed"
@@ -2002,6 +2006,8 @@ async def handle_db_codegen_generate(arguments: Dict[str, Any]) -> List[TextCont
             "include_lombok": include_lombok,
             "include_mapstruct": include_mapstruct
         }
+        if project_path:
+            dependency_args["project_path"] = project_path
         
         dependency_analysis = await handle_springboot_analyze_dependencies(dependency_args)
         dependency_text = dependency_analysis[0].text if dependency_analysis else "Dependency analysis failed"
@@ -2060,7 +2066,7 @@ async def handle_db_codegen_generate(arguments: Dict[str, Any]) -> List[TextCont
         generator = CodegenGenerator()
         
         # Step 1: Analyze table structure with all table names for prefix optimization
-        _ps = detect_springboot_project_structure()
+        _ps = _detect_project_structure(project_path)
         analysis_result = await analyzer.analyze_table_for_codegen(
             connection_id,
             table_name,
@@ -2135,14 +2141,7 @@ async def handle_db_codegen_generate(arguments: Dict[str, Any]) -> List[TextCont
         
         # 重新获取项目结构（可能在验证过程中已创建）
         # Allow caller to pin the target project root
-        project_path_arg = arguments.get("project_path")
-        if project_path_arg:
-            try:
-                project_structure = detect_springboot_project_structure(Path(project_path_arg))
-            except Exception:
-                project_structure = detect_springboot_project_structure()
-        else:
-            project_structure = detect_springboot_project_structure()
+        project_structure = _detect_project_structure(project_path)
         
         # 确定输出目录
         if project_structure["java_source_dir"] and project_structure["java_source_dir"].exists():
@@ -2150,7 +2149,7 @@ async def handle_db_codegen_generate(arguments: Dict[str, Any]) -> List[TextCont
             resources_dir = project_structure["resources_dir"]
         else:
             # 如果仍然没有检测到，使用当前目录创建
-            current_dir = Path.cwd()
+            current_dir = Path(project_path).expanduser() if project_path else Path.cwd()
             java_source_dir = current_dir / "src" / "main" / "java"
             resources_dir = current_dir / "src" / "main" / "resources"
             java_source_dir.mkdir(parents=True, exist_ok=True)
@@ -2436,6 +2435,12 @@ def detect_springboot_project_structure(start_dir: Path = None) -> Dict[str, Pat
     return result
 
 
+def _detect_project_structure(project_path: Optional[str] = None) -> Dict[str, Path]:
+    """Resolve project structure from an explicit path or the current directory."""
+    start_dir = Path(project_path).expanduser() if project_path else None
+    return detect_springboot_project_structure(start_dir)
+
+
 def get_springboot_project_tools() -> List[Tool]:
     """
     Get SpringBoot project validation and environment check tools
@@ -2468,6 +2473,11 @@ def get_springboot_project_tools() -> List[Tool]:
                         "description": "Template category to check dependencies for",
                         "enum": template_categories,
                         "default": "MybatisPlus-Mixed"
+                    },
+                    "project_path": {
+                        "type": "string",
+                        "description": "Path to project root (optional, defaults to current directory)",
+                        "default": "."
                     }
                 },
                 "required": []
@@ -2562,10 +2572,11 @@ async def handle_springboot_validate_project(arguments: Dict[str, Any]) -> List[
         check_dependencies = arguments.get("check_dependencies", True)
         create_missing_dirs = arguments.get("create_missing_dirs", True)
         template_category = arguments.get("template_category", "MybatisPlus-Mixed")
+        project_path = arguments.get("project_path")
         
         # 1. 检测项目结构
-        project_structure = detect_springboot_project_structure()
-        current_dir = Path.cwd()
+        project_structure = _detect_project_structure(project_path)
+        current_dir = Path(project_path).expanduser() if project_path else Path.cwd()
         
         validation_results = {
             "project_structure": {},
@@ -2598,7 +2609,7 @@ async def handle_springboot_validate_project(arguments: Dict[str, Any]) -> List[
                         validation_results["created_directories"].append(str(full_path))
                 
                 # 重新检测结构
-                project_structure = detect_springboot_project_structure()
+                project_structure = _detect_project_structure(project_path)
         
         # 检查关键目录
         required_dirs = {
@@ -2766,15 +2777,18 @@ async def handle_springboot_analyze_dependencies(arguments: Dict[str, Any]) -> L
         include_swagger = arguments.get("include_swagger", True)
         include_lombok = arguments.get("include_lombok", True)
         include_mapstruct = arguments.get("include_mapstruct", True)
-        project_path = arguments.get("project_path", ".")
+        requested_project_path = arguments.get("project_path")
+        project_path = requested_project_path or "."
         
         # 导入依赖管理器
         from ..utils.dependency_manager import DependencyManager
         
         # 检测项目结构
-        project_structure = detect_springboot_project_structure()
+        project_structure = _detect_project_structure(project_path)
         if project_structure["project_root"]:
             project_path = str(project_structure["project_root"])
+        elif requested_project_path:
+            project_path = str(Path(requested_project_path).expanduser())
         else:
             project_path = str(Path.cwd())
         

--- a/tests/unit/test_project_path_contract.py
+++ b/tests/unit/test_project_path_contract.py
@@ -1,0 +1,164 @@
+"""Regression tests for explicit Spring Boot project path forwarding."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from dbjavagenix.core.models import DatabaseType
+from dbjavagenix.database import mcp_tools
+
+
+def _project_structure(root: Path) -> dict[str, Path]:
+    java = root / "src" / "main" / "java"
+    resources = root / "src" / "main" / "resources"
+    tests = root / "src" / "test" / "java"
+    for path in (java, resources, tests):
+        path.mkdir(parents=True, exist_ok=True)
+    return {
+        "project_root": root,
+        "java_source_dir": java,
+        "resources_dir": resources,
+        "test_dir": tests,
+    }
+
+
+def test_project_structure_helper_uses_explicit_path(tmp_path):
+    (tmp_path / "src" / "main" / "java").mkdir(parents=True)
+
+    structure = mcp_tools._detect_project_structure(str(tmp_path))
+
+    assert structure["project_root"] == tmp_path
+
+
+@pytest.mark.asyncio
+async def test_codegen_analyze_forwards_project_path(monkeypatch, tmp_path):
+    calls = []
+    structure = _project_structure(tmp_path)
+
+    monkeypatch.setattr(
+        mcp_tools,
+        "detect_springboot_project_structure",
+        lambda start_dir=None: calls.append(start_dir) or structure,
+    )
+    monkeypatch.setattr(
+        mcp_tools.connection_manager,
+        "get_connection_info",
+        lambda _connection_id: SimpleNamespace(database="app", type=DatabaseType.MYSQL),
+    )
+
+    class FakeAnalyzer:
+        def __init__(self, _manager):
+            pass
+
+        async def analyze_table_for_codegen(self, *args, **kwargs):
+            assert kwargs["project_root"] == str(tmp_path)
+            return {
+                "table_info": {
+                    "name": "users",
+                    "comment": "",
+                    "columns": [{"name": "id", "type": "BIGINT"}],
+                },
+                "java_types": ["Long"],
+                "imports_needed": [],
+                "relationships": {"primary_keys": [], "foreign_keys": [], "indexes": []},
+                "template_context": {
+                    "columns": [{"javaType": "Long"}],
+                    "className": "Users",
+                    "lowerCaseName": "users",
+                    "hasDateField": False,
+                    "hasBigDecimalField": False,
+                    "primaryKey": None,
+                },
+            }
+
+    import dbjavagenix.database.codegen_tools as codegen_tools
+
+    monkeypatch.setattr(codegen_tools, "CodegenAnalyzer", FakeAnalyzer)
+
+    response = await mcp_tools.handle_db_codegen_analyze(
+        {
+            "connection_id": "conn-1",
+            "table_name": "users",
+            "project_path": str(tmp_path),
+        }
+    )
+
+    assert response[0].text.startswith("Code Generation Analysis: users")
+    assert calls == [tmp_path]
+
+
+@pytest.mark.asyncio
+async def test_validate_project_forwards_project_path(monkeypatch, tmp_path):
+    calls = []
+    structure = _project_structure(tmp_path)
+    monkeypatch.setattr(
+        mcp_tools,
+        "detect_springboot_project_structure",
+        lambda start_dir=None: calls.append(start_dir) or structure,
+    )
+
+    await mcp_tools.handle_springboot_validate_project(
+        {
+            "project_path": str(tmp_path),
+            "check_dependencies": False,
+            "create_missing_dirs": False,
+        }
+    )
+
+    assert calls == [tmp_path]
+
+
+@pytest.mark.asyncio
+async def test_dependency_analysis_preserves_explicit_path(monkeypatch, tmp_path):
+    calls = []
+    structure = _project_structure(tmp_path)
+    monkeypatch.setattr(
+        mcp_tools,
+        "detect_springboot_project_structure",
+        lambda start_dir=None: calls.append(start_dir) or structure,
+    )
+
+    class FakeDependencyManager:
+        def check_and_fix_dependencies(self, **kwargs):
+            assert kwargs["project_root"] == str(tmp_path)
+            return {
+                "auto_add_result": {"success": True, "added_count": 0},
+                "fix_result": {},
+                "analysis_result": {"maven_xml": {}},
+            }
+
+        def get_dependency_health_report(self, project_root):
+            assert project_root == str(tmp_path)
+            return {
+                "build_tool": "maven",
+                "health_score": 100,
+                "found_dependencies": 1,
+                "total_dependencies": 1,
+                "missing_required": 0,
+                "missing_optional": 0,
+            }
+
+        def generate_migration_guide(self, project_root):
+            assert project_root == str(tmp_path)
+            return {"success": True, "total_suggestions": 0, "migration_suggestions": []}
+
+    import dbjavagenix.utils.dependency_manager as dependency_manager
+
+    monkeypatch.setattr(dependency_manager, "DependencyManager", FakeDependencyManager)
+
+    await mcp_tools.handle_springboot_analyze_dependencies(
+        {"project_path": str(tmp_path), "template_category": "Default", "database_type": "mysql"}
+    )
+
+    assert calls == [tmp_path]
+
+
+def test_validation_tool_schema_exposes_project_path():
+    tool = next(
+        tool
+        for tool in mcp_tools.get_springboot_project_tools()
+        if tool.name == "springboot_validate_project"
+    )
+
+    assert "project_path" in tool.inputSchema["properties"]


### PR DESCRIPTION
## 背景
多个支持 `project_path` 的工具仍使用当前工作目录进行 Spring Boot 项目结构检测，导致从其他目录调用时，项目校验、依赖分析、代码生成分析与最终写入路径可能指向不同项目。

## 变更
- 新增统一项目结构解析入口，显式转发 `project_path`。
- `db_codegen_analyze`、`db_codegen_generate`、项目校验和依赖分析统一使用同一项目边界。
- 生成阶段的文件输出路径与前置分析保持一致。
- 为显式路径转发和工具 schema 增加回归测试。

## 验证
- 单元测试：`617 passed`
- Ruff lint：通过
- `git diff --check`：通过

## 兼容性与性能
未传入 `project_path` 时保持当前目录行为；本次未进行性能基准测量，变更重点是路径边界一致性。

Closes #83