### PR TITLE
:bug: fix(mcp): 统一成功响应 JSON 序列化

### DIFF
--- a/src/dbjavagenix/database/mcp_tools.py
+++ b/src/dbjavagenix/database/mcp_tools.py
@@ -564,7 +564,7 @@ async def handle_db_connect_test(arguments: Dict[str, Any]) -> List[TextContent]
                  f"- Host: {config.host}:{config.port}\n"
                  f"- Type: {config.type.value}\n\n"
                  f"Use this connection_id for subsequent database operations.\n\n"
-                 f"Raw Response: {response}"
+                 f"Raw Response: {json.dumps(response, ensure_ascii=False)}"
         )]
         
     except DatabaseConnectionError as e:
@@ -849,7 +849,10 @@ async def handle_db_query_table_exists(arguments: Dict[str, Any]) -> List[TextCo
         status = "exists" if exists else "does not exist"
         return [TextContent(
             type="text",
-            text=f"Table '{table}' {status} in database '{database}'\n\nRaw Response: {response}"
+            text=(
+                f"Table '{table}' {status} in database '{database}'\n\n"
+                f"Raw Response: {json.dumps(response, ensure_ascii=False)}"
+            )
         )]
         
     except (DatabaseConnectionError, DatabaseQueryError) as e:
@@ -925,7 +928,7 @@ async def handle_db_query_execute(arguments: Dict[str, Any]) -> List[TextContent
         else:
             result_text = "Query executed successfully. No rows returned."
         
-        result_text += f"\n\nRaw Response: {response}"
+        result_text += f"\n\nRaw Response: {json.dumps(response, ensure_ascii=False)}"
         
         return [TextContent(
             type="text",
@@ -1114,7 +1117,7 @@ async def handle_db_table_describe(arguments: Dict[str, Any]) -> List[TextConten
             for imp in sorted(java_imports):
                 result_text += f"import {imp};\n"
         
-        result_text += f"\nRaw Response: {response}"
+        result_text += f"\nRaw Response: {json.dumps(response, ensure_ascii=False)}"
         
         return [TextContent(
             type="text",
@@ -1250,7 +1253,7 @@ async def handle_db_table_columns(arguments: Dict[str, Any]) -> List[TextContent
                 result_text += f"  Comment: {row['COLUMN_COMMENT']}\n"
             result_text += "\n"
         
-        result_text += f"Raw Response: {response}"
+        result_text += f"Raw Response: {json.dumps(response, ensure_ascii=False)}"
         
         return [TextContent(
             type="text",
@@ -1352,7 +1355,7 @@ async def handle_db_table_primary_keys(arguments: Dict[str, Any]) -> List[TextCo
         else:
             result_text = f"No primary keys found for table {database}.{table}\n"
         
-        result_text += f"\nRaw Response: {response}"
+        result_text += f"\nRaw Response: {json.dumps(response, ensure_ascii=False)}"
         
         return [TextContent(
             type="text",
@@ -1494,7 +1497,7 @@ async def handle_db_table_foreign_keys(arguments: Dict[str, Any]) -> List[TextCo
         else:
             result_text = f"No foreign keys found for table {database}.{table}\n"
         
-        result_text += f"Raw Response: {response}"
+        result_text += f"Raw Response: {json.dumps(response, ensure_ascii=False)}"
         
         return [TextContent(
             type="text",
@@ -1650,7 +1653,7 @@ async def handle_db_table_indexes(arguments: Dict[str, Any]) -> List[TextContent
         else:
             result_text = f"No indexes found for table {database}.{table}\n"
         
-        result_text += f"Raw Response: {response}"
+        result_text += f"Raw Response: {json.dumps(response, ensure_ascii=False)}"
         
         return [TextContent(
             type="text",

--- a/tests/unit/test_mcp_error_json.py
+++ b/tests/unit/test_mcp_error_json.py
@@ -73,3 +73,46 @@ async def test_table_list_query_error_raw_response_is_json(monkeypatch):
     assert payload["success"] is False
     assert payload["error"] == "query_failed"
     assert payload["message"] == "[DB_QUERY_FAILED] database unavailable"
+
+
+@pytest.mark.asyncio
+async def test_query_execute_success_raw_response_is_json(monkeypatch):
+    monkeypatch.setattr(
+        mcp_tools.connection_manager,
+        "execute_query",
+        lambda *_args, **_kwargs: [{"id": 1, "name": "Alice"}],
+    )
+
+    response = await mcp_tools.handle_db_query_execute(
+        {"connection_id": "sqlite-1", "query": "SELECT 1", "limit": 10}
+    )
+
+    payload = _raw_payload(response)
+    assert payload["success"] is True
+    assert payload["data"] == [{"id": 1, "name": "Alice"}]
+
+
+@pytest.mark.asyncio
+async def test_table_exists_success_raw_response_is_json(monkeypatch):
+    monkeypatch.setattr(
+        mcp_tools.connection_manager,
+        "get_connection_info",
+        lambda _id: SimpleNamespace(type=DatabaseType.SQLITE),
+    )
+    monkeypatch.setattr(
+        mcp_tools.connection_manager,
+        "execute_query",
+        lambda *_args, **_kwargs: [{"count": 1}],
+    )
+
+    response = await mcp_tools.handle_db_query_table_exists(
+        {"connection_id": "sqlite-1", "database": "app", "table": "users"}
+    )
+
+    payload = _raw_payload(response)
+    assert payload == {
+        "success": True,
+        "database": "app",
+        "table": "users",
+        "exists": True,
+    }


### PR DESCRIPTION
## 关联 Issue

Closes #107

## 背景（Situation）

多个 MCP 成功路径仍以 Python `repr` 拼接 Raw Response，使用单引号、`None` 和 `True` 等非 JSON 语法；失败路径已使用 `json.dumps`，同一 public handler 因此存在两套响应协议，调用方无法稳定执行 `json.loads`。

## 任务（Task）

把成功路径的结构化 Raw Response 统一序列化为 UTF-8 JSON，保持用户可读摘要和字段名不变，并覆盖查询、表存在性及 metadata 成功响应。

## 行动（Action）

- 将连接、表存在性、查询、表描述、列、主键、外键和索引成功分支改用 `json.dumps`。
- 增加成功查询与表存在性响应的 JSON 回归测试。
- 保留错误 envelope、SQL 校验、limit 和文本摘要语义。
- 没有做什么：不重写所有历史 handler、不改变 SQL 或数据库权限、不建立性能收益结论。

## 验证（Verification）

环境：Windows 11，Python 3.12.12。

- MCP 定向测试：30 passed。
- `PYTHONPATH=src python -m pytest tests/unit/ -q`：651 passed。
- `ruff check src tests scripts`、变更文件格式检查和 `git diff --check`：通过。

## 实验与证据（Evidence）

对查询和表存在性成功响应的 Raw Response 片段执行 `json.loads`：修复前因 Python `repr` 失败，修复后成功解析，布尔值、空值和列表保持 JSON 语义。用户可读文本未改变。

## 兼容性、风险与回滚

- 公共 API / 数据格式 / 迁移：字段集合不变，成功响应的编码从 Python repr 纠正为标准 JSON。
- 风险与已知限制：依赖单引号 repr 的非标准客户端需迁移到 JSON；其他未改历史 handler 仍需独立审计。
- 回滚：revert 对应提交即可恢复旧序列化行为，不涉及数据。
- 后续 Issue：#107 的后续回归记录由 #112 单独标识。