### PR TITLE
:recycle: refactor(model): 固化列元数据字段契约

### DIFF
--- a/src/dbjavagenix/core/models.py
+++ b/src/dbjavagenix/core/models.py
@@ -68,6 +68,7 @@ class ColumnInfo:
     max_length: Optional[int] = None
     precision: Optional[int] = None
     scale: Optional[int] = None
+    auto_increment: bool = False
 
 
 @dataclass

--- a/src/dbjavagenix/database/codegen_tools.py
+++ b/src/dbjavagenix/database/codegen_tools.py
@@ -160,12 +160,11 @@ class CodegenAnalyzer:
                 primary_key=col["primary_key"],
                 default_value=col["default_value"],
                 comment=col["comment"],
+                auto_increment=col["auto_increment"],
+                max_length=col["max_length"],
+                precision=col.get("precision"),
+                scale=col.get("scale"),
             )
-            # 添加额外属性
-            column_obj.auto_increment = col["auto_increment"]
-            column_obj.max_length = col["max_length"]
-            column_obj.precision = col.get("precision")
-            column_obj.scale = col.get("scale")
             column_objects.append(column_obj)
 
         table_obj = TableInfo(
@@ -193,10 +192,10 @@ class CodegenAnalyzer:
             "primary_key": column.primary_key,
             "default_value": column.default_value,
             "comment": column.comment,
-            "auto_increment": getattr(column, "auto_increment", False),
-            "max_length": getattr(column, "max_length", None),
-            "precision": getattr(column, "precision", None),
-            "scale": getattr(column, "scale", None),
+            "auto_increment": column.auto_increment,
+            "max_length": column.max_length,
+            "precision": column.precision,
+            "scale": column.scale,
             "java_type": column.java_type,
         }
 

--- a/tests/unit/test_codegen_analyzer.py
+++ b/tests/unit/test_codegen_analyzer.py
@@ -1,5 +1,6 @@
 """Unit tests for the public code-generation analysis workflow."""
 
+import asyncio
 from types import SimpleNamespace
 
 import pytest
@@ -162,6 +163,39 @@ async def test_table_analysis_forwards_schema_to_all_metadata_queries():
     assert {call[3] for call in introspector.calls} == {"tenant_a"}
     assert result["table_info"]["schema"] == "tenant_a"
     assert result["relationships"]["primary_keys"] == ["id"]
+
+
+def test_table_analysis_keeps_column_metadata_typed():
+    analyzer = CodegenAnalyzer(object())
+    introspector = _SchemaAwareIntrospector()
+
+    def get_columns(_connection_id, _table_name, _schema=None):
+        return [
+            {
+                "name": "id",
+                "type": "BIGINT",
+                "nullable": False,
+                "primary_key": True,
+                "default_value": None,
+                "comment": "Primary key",
+                "auto_increment": True,
+                "max_length": None,
+                "precision": None,
+                "scale": None,
+            }
+        ]
+
+    introspector.get_columns = get_columns
+    analyzer.introspector = introspector
+
+    result = asyncio.run(
+        analyzer.analyze_table_for_codegen("mysql-1", "users", template_category="Default")
+    )
+
+    column = result["table_info"]["columns"][0]
+    assert column["auto_increment"] is True
+    assert column["precision"] is None
+    assert column["scale"] is None
 
 
 def test_codegen_entrypoints_expose_optional_schema():

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -21,6 +21,19 @@ def test_column_info_creation():
     assert column.name == "user_id"
     assert column.java_type == "Long"
     assert column.primary_key is True
+    assert column.auto_increment is False
+
+
+def test_column_info_persists_auto_increment_metadata():
+    column = ColumnInfo(
+        name="id",
+        data_type="BIGINT",
+        java_type="Long",
+        primary_key=True,
+        auto_increment=True,
+    )
+
+    assert column.auto_increment is True
 
 
 def test_table_info_entity_name():


### PR DESCRIPTION
## 关联 Issue

Closes #97

## 背景（Situation）

`ColumnInfo` 是核心数据模型，但分析器原先先构造对象，再动态挂载 `auto_increment`、`max_length`、`precision` 和 `scale`。其中部分字段不在 dataclass 定义内，静态类型检查、序列化和模板调用方无法发现契约缺失。

## 任务（Task）

将列元数据收敛为正式类型字段，保持默认值兼容；分析器在构造阶段显式传递字段，模板上下文直接读取类型化属性。

## 行动（Action）

- 将 `auto_increment` 等列属性纳入 `ColumnInfo` 正式定义。
- 移除动态属性构造，保持 `isAutoIncrement`、`autoIncrement`、`maxLength` 等 Mustache 别名。
- 增加模型、analyzer 和上下文回归测试。
- 没有做什么：不改变数据库查询、模板文本、API 字段名或性能目标。

## 验证（Verification）

环境：Windows 11，Python 3.12.12。

- `PYTHONPATH=src python -m pytest tests/unit/ -q`：640 passed。
- 模型和模板上下文定向测试：通过。
- `ruff check src tests scripts`、`ruff format --check` 与 `git diff --check`：通过。

## 实验与证据（Evidence）

构造 `auto_increment=true`、`max_length=20` 的 `ColumnInfo` 后，上下文的 `isAutoIncrement`/`autoIncrement` 均为 true，`maxLength` 为 20；缺失正式字段的非标准对象不再被静默兜底。未建立性能基准。

## 兼容性、风险与回滚

- 公共 API / 数据格式 / 迁移：dataclass 增加带默认值字段，既有构造调用保持兼容。
- 风险与已知限制：依赖动态属性的非标准调用方会更早暴露错误；未改变数据库驱动行为。
- 回滚：revert 对应提交即可恢复动态属性路径。
- 后续 Issue：类型检查覆盖率提升可另行跟踪。