### PR TITLE
:bug: fix(dialect): 补齐 SQLite 方言注册与类型映射

### DIFF
--- a/src/dbjavagenix/database/dialect.py
+++ b/src/dbjavagenix/database/dialect.py
@@ -304,6 +304,77 @@ class PostgreSQLDialect(DialectAdapter):
 
 
 # ============================================================
+# SQLite
+# ============================================================
+
+
+class SQLiteDialect(DialectAdapter):
+    """SQLite declared-type and storage-affinity mappings."""
+
+    name = "sqlite"
+
+    @property
+    def type_to_java(self) -> Dict[str, str]:
+        return {
+            "INTEGER": "Long",
+            "INT": "Integer",
+            "TINYINT": "Integer",
+            "SMALLINT": "Integer",
+            "MEDIUMINT": "Integer",
+            "BIGINT": "Long",
+            "TEXT": "String",
+            "CHARACTER": "String",
+            "VARCHAR": "String",
+            "VARYING CHARACTER": "String",
+            "NCHAR": "String",
+            "NATIVE CHARACTER": "String",
+            "NVARCHAR": "String",
+            "CLOB": "String",
+            "REAL": "Double",
+            "DOUBLE": "Double",
+            "DOUBLE PRECISION": "Double",
+            "FLOAT": "Float",
+            "DECIMAL": "BigDecimal",
+            "NUMERIC": "BigDecimal",
+            "BLOB": "byte[]",
+            "DATE": "LocalDate",
+            "DATETIME": "LocalDateTime",
+            "TIMESTAMP": "LocalDateTime",
+            "BOOLEAN": "Boolean",
+        }
+
+    @property
+    def type_to_jdbc(self) -> Dict[str, str]:
+        return {
+            "INTEGER": "BIGINT",
+            "INT": "INTEGER",
+            "TINYINT": "INTEGER",
+            "SMALLINT": "INTEGER",
+            "MEDIUMINT": "INTEGER",
+            "BIGINT": "BIGINT",
+            "TEXT": "VARCHAR",
+            "CHARACTER": "VARCHAR",
+            "VARCHAR": "VARCHAR",
+            "VARYING CHARACTER": "VARCHAR",
+            "NCHAR": "VARCHAR",
+            "NATIVE CHARACTER": "VARCHAR",
+            "NVARCHAR": "VARCHAR",
+            "CLOB": "LONGVARCHAR",
+            "REAL": "DOUBLE",
+            "DOUBLE": "DOUBLE",
+            "DOUBLE PRECISION": "DOUBLE",
+            "FLOAT": "FLOAT",
+            "DECIMAL": "DECIMAL",
+            "NUMERIC": "NUMERIC",
+            "BLOB": "BINARY",
+            "DATE": "DATE",
+            "DATETIME": "TIMESTAMP",
+            "TIMESTAMP": "TIMESTAMP",
+            "BOOLEAN": "BOOLEAN",
+        }
+
+
+# ============================================================
 # Registry
 # ============================================================
 
@@ -311,6 +382,7 @@ class PostgreSQLDialect(DialectAdapter):
 _REGISTRY: Dict[str, DialectAdapter] = {
     "mysql": MySQLDialect(),
     "postgresql": PostgreSQLDialect(),
+    "sqlite": SQLiteDialect(),
 }
 
 

--- a/tests/unit/test_dialect.py
+++ b/tests/unit/test_dialect.py
@@ -6,6 +6,7 @@ from dbjavagenix.database.dialect import (
     DialectAdapter,
     MySQLDialect,
     PostgreSQLDialect,
+    SQLiteDialect,
     _strip_paren,
     get_dialect,
     list_supported_dialects,
@@ -30,12 +31,16 @@ class TestRegistry:
     def test_known_dialects(self):
         assert "mysql" in list_supported_dialects()
         assert "postgresql" in list_supported_dialects()
+        assert "sqlite" in list_supported_dialects()
 
     def test_get_mysql(self):
         assert isinstance(get_dialect("mysql"), MySQLDialect)
 
     def test_get_postgresql(self):
         assert isinstance(get_dialect("postgresql"), PostgreSQLDialect)
+
+    def test_get_sqlite(self):
+        assert isinstance(get_dialect("sqlite"), SQLiteDialect)
 
     def test_get_case_insensitive(self):
         assert isinstance(get_dialect("MySQL"), MySQLDialect)
@@ -167,6 +172,33 @@ class TestPostgreSQLDialect:
 
     def test_unknown_falls_back_to_string(self):
         assert self.d.java_type_for("WEIRD_PG_TYPE") == "String"
+
+
+class TestSQLiteDialect:
+    def setup_method(self):
+        self.d = SQLiteDialect()
+
+    def test_storage_affinity_types(self):
+        assert self.d.java_type_for("INTEGER") == "Long"
+        assert self.d.java_type_for("VARCHAR(255)") == "String"
+        assert self.d.java_type_for("REAL") == "Double"
+        assert self.d.java_type_for("BLOB") == "byte[]"
+
+    def test_declared_type_aliases(self):
+        assert self.d.java_type_for("DOUBLE PRECISION") == "Double"
+        assert self.d.java_type_for("VARYING CHARACTER") == "String"
+        assert self.d.java_type_for("TIMESTAMP") == "LocalDateTime"
+
+    def test_jdbc_types(self):
+        assert self.d.jdbc_type_for("INTEGER") == "BIGINT"
+        assert self.d.jdbc_type_for("TEXT") == "VARCHAR"
+        assert self.d.jdbc_type_for("BLOB") == "BINARY"
+        assert self.d.jdbc_type_for("DATETIME") == "TIMESTAMP"
+
+    def test_type_categories(self):
+        assert self.d.is_string_type("TEXT")
+        assert self.d.is_date_type("TIMESTAMP")
+        assert self.d.is_decimal_type("NUMERIC")
 
 
 class TestCrossDialectIsolation:


### PR DESCRIPTION
## 关联 Issue

Closes #101

## 背景（Situation）

SQLite 已在连接、元数据读取和公开能力列表中声明为支持数据库，但代码生成方言注册表此前只注册 MySQL 和 PostgreSQL，未识别 SQLite 时会静默回退到 MySQL 映射，`INTEGER`、`BLOB` 等类型可能生成错误的 Java/JDBC 类型。

## 任务（Task）

注册独立 `SQLiteDialect`，覆盖常见声明类型、存储亲和性和 JDBC 类型映射；保持未知方言的既有 MySQL 回退兼容，并为工厂和映射建立回归证据。

## 行动（Action）

- 新增 `SQLiteDialect` 并接入 `get_dialect('sqlite')` 注册表。
- 覆盖 INTEGER、TEXT、BLOB、REAL、NUMERIC、日期声明等常见输入。
- 增加注册、别名、类型分类和 JDBC 输出测试。
- 没有做什么：不修改 SQLite SQL、连接生命周期、模板文本或未声明类型的回退规则。

## 验证（Verification）

环境：Windows 11，Python 3.12.12。

- `PYTHONPATH=src python -m pytest tests/unit/ -q`：648 passed。
- `python -m ruff check src tests scripts` 与 `ruff format --check`：通过。
- `git diff --check`：通过。

## 实验与证据（Evidence）

修复前 `get_dialect('sqlite')` 返回 MySQL adapter，修复后返回 `SQLiteDialect`，名称为 `sqlite`；`INTEGER` 映射为 `Long`，`BLOB` 映射为 `byte[]`，`TEXT` 的 JDBC 类型为 `VARCHAR`。未知方言仍按 MySQL 回退。未建立性能基准。

## 兼容性、风险与回滚

- 公共 API / 数据格式 / 迁移：方言工厂新增已声明的 SQLite 分支，已有 MySQL/PostgreSQL 调用不变。
- 风险与已知限制：SQLite 动态类型和未声明类型只能按现有规则推断；未覆盖所有扩展声明和真实 Java 编译。
- 回滚：revert 对应提交即可恢复 MySQL 回退行为。
- 后续 Issue：需要新增方言时复用 adapter 注册契约并补真实 catalog 类型测试。