### PR TITLE
:bug: fix(mcp): 统一错误响应为有效 JSON

### DIFF
--- a/src/dbjavagenix/database/mcp_tools.py
+++ b/src/dbjavagenix/database/mcp_tools.py
@@ -568,7 +568,7 @@ async def handle_db_connect_test(arguments: Dict[str, Any]) -> List[TextContent]
         }
         return [TextContent(
             type="text",
-            text=f"Database connection failed: {safe_error}\n\nRaw Response: {error_response}"
+            text=f"Database connection failed: {safe_error}\n\nRaw Response: {json.dumps(error_response, ensure_ascii=False)}"
         )]
         
     except Exception as e:
@@ -581,7 +581,7 @@ async def handle_db_connect_test(arguments: Dict[str, Any]) -> List[TextContent]
         }
         return [TextContent(
             type="text",
-            text=f"Unexpected error: {safe_error}\n\nRaw Response: {error_response}"
+            text=f"Unexpected error: {safe_error}\n\nRaw Response: {json.dumps(error_response, ensure_ascii=False)}"
         )]
 
 
@@ -659,7 +659,7 @@ async def handle_db_query_databases(arguments: Dict[str, Any]) -> List[TextConte
         }
         return [TextContent(
             type="text",
-            text=f"Failed to list databases: {str(e)}\n\nRaw Response: {error_response}"
+            text=f"Failed to list databases: {str(e)}\n\nRaw Response: {json.dumps(error_response, ensure_ascii=False)}"
         )]
         
     except Exception as e:
@@ -671,7 +671,7 @@ async def handle_db_query_databases(arguments: Dict[str, Any]) -> List[TextConte
         }
         return [TextContent(
             type="text",
-            text=f"Unexpected error: {str(e)}\n\nRaw Response: {error_response}"
+            text=f"Unexpected error: {str(e)}\n\nRaw Response: {json.dumps(error_response, ensure_ascii=False)}"
         )]
 
 
@@ -763,7 +763,7 @@ async def handle_db_query_tables(arguments: Dict[str, Any]) -> List[TextContent]
         }
         return [TextContent(
             type="text",
-            text=f"Failed to list tables: {str(e)}\n\nRaw Response: {error_response}"
+            text=f"Failed to list tables: {str(e)}\n\nRaw Response: {json.dumps(error_response, ensure_ascii=False)}"
         )]
         
     except Exception as e:
@@ -775,7 +775,7 @@ async def handle_db_query_tables(arguments: Dict[str, Any]) -> List[TextContent]
         }
         return [TextContent(
             type="text",
-            text=f"Unexpected error: {str(e)}\n\nRaw Response: {error_response}"
+            text=f"Unexpected error: {str(e)}\n\nRaw Response: {json.dumps(error_response, ensure_ascii=False)}"
         )]
 
 
@@ -852,7 +852,7 @@ async def handle_db_query_table_exists(arguments: Dict[str, Any]) -> List[TextCo
         }
         return [TextContent(
             type="text",
-            text=f"Failed to check table existence: {str(e)}\n\nRaw Response: {error_response}"
+            text=f"Failed to check table existence: {str(e)}\n\nRaw Response: {json.dumps(error_response, ensure_ascii=False)}"
         )]
         
     except Exception as e:
@@ -864,7 +864,7 @@ async def handle_db_query_table_exists(arguments: Dict[str, Any]) -> List[TextCo
         }
         return [TextContent(
             type="text",
-            text=f"Unexpected error: {str(e)}\n\nRaw Response: {error_response}"
+            text=f"Unexpected error: {str(e)}\n\nRaw Response: {json.dumps(error_response, ensure_ascii=False)}"
         )]
 
 
@@ -932,7 +932,7 @@ async def handle_db_query_execute(arguments: Dict[str, Any]) -> List[TextContent
         }
         return [TextContent(
             type="text",
-            text=f"Failed to execute query: {str(e)}\n\nRaw Response: {error_response}"
+            text=f"Failed to execute query: {str(e)}\n\nRaw Response: {json.dumps(error_response, ensure_ascii=False)}"
         )]
         
     except Exception as e:
@@ -944,7 +944,7 @@ async def handle_db_query_execute(arguments: Dict[str, Any]) -> List[TextContent
         }
         return [TextContent(
             type="text", 
-            text=f"Unexpected error: {str(e)}\n\nRaw Response: {error_response}"
+            text=f"Unexpected error: {str(e)}\n\nRaw Response: {json.dumps(error_response, ensure_ascii=False)}"
         )]
 
 
@@ -1121,7 +1121,7 @@ async def handle_db_table_describe(arguments: Dict[str, Any]) -> List[TextConten
         }
         return [TextContent(
             type="text",
-            text=f"Failed to describe table: {str(e)}\n\nRaw Response: {error_response}"
+            text=f"Failed to describe table: {str(e)}\n\nRaw Response: {json.dumps(error_response, ensure_ascii=False)}"
         )]
         
     except Exception as e:
@@ -1133,7 +1133,7 @@ async def handle_db_table_describe(arguments: Dict[str, Any]) -> List[TextConten
         }
         return [TextContent(
             type="text",
-            text=f"Unexpected error: {str(e)}\n\nRaw Response: {error_response}"
+            text=f"Unexpected error: {str(e)}\n\nRaw Response: {json.dumps(error_response, ensure_ascii=False)}"
         )]
 
 
@@ -1257,7 +1257,7 @@ async def handle_db_table_columns(arguments: Dict[str, Any]) -> List[TextContent
         }
         return [TextContent(
             type="text",
-            text=f"Failed to get column information: {str(e)}\n\nRaw Response: {error_response}"
+            text=f"Failed to get column information: {str(e)}\n\nRaw Response: {json.dumps(error_response, ensure_ascii=False)}"
         )]
         
     except Exception as e:
@@ -1269,7 +1269,7 @@ async def handle_db_table_columns(arguments: Dict[str, Any]) -> List[TextContent
         }
         return [TextContent(
             type="text",
-            text=f"Unexpected error: {str(e)}\n\nRaw Response: {error_response}"
+            text=f"Unexpected error: {str(e)}\n\nRaw Response: {json.dumps(error_response, ensure_ascii=False)}"
         )]
 
 
@@ -1359,7 +1359,7 @@ async def handle_db_table_primary_keys(arguments: Dict[str, Any]) -> List[TextCo
         }
         return [TextContent(
             type="text",
-            text=f"Failed to get primary keys: {str(e)}\n\nRaw Response: {error_response}"
+            text=f"Failed to get primary keys: {str(e)}\n\nRaw Response: {json.dumps(error_response, ensure_ascii=False)}"
         )]
         
     except Exception as e:
@@ -1371,7 +1371,7 @@ async def handle_db_table_primary_keys(arguments: Dict[str, Any]) -> List[TextCo
         }
         return [TextContent(
             type="text",
-            text=f"Unexpected error: {str(e)}\n\nRaw Response: {error_response}"
+            text=f"Unexpected error: {str(e)}\n\nRaw Response: {json.dumps(error_response, ensure_ascii=False)}"
         )]
 
 
@@ -1501,7 +1501,7 @@ async def handle_db_table_foreign_keys(arguments: Dict[str, Any]) -> List[TextCo
         }
         return [TextContent(
             type="text",
-            text=f"Failed to get foreign keys: {str(e)}\n\nRaw Response: {error_response}"
+            text=f"Failed to get foreign keys: {str(e)}\n\nRaw Response: {json.dumps(error_response, ensure_ascii=False)}"
         )]
         
     except Exception as e:
@@ -1513,7 +1513,7 @@ async def handle_db_table_foreign_keys(arguments: Dict[str, Any]) -> List[TextCo
         }
         return [TextContent(
             type="text",
-            text=f"Unexpected error: {str(e)}\n\nRaw Response: {error_response}"
+            text=f"Unexpected error: {str(e)}\n\nRaw Response: {json.dumps(error_response, ensure_ascii=False)}"
         )]
 
 
@@ -1657,7 +1657,7 @@ async def handle_db_table_indexes(arguments: Dict[str, Any]) -> List[TextContent
         }
         return [TextContent(
             type="text",
-            text=f"Failed to get table indexes: {str(e)}\n\nRaw Response: {error_response}"
+            text=f"Failed to get table indexes: {str(e)}\n\nRaw Response: {json.dumps(error_response, ensure_ascii=False)}"
         )]
         
     except Exception as e:
@@ -1669,7 +1669,7 @@ async def handle_db_table_indexes(arguments: Dict[str, Any]) -> List[TextContent
         }
         return [TextContent(
             type="text",
-            text=f"Unexpected error: {str(e)}\n\nRaw Response: {error_response}"
+            text=f"Unexpected error: {str(e)}\n\nRaw Response: {json.dumps(error_response, ensure_ascii=False)}"
         )]
 
 
@@ -1921,7 +1921,7 @@ async def handle_db_codegen_analyze(arguments: Dict[str, Any]) -> List[TextConte
         }
         return [TextContent(
             type="text",
-            text=f"Failed to analyze table for code generation: {str(e)}\n\nRaw Response: {error_response}"
+            text=f"Failed to analyze table for code generation: {str(e)}\n\nRaw Response: {json.dumps(error_response, ensure_ascii=False)}"
         )]
         
     except Exception as e:
@@ -1933,7 +1933,7 @@ async def handle_db_codegen_analyze(arguments: Dict[str, Any]) -> List[TextConte
         }
         return [TextContent(
             type="text",
-            text=f"Unexpected error: {str(e)}\n\nRaw Response: {error_response}"
+            text=f"Unexpected error: {str(e)}\n\nRaw Response: {json.dumps(error_response, ensure_ascii=False)}"
         )]
 
 
@@ -2361,7 +2361,7 @@ async def handle_db_codegen_generate(arguments: Dict[str, Any]) -> List[TextCont
         }
         return [TextContent(
             type="text",
-            text=f"Failed to generate code: {str(e)}\n\nRaw Response: {error_response}"
+            text=f"Failed to generate code: {str(e)}\n\nRaw Response: {json.dumps(error_response, ensure_ascii=False)}"
         )]
         
     except Exception as e:
@@ -2373,7 +2373,7 @@ async def handle_db_codegen_generate(arguments: Dict[str, Any]) -> List[TextCont
         }
         return [TextContent(
             type="text",
-            text=f"Unexpected error: {str(e)}\n\nRaw Response: {error_response}"
+            text=f"Unexpected error: {str(e)}\n\nRaw Response: {json.dumps(error_response, ensure_ascii=False)}"
         )]
 
 
@@ -2757,7 +2757,7 @@ async def handle_springboot_validate_project(arguments: Dict[str, Any]) -> List[
         }
         return [TextContent(
             type="text",
-            text=f"Project validation failed: {str(e)}\n\nRaw Response: {error_response}"
+            text=f"Project validation failed: {str(e)}\n\nRaw Response: {json.dumps(error_response, ensure_ascii=False)}"
         )]
 
 
@@ -2897,7 +2897,7 @@ async def handle_springboot_analyze_dependencies(arguments: Dict[str, Any]) -> L
         }
         return [TextContent(
             type="text",
-            text=f"Dependency analysis failed: {str(e)}\n\nRaw Response: {error_response}"
+            text=f"Dependency analysis failed: {str(e)}\n\nRaw Response: {json.dumps(error_response, ensure_ascii=False)}"
         )]
 
 

--- a/tests/unit/test_mcp_error_json.py
+++ b/tests/unit/test_mcp_error_json.py
@@ -1,0 +1,75 @@
+"""Regression tests for JSON-serializable MCP error envelopes."""
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from dbjavagenix.core.exceptions import DatabaseConnectionError, DatabaseQueryError
+from dbjavagenix.core.models import DatabaseType
+from dbjavagenix.database import mcp_tools
+
+
+def _raw_payload(response):
+    text = response[0].text
+    return json.loads(text.split("Raw Response:", 1)[1].strip())
+
+
+@pytest.mark.asyncio
+async def test_connection_error_raw_response_is_json(monkeypatch):
+    def fail_create(_config):
+        raise DatabaseConnectionError("invalid credentials")
+
+    monkeypatch.setattr(mcp_tools.connection_manager, "create_connection", fail_create)
+
+    response = await mcp_tools.handle_db_connect_test(
+        {
+            "database_type": "sqlite",
+            "host": "",
+            "port": 0,
+            "username": "",
+            "password": "secret",
+            "database": ":memory:",
+        }
+    )
+
+    assert _raw_payload(response) == {
+        "success": False,
+        "error": "connection_failed",
+        "message": "[DB_CONNECTION_FAILED] invalid credentials",
+    }
+
+
+@pytest.mark.asyncio
+async def test_database_list_error_raw_response_is_json(monkeypatch):
+    monkeypatch.setattr(mcp_tools.connection_manager, "get_connection_info", lambda _id: None)
+
+    response = await mcp_tools.handle_db_query_databases({"connection_id": "missing"})
+
+    payload = _raw_payload(response)
+    assert payload["success"] is False
+    assert payload["error"] == "query_failed"
+    assert "missing" in payload["message"]
+
+
+@pytest.mark.asyncio
+async def test_table_list_query_error_raw_response_is_json(monkeypatch):
+    monkeypatch.setattr(
+        mcp_tools.connection_manager,
+        "get_connection_info",
+        lambda _id: SimpleNamespace(type=DatabaseType.MYSQL),
+    )
+
+    def fail_query(*_args, **_kwargs):
+        raise DatabaseQueryError("database unavailable")
+
+    monkeypatch.setattr(mcp_tools.connection_manager, "execute_query", fail_query)
+
+    response = await mcp_tools.handle_db_query_tables(
+        {"connection_id": "conn-1", "database": "app"}
+    )
+
+    payload = _raw_payload(response)
+    assert payload["success"] is False
+    assert payload["error"] == "query_failed"
+    assert payload["message"] == "[DB_QUERY_FAILED] database unavailable"


### PR DESCRIPTION
## 背景
数据库 MCP 工具的多个错误分支使用 Python 字典 repr 写入 `Raw Response`，导致单引号和 `True/False` 使载荷无法按 JSON 解析。CLI helper 和其他 MCP 调用方因此丢失稳定的 `error`、`message` 字段。

## 变更
- 统一连接、数据库/表查询、表元数据、代码生成、Spring Boot 项目工具的错误响应序列化。
- 使用 `json.dumps(..., ensure_ascii=False)` 保持中文信息并输出有效 JSON。
- 新增连接失败、数据库列表失败、表列表查询失败的回归测试。

## 验证
- `tests/unit`：`620 passed`
- Ruff check：通过
- `git diff --check`：通过
- 未配置本机真实 MySQL，未运行依赖该外部服务的集成测试。

## 兼容性与性能
仅改变 `Raw Response` 的序列化格式，错误字段语义保持不变；性能未测量，本次不宣称性能提升。

Closes #85