### PR TITLE
:test_tube: test(mcp): 补充成功响应 JSON 回归

### DIFF
--- a/src/dbjavagenix/database/mcp_tools.py
+++ b/src/dbjavagenix/database/mcp_tools.py
@@ -564,7 +564,7 @@ async def handle_db_connect_test(arguments: Dict[str, Any]) -> List[TextContent]
                  f"- Host: {config.host}:{config.port}\n"
                  f"- Type: {config.type.value}\n\n"
                  f"Use this connection_id for subsequent database operations.\n\n"
-                 f"Raw Response: {response}"
+                 f"Raw Response: {json.dumps(response, ensure_ascii=False)}"
         )]
         
     except DatabaseConnectionError as e:
@@ -849,7 +849,10 @@ async def handle_db_query_table_exists(arguments: Dict[str, Any]) -> List[TextCo
         status = "exists" if exists else "does not exist"
         return [TextContent(
             type="text",
-            text=f"Table '{table}' {status} in database '{database}'\n\nRaw Response: {response}"
+            text=(
+                f"Table '{table}' {status} in database '{database}'\n\n"
+                f"Raw Response: {json.dumps(response, ensure_ascii=False)}"
+            )
         )]
         
     except (DatabaseConnectionError, DatabaseQueryError) as e:
@@ -925,7 +928,7 @@ async def handle_db_query_execute(arguments: Dict[str, Any]) -> List[TextContent
         else:
             result_text = "Query executed successfully. No rows returned."
         
-        result_text += f"\n\nRaw Response: {response}"
+        result_text += f"\n\nRaw Response: {json.dumps(response, ensure_ascii=False)}"
         
         return [TextContent(
             type="text",
@@ -1114,7 +1117,7 @@ async def handle_db_table_describe(arguments: Dict[str, Any]) -> List[TextConten
             for imp in sorted(java_imports):
                 result_text += f"import {imp};\n"
         
-        result_text += f"\nRaw Response: {response}"
+        result_text += f"\nRaw Response: {json.dumps(response, ensure_ascii=False)}"
         
         return [TextContent(
             type="text",
@@ -1250,7 +1253,7 @@ async def handle_db_table_columns(arguments: Dict[str, Any]) -> List[TextContent
                 result_text += f"  Comment: {row['COLUMN_COMMENT']}\n"
             result_text += "\n"
         
-        result_text += f"Raw Response: {response}"
+        result_text += f"Raw Response: {json.dumps(response, ensure_ascii=False)}"
         
         return [TextContent(
             type="text",
@@ -1352,7 +1355,7 @@ async def handle_db_table_primary_keys(arguments: Dict[str, Any]) -> List[TextCo
         else:
             result_text = f"No primary keys found for table {database}.{table}\n"
         
-        result_text += f"\nRaw Response: {response}"
+        result_text += f"\nRaw Response: {json.dumps(response, ensure_ascii=False)}"
         
         return [TextContent(
             type="text",
@@ -1494,7 +1497,7 @@ async def handle_db_table_foreign_keys(arguments: Dict[str, Any]) -> List[TextCo
         else:
             result_text = f"No foreign keys found for table {database}.{table}\n"
         
-        result_text += f"Raw Response: {response}"
+        result_text += f"Raw Response: {json.dumps(response, ensure_ascii=False)}"
         
         return [TextContent(
             type="text",
@@ -1650,7 +1653,7 @@ async def handle_db_table_indexes(arguments: Dict[str, Any]) -> List[TextContent
         else:
             result_text = f"No indexes found for table {database}.{table}\n"
         
-        result_text += f"Raw Response: {response}"
+        result_text += f"Raw Response: {json.dumps(response, ensure_ascii=False)}"
         
         return [TextContent(
             type="text",

--- a/tests/unit/test_mcp_error_json.py
+++ b/tests/unit/test_mcp_error_json.py
@@ -73,3 +73,46 @@ async def test_table_list_query_error_raw_response_is_json(monkeypatch):
     assert payload["success"] is False
     assert payload["error"] == "query_failed"
     assert payload["message"] == "[DB_QUERY_FAILED] database unavailable"
+
+
+@pytest.mark.asyncio
+async def test_query_execute_success_raw_response_is_json(monkeypatch):
+    monkeypatch.setattr(
+        mcp_tools.connection_manager,
+        "execute_query",
+        lambda *_args, **_kwargs: [{"id": 1, "name": "Alice"}],
+    )
+
+    response = await mcp_tools.handle_db_query_execute(
+        {"connection_id": "sqlite-1", "query": "SELECT 1", "limit": 10}
+    )
+
+    payload = _raw_payload(response)
+    assert payload["success"] is True
+    assert payload["data"] == [{"id": 1, "name": "Alice"}]
+
+
+@pytest.mark.asyncio
+async def test_table_exists_success_raw_response_is_json(monkeypatch):
+    monkeypatch.setattr(
+        mcp_tools.connection_manager,
+        "get_connection_info",
+        lambda _id: SimpleNamespace(type=DatabaseType.SQLITE),
+    )
+    monkeypatch.setattr(
+        mcp_tools.connection_manager,
+        "execute_query",
+        lambda *_args, **_kwargs: [{"count": 1}],
+    )
+
+    response = await mcp_tools.handle_db_query_table_exists(
+        {"connection_id": "sqlite-1", "database": "app", "table": "users"}
+    )
+
+    payload = _raw_payload(response)
+    assert payload == {
+        "success": True,
+        "database": "app",
+        "table": "users",
+        "exists": True,
+    }


### PR DESCRIPTION
## 关联 Issue

Refs #107

## 背景（Situation）

该历史 PR 与 #110 共享同一实现提交 `fc01c97`，展示层此前重复使用 `:bug: fix(mcp): 统一成功响应 JSON 序列化` 标题和同一段简短正文，无法区分实现记录与回归记录，也使 Issue/PR 关系不清晰。

## 任务（Task）

将本条历史记录明确标识为成功响应 JSON 回归覆盖，保留可追溯的输入、结果和边界；不伪造第二份实现或新的运行时行为。

## 行动（Action）

- 重命名 PR 为 `:test_tube: test(mcp): 补充成功响应 JSON 回归`，与记录职责一致。
- 说明其与 #110 的共享提交关系，并将 Issue 改为引用而非重复关闭。
- 补充 `json.loads` 断言、成功/失败 envelope 和未测边界。
- 没有做什么：不重复修改 `mcp_tools.py`，不改变公共 payload，不重写合并提交历史。

## 验证（Verification）

环境：Windows 11，Python 3.12.12。

- 共享提交对应的 MCP 定向回归：30 passed。
- 完整 `PYTHONPATH=src python -m pytest tests/unit/ -q`：651 passed。
- `ruff check src tests scripts`、格式检查和 `git diff --check`：通过。

## 实验与证据（Evidence）

受控成功查询和表存在性响应经 `json.loads` 均可解析；`success=false` 错误 envelope 仍保持 JSON。该 PR 不声称新增代码，只把重复历史记录、验证结果和边界补充清楚。

## 兼容性、风险与回滚

- 公共 API / 数据格式 / 迁移：无变化；这是合并 PR 展示元数据与测试职责说明修复。
- 风险与已知限制：旧的 `fc01c97` 提交标题仍不可变；PR 标题用于浏览，不能替代 commit object。
- 回滚：恢复 PR 标题/正文即可；不涉及运行时回滚或数据。
- 后续 Issue：继续由 #107 跟踪其他历史 handler 的 JSON 审计。