### PR TITLE
:test_tube: test(metadata): 对齐 SQLite 自增检测基准

### DIFF
--- a/docs/benchmarks/introspection.md
+++ b/docs/benchmarks/introspection.md
@@ -21,4 +21,6 @@ python scripts/benchmark_introspection.py --iterations 30 --warmup 5
 
 ## 当前范围
 
-本次只建立可重放基线，没有改变元数据查询实现，也没有声称性能提升。后续优化必须先用该基准记录前后结果，并同时确认元数据契约测试仍通过。
+当前基准包含 SQLite 自增主键识别所需的 `sqlite_master` DDL 查询，因此固定 schema 的
+`describe_table` 每次调用包含 7 次 SQL 往返。该变化是元数据完整性修复的直接成本，不代表
+性能提升或跨环境结论。后续优化必须先用该基准记录前后结果，并同时确认元数据契约测试仍通过。

--- a/tests/unit/test_introspection_benchmark.py
+++ b/tests/unit/test_introspection_benchmark.py
@@ -18,7 +18,7 @@ def test_benchmark_reports_contract_and_round_trip_baseline():
     assert result["columns"] == 4
     assert result["indexes"] == 2
     assert result["foreign_keys"] == 1
-    assert result["queries_per_call"] == 6
+    assert result["queries_per_call"] == 7
     assert 0 < result["median_ms"] <= result["p95_ms"] <= result["max_ms"]
 
 

--- a/tests/unit/test_visualization_introspection.py
+++ b/tests/unit/test_visualization_introspection.py
@@ -66,6 +66,8 @@ def test_sqlite_er_queries_escape_special_table_names(monkeypatch):
             return [{"name": "id", "type": "INTEGER", "pk": 1}]
         if query == "PRAGMA foreign_key_list('odd''table')":
             return []
+        if query == "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?":
+            return [{"sql": 'CREATE TABLE "odd\'table" (id INTEGER PRIMARY KEY)'}]
         raise AssertionError(f"unexpected query: {query}")
 
     monkeypatch.setattr(visualization_tools.connection_manager, "execute_query", execute_query)
@@ -81,5 +83,6 @@ def test_sqlite_er_queries_escape_special_table_names(monkeypatch):
     assert foreign_keys == []
     assert calls == [
         ("PRAGMA table_info('odd''table')", None),
+        ("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?", ("odd'table",)),
         ("PRAGMA foreign_key_list('odd''table')", None),
     ]


### PR DESCRIPTION
## 关联 Issue

Closes #108

## 背景（Situation）

#106 为识别 SQLite `AUTOINCREMENT` 增加了 `sqlite_master` DDL 查询，`describe_table` 的 SQL 往返从 6 次变为 7 次；旧 benchmark 和可视化测试桩仍假设 6 次，导致回归测试与当前元数据契约不一致。

## 任务（Task）

同步查询次数基线和 SQLite 测试桩，明确新增往返用于自增语义读取；不修改运行时代码或把额外查询描述为性能优化。

## 行动（Action）

- 将 SQLite 描述查询基线更新为 7 次，并写明每次调用的来源。
- 让 ER 测试桩覆盖参数绑定的 `sqlite_master` 查询。
- 保留 PRAGMA 特殊表名转义和既有 metadata 断言。
- 没有做什么：不删除自增检测、不优化 SQL、不宣称吞吐或延迟提升。

## 验证（Verification）

环境：Windows 11，Python 3.12.12。

- `PYTHONPATH=src python -m pytest tests/unit/ -q`：651 passed。
- SQLite benchmark 与 visualization 定向测试：通过。
- Ruff 检查、格式检查和 `git diff --check`：通过。

## 实验与证据（Evidence）

在固定 SQLite schema 上运行描述 benchmark，`queries_per_call` 稳定为 7；ER 特殊表名测试确认 DDL 查询表名仍作为参数传入，PRAGMA 标识符保持转义。7 次是完整性成本，不是性能收益。

## 兼容性、风险与回滚

- 公共 API / 数据格式 / 迁移：仅更新测试和基准说明，运行时输出不变。
- 风险与已知限制：基准受本地 SQLite/文件系统影响，不能代表生产延迟；后续优化须保持自增字段证据。
- 回滚：revert 对应测试提交即可恢复旧基线说明，但应同时回滚依赖它的断言。
- 后续 Issue：若要减少 catalog 往返，应另建带前后测量的 perf Issue。