### PR TITLE
:test_tube: test(generator): 增加 Java 生成代码编译 smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,6 +181,37 @@ jobs:
       - name: Render every Java template
         run: uv run python scripts/verify_templates.py
 
+  java-compile:
+    name: Generated Java compile smoke
+    runs-on: ubuntu-latest
+    env:
+      PYTHONPATH: src
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Temurin Java 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Install runtime dependencies
+        run: |
+          uv venv --python 3.12
+          uv pip install -e "."
+
+      - name: Render and compile generated Java fixture
+        run: |
+          java --version
+          mvn --version
+          uv run python scripts/verify_java_compile.py
+
   docker:
     name: Docker image smoke test
     runs-on: ubuntu-latest
@@ -241,7 +272,7 @@ jobs:
   ci-success:
     name: Required CI status
     if: always()
-    needs: [metadata, quality, format, integration, templates, docker, package]
+    needs: [metadata, quality, format, integration, templates, java-compile, docker, package]
     runs-on: ubuntu-latest
     steps:
       - name: Fail when any required job failed or was cancelled

--- a/docs/development.md
+++ b/docs/development.md
@@ -72,6 +72,9 @@ PYTHONPATH=src python -m pytest tests/integration/ -q
 # 运行模板和 MCP Apps 验证脚本
 PYTHONPATH=src python scripts/verify_templates.py
 PYTHONPATH=src python scripts/verify_mcp_apps.py
+
+# 渲染并用 Java 21 / Maven 编译 sb35-java21 固定 fixture
+PYTHONPATH=src python scripts/verify_java_compile.py
 ```
 
 ### 6. 验证安装

--- a/scripts/verify_java_compile.py
+++ b/scripts/verify_java_compile.py
@@ -1,0 +1,217 @@
+"""Compile a representative Java 21 project rendered from current templates."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pystache
+
+ROOT = Path(__file__).resolve().parents[1]
+TEMPLATE_ROOT = ROOT / "src" / "dbjavagenix" / "templates" / "java" / "sb35-java21"
+FIXTURE_PACKAGE = "com.dbjavagenix.compilefixture"
+
+TEMPLATES = (
+    ("entity.mustache", "entityPackage", "Invoice.java"),
+    ("dao.mustache", "daoPackage", "InvoiceDao.java"),
+    ("dto.mustache", "dtoPackage", "InvoiceDTO.java"),
+    ("service.mustache", "servicePackage", "InvoiceService.java"),
+    ("serviceImpl.mustache", "serviceImplPackage", "InvoiceServiceImpl.java"),
+    ("controller.mustache", "controllerPackage", "InvoiceController.java"),
+)
+
+CONTEXT = {
+    "entityPackage": f"{FIXTURE_PACKAGE}.entity",
+    "dtoPackage": f"{FIXTURE_PACKAGE}.dto",
+    "daoPackage": f"{FIXTURE_PACKAGE}.dao",
+    "servicePackage": f"{FIXTURE_PACKAGE}.service",
+    "serviceImplPackage": f"{FIXTURE_PACKAGE}.service.impl",
+    "controllerPackage": f"{FIXTURE_PACKAGE}.controller",
+    "className": "Invoice",
+    "tableName": "invoice",
+    "entityNameLowerCase": "invoice",
+    "comment": "Invoice",
+    "author": "DBJavaGenix CI",
+    "date": "2026-09-08",
+    "primaryKeyName": "id",
+    "primaryKeyType": "Long",
+    "capitalizedPrimaryKeyName": "Id",
+    "serialVersionUID": "1",
+    "hasJakarta": True,
+    "hasSpringDoc": True,
+    "useLombok": True,
+    "useSwagger": True,
+    "generateDto": True,
+    "imports": ["java.math.BigDecimal", "java.time.OffsetDateTime"],
+    "columns": [
+        {
+            "name": "id",
+            "javaName": "id",
+            "capitalizedJavaName": "Id",
+            "javaType": "Long",
+            "comment": "Primary key",
+            "isPrimaryKey": True,
+            "nullable": False,
+            "isString": False,
+            "maxLength": None,
+            "last": False,
+        },
+        {
+            "name": "amount",
+            "javaName": "amount",
+            "capitalizedJavaName": "Amount",
+            "javaType": "BigDecimal",
+            "comment": "Amount",
+            "isPrimaryKey": False,
+            "nullable": False,
+            "isString": False,
+            "maxLength": None,
+            "last": False,
+        },
+        {
+            "name": "created_at",
+            "javaName": "createdAt",
+            "capitalizedJavaName": "CreatedAt",
+            "javaType": "OffsetDateTime",
+            "comment": "Creation time",
+            "isPrimaryKey": False,
+            "nullable": True,
+            "isString": False,
+            "maxLength": None,
+            "last": True,
+        },
+    ],
+}
+
+POM = """<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>3.5.5</version>
+    <relativePath/>
+  </parent>
+  <groupId>com.dbjavagenix</groupId>
+  <artifactId>generated-compile-fixture</artifactId>
+  <version>1.0.0</version>
+  <properties>
+    <java.version>21</java.version>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-jpa</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-validation</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springdoc</groupId>
+      <artifactId>springdoc-openapi-starter-webmvc-api</artifactId>
+      <version>2.8.9</version>
+    </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>org.projectlombok</groupId>
+              <artifactId>lombok</artifactId>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>
+"""
+
+
+def render_fixture(project_dir: Path) -> list[Path]:
+    """Render the representative sb35-java21 source set into ``project_dir``."""
+    source_root = project_dir / "src" / "main" / "java"
+    renderer = pystache.Renderer()
+    rendered_files: list[Path] = []
+
+    for template_name, package_key, output_name in TEMPLATES:
+        template_path = TEMPLATE_ROOT / template_name
+        code = renderer.render(template_path.read_text(encoding="utf-8"), CONTEXT)
+        output_path = source_root / Path(CONTEXT[package_key].replace(".", "/")) / output_name
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(code, encoding="utf-8")
+        rendered_files.append(output_path)
+
+    (project_dir / "pom.xml").write_text(POM, encoding="utf-8")
+    return rendered_files
+
+
+def build_maven_command(maven: str) -> list[str]:
+    """Build the explicit, batch-mode compile command for a rendered fixture."""
+    return [maven, "-B", "-ntp", "-DskipTests", "clean", "compile"]
+
+
+def cleanup_fixture(project_dir: Path, *, keep_fixture: bool, compile_succeeded: bool) -> None:
+    """Remove a successful fixture unless diagnostics were explicitly requested."""
+    if keep_fixture or not compile_succeeded:
+        print(f"Fixture retained at {project_dir}")
+        return
+    shutil.rmtree(project_dir, ignore_errors=True)
+
+
+def verify_java_compile(*, keep_fixture: bool = False) -> int:
+    """Render and compile the fixture, retaining it only when requested or on failure."""
+    maven = shutil.which("mvn")
+    if maven is None:
+        print("Maven executable 'mvn' was not found on PATH")
+        return 1
+
+    project_dir = Path(tempfile.mkdtemp(prefix="dbjavagenix-java-compile-"))
+    compile_succeeded = False
+    try:
+        rendered_files = render_fixture(project_dir)
+        command = build_maven_command(maven)
+        print(f"Rendered {len(rendered_files)} sb35-java21 files to {project_dir}", flush=True)
+        print("$ " + " ".join(command), flush=True)
+        result = subprocess.run(command, cwd=project_dir, text=True, check=False)
+        if result.returncode != 0:
+            print("Java compile failed")
+            return result.returncode
+        compile_succeeded = True
+        print("Generated Java compile smoke passed")
+        return 0
+    finally:
+        cleanup_fixture(
+            project_dir,
+            keep_fixture=keep_fixture,
+            compile_succeeded=compile_succeeded,
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--keep-fixture",
+        action="store_true",
+        help="Keep the generated temporary Maven project after a successful compile.",
+    )
+    args = parser.parse_args()
+    return verify_java_compile(keep_fixture=args.keep_fixture)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_java_compile_smoke.py
+++ b/tests/unit/test_java_compile_smoke.py
@@ -1,0 +1,63 @@
+"""Unit coverage for the generated Java compile fixture."""
+
+import runpy
+import xml.etree.ElementTree as element_tree
+from pathlib import Path
+
+
+_SCRIPT = runpy.run_path(str(Path(__file__).parents[2] / "scripts" / "verify_java_compile.py"))
+CONTEXT = _SCRIPT["CONTEXT"]
+POM = _SCRIPT["POM"]
+TEMPLATES = _SCRIPT["TEMPLATES"]
+build_maven_command = _SCRIPT["build_maven_command"]
+cleanup_fixture = _SCRIPT["cleanup_fixture"]
+render_fixture = _SCRIPT["render_fixture"]
+
+
+def test_rendered_fixture_contains_every_java_layer(tmp_path):
+    files = render_fixture(tmp_path)
+
+    assert len(files) == len(TEMPLATES) == 6
+    assert {path.name for path in files} == {
+        "Invoice.java",
+        "InvoiceDao.java",
+        "InvoiceDTO.java",
+        "InvoiceService.java",
+        "InvoiceServiceImpl.java",
+        "InvoiceController.java",
+    }
+    for (_, package_key, _), path in zip(TEMPLATES, files, strict=True):
+        rendered = path.read_text(encoding="utf-8")
+        assert "{{" not in rendered
+        assert "}}" not in rendered
+        assert f"package {CONTEXT[package_key]};" in rendered
+
+
+def test_fixture_pom_locks_java_and_spring_boot_versions():
+    namespace = {"m": "http://maven.apache.org/POM/4.0.0"}
+    root = element_tree.fromstring(POM)
+
+    assert root.findtext("m:parent/m:version", namespaces=namespace) == "3.5.5"
+    assert root.findtext("m:properties/m:java.version", namespaces=namespace) == "21"
+
+
+def test_maven_command_is_non_interactive_compile_only():
+    command = build_maven_command("mvn")
+
+    assert command == ["mvn", "-B", "-ntp", "-DskipTests", "clean", "compile"]
+
+
+def test_cleanup_removes_only_successful_default_fixture(tmp_path):
+    successful_fixture = tmp_path / "successful"
+    failed_fixture = tmp_path / "failed"
+    requested_fixture = tmp_path / "requested"
+    for fixture in (successful_fixture, failed_fixture, requested_fixture):
+        fixture.mkdir()
+
+    cleanup_fixture(successful_fixture, keep_fixture=False, compile_succeeded=True)
+    cleanup_fixture(failed_fixture, keep_fixture=False, compile_succeeded=False)
+    cleanup_fixture(requested_fixture, keep_fixture=True, compile_succeeded=True)
+
+    assert not successful_fixture.exists()
+    assert failed_fixture.exists()
+    assert requested_fixture.exists()


### PR DESCRIPTION
## 关联 Issue

Closes #122

## 背景（Situation）

现有 `scripts/verify_templates.py` 能验证 Mustache 模板可被渲染且不存在未展开标签，但不能发现由导入、注解处理器、Jakarta API、Spring Data JPA 或 SpringDoc 依赖组合导致的 Java 编译错误。`sb35-java21` 是当前面向 Spring Boot 3.5 与 Java 21 的模板组，需要一条可复现的编译级门禁。

本 PR 不把固定样例扩展为真实数据库、应用启动或 HTTP 行为测试；这些属于后续集成测试范围。

## 任务（Task）

- 用代表性上下文渲染 `sb35-java21` 的 entity、dao、dto、service、serviceImpl、controller 六层代码。
- 用 Java 21 与 Maven 编译渲染结果，并在 CI 中把结果纳入汇总必需状态。
- 为渲染范围、版本约束、Maven 命令和临时目录清理行为添加单元测试与本地开发命令。

## 行动（Action）

- 新增 `scripts/verify_java_compile.py`：构造 `Invoice` 固定 fixture，覆盖 `Long` 主键、非空 `BigDecimal`、可空 `OffsetDateTime`、DTO、Lombok、Jakarta Validation/Persistence 与 SpringDoc 分支。
- 脚本写入独立临时 Maven 项目，使用 Spring Boot `3.5.5`、Java `21`、Spring Data JPA、Validation、SpringDoc `2.8.9` 和 Lombok，执行 `mvn -B -ntp -DskipTests clean compile`。
- 成功时删除临时工程；编译失败或传入 `--keep-fixture` 时保留路径供诊断。新增 4 个单元测试覆盖源文件层级、版本锁定、非交互 Maven 命令和上述清理分支。
- CI 新增 `java-compile` job，使用 `actions/setup-java@v5` 安装 Temurin 21；`ci-success` 依赖该 job。开发文档补充相同本地命令。

## 验证（Verification）

本地环境：Windows 11 x86_64、Temurin `21.0.12.1`、Maven `3.9.16`。以下命令均在提交 `bc2801c` 的工作树执行：

```powershell
$env:PYTHONPATH='src'; python -m pytest tests/unit/ -q
# 664 passed in 5.42s

$env:PYTHONPATH='src'; python scripts/verify_templates.py
# 26 个 Java 模板均成功渲染

$env:PYTHONPATH='src'; python scripts/verify_java_compile.py
# Compiling 6 source files with javac [release 21]
# BUILD SUCCESS

uv run --isolated --python 3.12 --with-editable . python scripts/verify_java_compile.py
# 安装项目的 53 个运行时依赖后，6 个源文件 BUILD SUCCESS（2.153s）

python -m ruff check scripts/verify_java_compile.py tests/unit/test_java_compile_smoke.py
python -m ruff format --check scripts/verify_java_compile.py tests/unit/test_java_compile_smoke.py
git diff --check
# 均通过
```

CI YAML 另以 `yaml.safe_load` 解析成功。最终的本机 compile run 也确认成功后的 fixture 路径不存在，符合默认清理约定。

## 实验与证据（Evidence）

| 实验 | 输入与方法 | 结果 | 可证明的边界 |
| --- | --- | --- | --- |
| E1：编译级 smoke | 固定 `Invoice` 上下文渲染六个 `sb35-java21` 模板；在临时 Maven 项目运行 batch compile | `javac [release 21]` 编译 6 个源文件，`BUILD SUCCESS` | 可证明该代表性分支的源代码和所列依赖可在 Java 21 编译；不代表所有表结构或配置分支 |
| E2：CI 同版本复验 | Python 3.12 隔离环境安装 editable 项目后执行相同脚本 | 安装 53 个运行时依赖，Maven 编译成功 | 覆盖新 CI job 的 Python 主版本与项目依赖安装路径；本机操作系统仍不同于 GitHub Ubuntu runner |
| E3：临时诊断策略 | 单元测试分别执行成功默认、失败默认、显式保留三条清理分支 | 4 个 smoke 单元测试通过；成功 fixture 物理路径检查为 `False` | 可证明脚本不会因成功编译留下 fixture；不模拟 Maven 下载失败或磁盘空间不足 |

没有测量性能指标，也没有运行真实数据库 DDL、CRUD、Spring Boot 应用启动或 HTTP 接口。现有 Testcontainers 集成套件保持独立，未据此宣称数据库兼容性提升。

## 兼容性、风险与回滚

- 兼容性：生成器模板和用户生成代码的公开 API 未改动；仅增加开发验证脚本、测试、文档和 CI job。
- 风险：新 job 会增加一次 Maven 依赖解析和编译时间；网络或 Maven Central 临时不可用会使 required CI 失败。`setup-uv` 与 GitHub Actions 缓存可减少重复安装，但不消除外部仓库可用性风险。
- 回滚：合并后如该门禁阻塞仓库，可 `git revert bc2801c`，撤回脚本、测试、文档和 `java-compile` required dependency，不涉及数据库迁移或用户数据回滚。
- 后续：在独立 Issue 中增加真实数据库生成样例或 Spring 上下文启动验证前，应先明确支持的模板组合与所需运行时依赖，避免把本 compile smoke 的结论扩大为运行时保证。