### PR TITLE
:bug: fix(metadata): 正确识别 SQLite 自增主键

### DIFF
--- a/src/dbjavagenix/database/introspection.py
+++ b/src/dbjavagenix/database/introspection.py
@@ -6,6 +6,7 @@ stays in this module so callers do not need to branch on vendor details.
 
 from __future__ import annotations
 
+import re
 from typing import Any, Dict, List
 
 from ..core.exceptions import DatabaseAnalysisError, DatabaseConnectionError
@@ -47,6 +48,22 @@ class DatabaseIntrospector:
     def _sqlite_identifier(value: str) -> str:
         """Quote a SQLite identifier used by PRAGMA statements."""
         return value.replace("'", "''")
+
+    def _sqlite_table_uses_autoincrement(self, connection_id: str, table_name: str) -> bool:
+        """Read SQLite's table DDL to preserve AUTOINCREMENT metadata.
+
+        ``PRAGMA table_info`` exposes the primary-key column as ``INTEGER`` but
+        intentionally omits the AUTOINCREMENT keyword.
+        """
+        rows = self.connection_manager.execute_query(
+            connection_id,
+            "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?",
+            (table_name,),
+        )
+        if not rows:
+            return False
+        definition = self._value(rows[0], "sql", default="") or ""
+        return bool(re.search(r"\bAUTOINCREMENT\b", str(definition), re.IGNORECASE))
 
     @staticmethod
     def _mysql_identifier(value: str) -> str:
@@ -233,6 +250,12 @@ class DatabaseIntrospector:
         else:
             raise DatabaseAnalysisError(f"Column metadata not implemented for {config.type}")
 
+        sqlite_autoincrement = (
+            self._sqlite_table_uses_autoincrement(connection_id, table_name)
+            if config.type == DatabaseType.SQLITE
+            and any(bool(self._value(row, "pk", default=0)) for row in rows)
+            else False
+        )
         columns = []
         for row in rows:
             name = self._value(row, "COLUMN_NAME", "column_name", "name", default="")
@@ -266,6 +289,11 @@ class DatabaseIntrospector:
                     "extra": extra,
                     "primary_key": primary_key or bool(self._value(row, "pk", default=0)),
                     "auto_increment": "auto_increment" in str(extra).lower()
+                    or (
+                        sqlite_autoincrement
+                        and bool(self._value(row, "pk", default=0))
+                        and str(self._value(row, "type", default="")).upper() == "INTEGER"
+                    )
                     or str(self._value(row, "type", default="")).upper() == "INTEGER AUTOINCREMENT",
                 }
             )

--- a/tests/unit/test_database_introspection.py
+++ b/tests/unit/test_database_introspection.py
@@ -78,6 +78,32 @@ def test_sqlite_introspection_returns_normalized_metadata():
         manager.close_connection(connection_id)
 
 
+def test_sqlite_introspection_detects_autoincrement_primary_key():
+    manager = ConnectionManager()
+    connection_id = manager.create_connection(
+        DatabaseConfig(
+            type=DatabaseType.SQLITE,
+            host="",
+            port=0,
+            database=":memory:",
+            username="",
+            password="",
+        )
+    )
+    try:
+        manager.execute_query(
+            connection_id,
+            "CREATE TABLE generated_ids (id INTEGER PRIMARY KEY AUTOINCREMENT, value TEXT)",
+        )
+        columns = DatabaseIntrospector(manager).get_columns(connection_id, "generated_ids")
+
+        assert columns[0]["primary_key"] is True
+        assert columns[0]["auto_increment"] is True
+        assert columns[1]["auto_increment"] is False
+    finally:
+        manager.close_connection(connection_id)
+
+
 def test_sqlite_introspection_escapes_special_table_names():
     manager = ConnectionManager()
     connection_id = manager.create_connection(


### PR DESCRIPTION
## 关联 Issue

Closes #105

## 背景（Situation）

SQLite 的 `PRAGMA table_info` 对 `INTEGER PRIMARY KEY AUTOINCREMENT` 只返回 `INTEGER`，不会把 `AUTOINCREMENT` 写入 type 字段。原元数据读取只检查 type，代码生成因此丢失自增语义。

## 任务（Task）

从 SQLite catalog 读取表 DDL，准确区分带 `AUTOINCREMENT` 的 INTEGER 主键和普通主键；保持表名参数化和其他数据库查询路径不变。

## 行动（Action）

- 查询 `sqlite_master` 的表定义并检测 `AUTOINCREMENT` 关键字。
- 仅对 INTEGER 主键的真实自增表标记 `auto_increment=true`。
- 使用绑定参数读取表名，保留 SQLite 标识符安全边界。
- 增加真实 SQLite 表、普通主键和特殊表名回归测试。
- 没有做什么：不修改 MySQL/PostgreSQL SQL、DDL、模板或数据库数据。

## 验证（Verification）

环境：Windows 11，Python 3.12.12 / SQLite 3.50.4。

- SQLite 元数据与跨数据库契约定向测试：14 passed。
- `PYTHONPATH=src python -m pytest tests/unit/ -q`：650 passed。
- Ruff 检查、格式检查和 `git diff --check`：通过。

## 实验与证据（Evidence）

创建 `generated_ids (id INTEGER PRIMARY KEY AUTOINCREMENT, value TEXT)` 后，修复前 id 的 `auto_increment` 为 false，修复后为 true；`value` 和普通 `INTEGER PRIMARY KEY` 保持 false。表名通过 `?` 参数传递，未拼接进 catalog SQL。

## 兼容性、风险与回滚

- 公共 API / 数据格式 / 迁移：补全现有 normalized metadata 字段，不改变其他方言。
- 风险与已知限制：读取一次 sqlite_master 使 SQLite 描述查询往返增加；未测性能收益，后续基准需以新次数为基线。
- 回滚：revert 对应提交即可恢复旧检测逻辑。
- 后续 Issue：如需覆盖 SQLite WITHOUT ROWID、生成列等特殊 DDL，应另建 metadata Issue。