### PR TITLE
:bug: fix(mcp): 按 schema 校验 PostgreSQL 表存在性

### DIFF
--- a/src/dbjavagenix/database/mcp_tools.py
+++ b/src/dbjavagenix/database/mcp_tools.py
@@ -376,6 +376,10 @@ def get_connection_tools() -> List[Tool]:
                     "table": {
                         "type": "string",
                         "description": "Table name"
+                    },
+                    "schema": {
+                        "type": "string",
+                        "description": "PostgreSQL schema (optional)"
                     }
                 },
                 "required": ["connection_id", "database", "table"]
@@ -867,6 +871,7 @@ async def handle_db_query_table_exists(arguments: Dict[str, Any]) -> List[TextCo
         connection_id = arguments["connection_id"]
         database = arguments["database"]
         table = arguments["table"]
+        schema = arguments.get("schema") or None
 
         # Get connection info to determine database type  
         config = connection_manager.get_connection_info(connection_id)
@@ -883,14 +888,17 @@ async def handle_db_query_table_exists(arguments: Dict[str, Any]) -> List[TextCo
             results = connection_manager.execute_query(connection_id, query, (database, table))
 
         elif config.type == DatabaseType.POSTGRESQL:
+            schema_filter = "AND table_schema = %s" if schema else ""
             query = """
             SELECT COUNT(*) AS count
             FROM information_schema.tables
             WHERE table_catalog = %s
               AND table_name = %s
               AND table_schema NOT IN ('pg_catalog', 'information_schema')
-            """
-            results = connection_manager.execute_query(connection_id, query, (database, table))
+              {schema_filter}
+            """.format(schema_filter=schema_filter)
+            params = (database, table, schema) if schema else (database, table)
+            results = connection_manager.execute_query(connection_id, query, params)
             
         elif config.type == DatabaseType.SQLITE:
             query = """
@@ -909,6 +917,7 @@ async def handle_db_query_table_exists(arguments: Dict[str, Any]) -> List[TextCo
             "success": True,
             "database": database,
             "table": table,
+            "schema": schema,
             "exists": exists
         }
         

--- a/tests/unit/test_database_capabilities.py
+++ b/tests/unit/test_database_capabilities.py
@@ -35,6 +35,18 @@ def test_connection_tool_schema_only_advertises_implemented_databases():
     )
 
 
+def test_table_exists_tool_advertises_optional_postgresql_schema():
+    table_tool = next(
+        tool for tool in get_connection_tools() if tool.name == "db_query_table_exists"
+    )
+
+    assert table_tool.inputSchema["properties"]["schema"] == {
+        "type": "string",
+        "description": "PostgreSQL schema (optional)",
+    }
+    assert "schema" not in table_tool.inputSchema["required"]
+
+
 def test_cli_version_only_advertises_implemented_databases():
     result = CliRunner().invoke(cli.app, ["version"])
 

--- a/tests/unit/test_mcp_error_json.py
+++ b/tests/unit/test_mcp_error_json.py
@@ -114,5 +114,6 @@ async def test_table_exists_success_raw_response_is_json(monkeypatch):
         "success": True,
         "database": "app",
         "table": "users",
+        "schema": None,
         "exists": True,
     }

--- a/tests/unit/test_postgresql_mcp_tools.py
+++ b/tests/unit/test_postgresql_mcp_tools.py
@@ -196,6 +196,30 @@ async def test_table_exists_uses_postgresql_catalog(monkeypatch, postgres_info):
     assert calls[0][2] == ("app", "users")
 
 
+@pytest.mark.asyncio
+async def test_table_exists_applies_postgresql_schema_filter_with_bound_parameter(
+    monkeypatch, postgres_info
+):
+    calls = []
+    monkeypatch.setattr(
+        mcp_tools.connection_manager, "get_connection_info", lambda cid: postgres_info
+    )
+
+    def execute_query(connection_id, query, params=None):
+        calls.append((connection_id, query, params))
+        return [{"count": 1}]
+
+    monkeypatch.setattr(mcp_tools.connection_manager, "execute_query", execute_query)
+
+    response = await mcp_tools.handle_db_query_table_exists(
+        {"connection_id": "pg-1", "database": "app", "table": "users", "schema": "tenant_a"}
+    )
+
+    assert "exists in database" in response[0].text
+    assert "table_schema = %s" in calls[0][1]
+    assert calls[0][2] == ("app", "users", "tenant_a")
+
+
 def test_postgresql_java_mapping_normalizes_catalog_type_names():
     assert mcp_tools._get_java_type_mapping(
         DatabaseType.POSTGRESQL, "timestamp with time zone"


### PR DESCRIPTION
## 关联 Issue

Closes #114

## 背景（Situation）

PostgreSQL 允许多个 schema 使用同一个表名。`db_query_table_exists` 原先只按数据库和表名查询，无法确认调用方需要的 `tenant_a.users`，与表列表、表描述和代码生成路径的 schema 契约不一致。

## 任务（Task）

为存在性检查增加可选 PostgreSQL `schema`，保持 MySQL/SQLite 现有行为和成功 Raw Response 的 JSON 可解析性，并确保 schema 值始终通过驱动参数绑定。

## 行动（Action）

- 在 MCP 输入模型中声明可选 `schema`。
- PostgreSQL 提供 schema 时追加参数化的 `table_schema = %s` 条件。
- 成功响应回显 schema；未提供时返回 JSON `null`。
- 增加输入契约、参数顺序、成功响应和方言兼容回归测试。
- 没有做什么：不改变 MySQL/SQLite SQL、表详情、代码生成或权限策略；未测性能收益。

## 验证（Verification）

环境：Windows 11，Python 3.12.12 / PostgreSQL stub。

- `PYTHONPATH=src python -m pytest tests/unit/ -q`：658 passed。
- 定向 schema/MCP 测试：17 passed。
- `ruff check src tests`、变更文件格式检查和 `git diff --check`：通过。

## 实验与证据（Evidence）

stub 对未指定 schema 收到参数 `("app", "users")`，对 `tenant_a` 收到 `("app", "users", "tenant_a")`；schema 值不进入 SQL 文本。两种路径的 Raw Response 均可由 `json.loads` 解析，并回显字符串或 JSON `null`。未建立真实 PostgreSQL 往返性能基准。

## 兼容性、风险与回滚

- 公共 API / 数据格式 / 迁移：新增可选输入和成功响应字段，旧客户端不传 schema 仍走原查询。
- 风险与已知限制：本地未运行真实 PostgreSQL 容器；SQLite 没有 schema 过滤，更多方言需另测。
- 回滚：revert 对应提交即可恢复旧存在性查询，不涉及数据。
- 后续 Issue：真实 PostgreSQL catalog/driver 已在 #133 覆盖，复杂权限与性能另行跟踪。