### PR TITLE
:books: docs(skill): 同步语义增强工作流与实际 AI 工具

### DIFF
--- a/.claude/skills/java-codegen-from-db/SKILL.md
+++ b/.claude/skills/java-codegen-from-db/SKILL.md
@@ -103,25 +103,35 @@ when_not_to_use:
 
 ---
 
-## 阶段 3: 语义增强(推荐,Phase 4 工具可用后启用)
+## 阶段 3: 语义增强(推荐)
 
-> 当前 Phase 2 时这些工具尚未实现,跳过本阶段直接进 4。
+当前 MCP server 已提供阶段 3 的 AI 工具。它们默认使用本地规则，不依赖
+`ANTHROPIC_API_KEY`；只有用户明确允许时才通过 `prefer_llm=true` 请求 Claude。
 
-**目的**: 让 LLM 推断"业务上合理的类名/字段名",而不是机械拼接表名。
+**目的**: 让 LLM 推断"业务上合理的类名/字段名",并在生成前选择匹配的模板，而不是机械拼接表名。
 
-### 3.1 推断业务命名(待实现)
+### 3.1 概述 schema(多表时推荐)
 
-- 调用 `ai_infer_business_names`(Phase 4 工具,详见 iteration-plan)
-- 例: `sys_user_role` → `UserRoleAssignment`(关系实体)
+- 调用 `ai_summarize_schema`，传入阶段 2 收集的 `table_names`、`foreign_keys`，可选传入 `table_column_counts`。
+- 向用户展示返回的 `narrative`、`modules`、`core_entities`、`relationships`，作为后续命名和模板推荐的共同上下文。
 
-### 3.2 推荐模板(待实现)
+### 3.2 推断业务命名
 
-- 调用 `ai_recommend_template`
-- 例: 检测到 RBAC 模式 → 建议 `MybatisPlus-Mixed` 或 `sb35-java21`
+- 调用 `ai_infer_business_names`，传入 `tables` 数组；每项至少包含 `name`，并尽量附上 `columns` 和 `foreign_keys`。
+- 需要外部模型增强时才传 `prefer_llm: true`，否则使用规则结果；不要把数据库密码放入工具参数。
+- 向用户展示每项返回的 `class_name`、`field_naming`、`table_kind`、`reason` 和 `confidence`。
+- 例: `sys_user_role` → `UserRoleAssignment`(关系实体)。
 
-### 3.3 用户确认点 ★
+### 3.3 推荐模板
 
-LLM **必须**把推断结果呈现给用户,等用户确认或修改,再进下一步。**禁止默认接受**。
+- 调用 `ai_recommend_template`，传入整库 `table_names` 和可选 `foreign_keys`。
+- 用户明确偏好 Java 21 / Spring Boot 3.x 时传 `hint_modern_stack: true`，否则让规则按 schema 模式推荐。
+- 向用户展示 `recommended_template`、`options`、`matched_pattern`、`confidence` 和 `reasons`。
+- 例: 检测到 RBAC 模式 → 建议 `MybatisPlus-Mixed`；现代栈偏好 → 建议 `sb35-java21`。
+
+### 3.4 用户确认点 ★
+
+LLM **必须**把 schema 概述、命名推断和模板推荐呈现给用户，等用户确认或修改，再进下一步。**禁止默认接受**。
 
 ---
 
@@ -229,8 +239,9 @@ LLM **必须**把推断结果呈现给用户,等用户确认或修改,再进下�
          db_table_describe          (×N 张表)
          db_table_foreign_keys      (×N 张表)
 
-[语义]   ai_infer_business_names    (Phase 4 后启用)
-         ai_recommend_template      (Phase 4 后启用)
+[语义]   ai_summarize_schema        (多表时推荐)
+         ai_infer_business_names    (规则默认,可选 prefer_llm)
+         ai_recommend_template      (按 schema 模式推荐)
 
 [生成]   codegen_build_context      (×1 per 表)
          codegen_render_entity      (×1 per 表)
@@ -253,4 +264,4 @@ LLM **必须**把推断结果呈现给用户,等用户确认或修改,再进下�
 
 ## 与 iteration-plan 的对应
 
-本 skill 实现 `iteration-plan/01-target-architecture.md` 第二章的工作流定义。Phase 2.2 拆分工具、Phase 4 引入 AI 工具后,本文件需同步更新阶段 3 和阶段 4。
+本 skill 实现 `iteration-plan/01-target-architecture.md` 第二章的工作流定义。工具契约变化时必须同步更新本文件，并由 Skill 契约测试校验关键工具仍可发现。

--- a/tests/unit/test_skill_contract.py
+++ b/tests/unit/test_skill_contract.py
@@ -1,0 +1,40 @@
+"""Contract checks for the executable java-codegen-from-db Skill."""
+
+from pathlib import Path
+
+
+SKILL_PATH = Path(__file__).parents[2] / ".claude" / "skills" / "java-codegen-from-db" / "SKILL.md"
+
+
+def _skill_text() -> str:
+    return SKILL_PATH.read_text(encoding="utf-8")
+
+
+def test_skill_uses_available_semantic_tools():
+    text = _skill_text()
+
+    assert "当前 MCP server 已提供阶段 3 的 AI 工具" in text
+    assert "当前 Phase 2 时这些工具尚未实现" not in text
+    for tool_name in (
+        "ai_summarize_schema",
+        "ai_infer_business_names",
+        "ai_recommend_template",
+    ):
+        assert f"`{tool_name}`" in text
+
+
+def test_skill_documents_ai_tool_contracts_and_confirmation():
+    text = _skill_text()
+
+    for field in (
+        "table_names",
+        "foreign_keys",
+        "table_column_counts",
+        "prefer_llm",
+        "hint_modern_stack",
+        "recommended_template",
+        "class_name",
+        "confidence",
+    ):
+        assert f"`{field}`" in text or field in text
+    assert "禁止默认接受" in text


### PR DESCRIPTION
## 关联 Issue

Closes #93

## 背景（Situation）

MCP 已提供并测试 `ai_summarize_schema`、`ai_infer_business_names`、`ai_recommend_template` 和 `ai_metrics`，但 `java-codegen-from-db` Skill 仍标注阶段 4 工具未实现，并要求跳过语义增强。按 Skill 执行的客户端因此无法使用已存在的能力，文档与工具 schema 不一致。

## 任务（Task）

同步语义增强工作流与当前 MCP schema，保留规则优先和无 API key 路径，并把结果展示和用户确认作为进入代码生成的前置条件。

## 行动（Action）

- 更新 Skill 的阶段 3 参数、返回字段和 `prefer_llm` 可选语义。
- 明确命名、模板推荐和 schema 摘要必须先展示，再等待用户确认。
- 新增 Skill 工作流契约测试，防止工具与文档再次漂移。
- 没有做什么：不修改 AI 推断算法、模型、缓存、数据库访问或性能目标。

## 验证（Verification）

环境：Windows 11，Python 3.12.12。

- `PYTHONPATH=src python -m pytest tests/unit/ -q`：631 passed。
- AI 与 Skill 定向契约测试：86 passed。
- `ruff check src tests` 与 `git diff --check`：通过。

## 实验与证据（Evidence）

用无 API key 的规则优先输入执行 Skill 契约，工具名称、必填参数和 `prefer_llm=false` 均与当前注册表一致；生成阶段只有在确认结果后才可继续。未执行真实 LLM 调用，也没有性能基准，因此不作质量或速度结论。

## 兼容性、风险与回滚

- 公共 API / 数据格式 / 迁移：只更新 Skill 和契约测试，不改变 MCP payload。
- 风险与已知限制：客户端是否渲染确认步骤仍取决于客户端实现；LLM 路径未在本 PR 验证。
- 回滚：revert 对应文档和测试提交即可。
- 后续 Issue：如需统一各 Skill 的阶段状态，应另建 docs/governance Issue。