### PR TITLE
:recycle: refactor(generator): 直接使用类型化列元数据

### DIFF
--- a/src/dbjavagenix/generator/template_context.py
+++ b/src/dbjavagenix/generator/template_context.py
@@ -243,10 +243,10 @@ class TemplateContextBuilder:
                 "primaryKey": column.primary_key,  # 兼容两种写法
                 "isNullable": column.nullable,
                 "nullable": column.nullable,
-                "isAutoIncrement": getattr(column, "auto_increment", False),
-                "autoIncrement": getattr(column, "auto_increment", False),
+                "isAutoIncrement": column.auto_increment,
+                "autoIncrement": column.auto_increment,
                 "defaultValue": column.default_value,
-                "maxLength": getattr(column, "max_length", None),
+                "maxLength": column.max_length,
                 # 验证相关
                 "required": not column.nullable and not column.primary_key,
                 "isString": self._is_string_type(column.data_type),
@@ -301,10 +301,10 @@ class TemplateContextBuilder:
                 "primaryKey": column.primary_key,  # 兼容两种写法
                 "isNullable": column.nullable,
                 "nullable": column.nullable,
-                "isAutoIncrement": getattr(column, "auto_increment", False),
-                "autoIncrement": getattr(column, "auto_increment", False),
+                "isAutoIncrement": column.auto_increment,
+                "autoIncrement": column.auto_increment,
                 "defaultValue": column.default_value,
-                "maxLength": getattr(column, "max_length", None),
+                "maxLength": column.max_length,
                 # 验证相关
                 "required": not column.nullable and not column.primary_key,
                 "isString": self._is_string_type(column.data_type),

--- a/tests/unit/test_template_context_builder.py
+++ b/tests/unit/test_template_context_builder.py
@@ -124,6 +124,13 @@ class TestJavaTypeMapping:
         assert builder._map_java_type("BYTEA") == "byte[]"
         assert builder._map_java_type("JSONB") == "String"
 
+    def test_sqlite_dialect_is_used_for_context_mapping(self):
+        builder = TemplateContextBuilder(database_type=DatabaseType.SQLITE)
+
+        assert builder.dialect.name == "sqlite"
+        assert builder._map_java_type("INTEGER") == "Long"
+        assert builder._map_jdbc_type("BLOB") == "BINARY"
+
 
 class TestJdbcTypeMapping:
     @pytest.mark.parametrize(
@@ -184,6 +191,29 @@ class TestBuildContextStructure:
             "date",
         ]:
             assert key in ctx, f"missing key {key}"
+
+    def test_typed_column_metadata_is_forwarded(self, builder):
+        table = TableInfo(
+            name="orders",
+            schema="main",
+            columns=[
+                ColumnInfo(
+                    name="id",
+                    data_type="INTEGER",
+                    java_type="Long",
+                    nullable=False,
+                    primary_key=True,
+                    auto_increment=True,
+                    max_length=20,
+                )
+            ],
+        )
+
+        column = builder.build_context(table)["columns"][0]
+
+        assert column["isAutoIncrement"] is True
+        assert column["autoIncrement"] is True
+        assert column["maxLength"] == 20
 
     def test_class_name_from_table(self, builder, rbac_user_table):
         ctx = builder.build_context(rbac_user_table, "Default")


### PR DESCRIPTION
## 关联 Issue

Closes #103

## 背景（Situation）

`ColumnInfo` 已将 `auto_increment`、`max_length`、`precision` 和 `scale` 定义为正式字段，但模板上下文仍用 `getattr` 和默认值读取它们，类型契约没有贯通到生成器边界，非标准对象缺字段时会被静默掩盖。

## 任务（Task）

让模板上下文直接消费类型化列元数据，同时保持既有 Mustache 键名和生成语义；缺失正式字段应尽早暴露，而不是继续静默降级。

## 行动（Action）

- `_build_columns_context` 与 `_build_non_primary_columns_context` 直接读取 `ColumnInfo` 正式属性。
- 保留 `isAutoIncrement`、`autoIncrement`、`maxLength` 等兼容别名。
- 增加 SQLite 类型映射和上下文字段回归测试。
- 没有做什么：不改变模板键名、数据库查询、SQL、输出文件名或性能目标。

## 验证（Verification）

环境：Windows 11，Python 3.12.12。

- `PYTHONPATH=src python -m pytest tests/unit/ -q`：650 passed。
- `python -m ruff check src tests scripts`、`ruff format --check` 与 `git diff --check`：通过。

## 实验与证据（Evidence）

构造 `auto_increment=true`、`max_length=20` 的 `ColumnInfo` 后，上下文两个自增键均为 true，`maxLength` 为 20；SQLite `INTEGER` 映射为 `Long`、`BLOB` 为 `BINARY` JDBC 类型。没有建立可比性能基准。

## 兼容性、风险与回滚

- 公共 API / 数据格式 / 迁移：只改变内部读取方式，公开 Mustache 键名保持不变。
- 风险与已知限制：依赖动态属性的非标准对象会更早抛出缺字段错误；真实数据库组合由集成测试覆盖。
- 回滚：revert 对应提交即可恢复动态属性兜底。
- 后续 Issue：可继续增加静态类型检查和模板上下文契约覆盖。