### PR TITLE
:bug: fix(mcp): 阻止服务启动日志污染 stdout

### DIFF
--- a/src/dbjavagenix/cli.py
+++ b/src/dbjavagenix/cli.py
@@ -73,20 +73,23 @@ def _codegen_result_succeeded(result: Optional[dict]) -> bool:
     return bool(result.get("success") or "Code Generation Complete:" in result.get("error", ""))
 
 
-def show_ascii_icon():
+def show_ascii_icon(output: Optional[Console] = None):
     """Display the DBJavaGenix ASCII icon"""
+    target_console = output if output is not None else console
     icon_path = Path(__file__).parent.parent / "config" / "ASCII_ICON.txt"
     try:
         if icon_path.exists():
             with open(icon_path, "r", encoding="utf-8") as f:
                 icon_content = f.read()
-            console.print(f"[bold cyan]{icon_content}[/bold cyan]")
-            console.print("[dim]AI-Enhanced Java Code Generator v0.1.0[/dim]")
-            console.print("[dim]Author: ZXP | Email: 2638265504@qq.com[/dim]\n")
+            target_console.print(f"[bold cyan]{icon_content}[/bold cyan]")
+            target_console.print("[dim]AI-Enhanced Java Code Generator v0.1.0[/dim]")
+            target_console.print("[dim]Author: ZXP | Email: 2638265504@qq.com[/dim]\n")
         else:
-            console.print("[bold cyan]DBJavaGenix - AI-Enhanced Java Code Generator[/bold cyan]")
+            target_console.print(
+                "[bold cyan]DBJavaGenix - AI-Enhanced Java Code Generator[/bold cyan]"
+            )
     except Exception:
-        console.print("[bold cyan]DBJavaGenix - AI-Enhanced Java Code Generator[/bold cyan]")
+        target_console.print("[bold cyan]DBJavaGenix - AI-Enhanced Java Code Generator[/bold cyan]")
 
 
 @app.command()
@@ -756,23 +759,26 @@ def server(
     ),
 ):
     """Start MCP server for LLM integration"""
-    show_ascii_icon()
+    server_console = Console(stderr=True)
+    show_ascii_icon(server_console)
     try:
-        console.print("[bold blue]Starting DBJavaGenix MCP Server...[/bold blue]")
+        server_console.print("[bold blue]Starting DBJavaGenix MCP Server...[/bold blue]")
 
         # MCP服务器无需配置文件即可启动
         if config_path:
-            console.print(f"[dim]Using configuration file: {config_path}[/dim]")
+            server_console.print(f"[dim]Using configuration file: {config_path}[/dim]")
             try:
                 config_manager = ConfigManager(config_path)
                 config = config_manager.load_config()
-                console.print("[green]✓[/green] Configuration loaded")
+                server_console.print("[green]✓[/green] Configuration loaded")
             except Exception as e:
-                console.print(f"[yellow]Warning: Failed to load config file: {e}[/yellow]")
-                console.print("[yellow]Continuing with dynamic configuration mode...[/yellow]")
+                server_console.print(f"[yellow]Warning: Failed to load config file: {e}[/yellow]")
+                server_console.print(
+                    "[yellow]Continuing with dynamic configuration mode...[/yellow]"
+                )
         else:
-            console.print("[cyan]Running in zero-configuration mode![/cyan]")
-            console.print("[dim]All configuration will be provided dynamically by LLM[/dim]")
+            server_console.print("[cyan]Running in zero-configuration mode![/cyan]")
+            server_console.print("[dim]All configuration will be provided dynamically by LLM[/dim]")
 
         # Dynamically compute tool counts and show names for clarity
         try:
@@ -782,38 +788,40 @@ def server(
             spring_tools = get_springboot_project_tools()
             total = len(conn_tools) + len(table_tools) + len(code_tools) + len(spring_tools)
 
-            console.print("\n[cyan]MCP Server Capabilities:[/cyan]")
-            console.print(f"- Database connection tools ({len(conn_tools)} tools)")
-            console.print(f"- Table structure analysis tools ({len(table_tools)} tools)")
-            console.print(f"- Java code generation tools ({len(code_tools)} tools)")
-            console.print(f"- Spring Boot project tools ({len(spring_tools)} tools)")
+            server_console.print("\n[cyan]MCP Server Capabilities:[/cyan]")
+            server_console.print(f"- Database connection tools ({len(conn_tools)} tools)")
+            server_console.print(f"- Table structure analysis tools ({len(table_tools)} tools)")
+            server_console.print(f"- Java code generation tools ({len(code_tools)} tools)")
+            server_console.print(f"- Spring Boot project tools ({len(spring_tools)} tools)")
             # List Spring Boot tools explicitly (includes springboot_read_config)
             spring_names = ", ".join(t.name for t in spring_tools)
-            console.print(f"  [dim]Spring Boot: {spring_names}[/dim]")
-            console.print(f"\n[green]Total: {total} MCP tools available[/green]")
+            server_console.print(f"  [dim]Spring Boot: {spring_names}[/dim]")
+            server_console.print(f"\n[green]Total: {total} MCP tools available[/green]")
         except Exception:
             # Fallback to a generic message if dynamic loading fails
-            console.print("\n[cyan]MCP Server Capabilities:[/cyan]")
-            console.print("- Database connection tools")
-            console.print("- Table structure analysis tools")
-            console.print("- Java code generation tools")
-            console.print("- Spring Boot project tools")
+            server_console.print("\n[cyan]MCP Server Capabilities:[/cyan]")
+            server_console.print("- Database connection tools")
+            server_console.print("- Table structure analysis tools")
+            server_console.print("- Java code generation tools")
+            server_console.print("- Spring Boot project tools")
 
-        console.print("\n[bold green]Starting MCP server in stdio mode...[/bold green]")
-        console.print("[dim]Server ready for LLM integration (no manual interaction needed)[/dim]")
-        console.print("[dim]Press Ctrl+C to stop the server[/dim]")
+        server_console.print("\n[bold green]Starting MCP server in stdio mode...[/bold green]")
+        server_console.print(
+            "[dim]Server ready for LLM integration (no manual interaction needed)[/dim]"
+        )
+        server_console.print("[dim]Press Ctrl+C to stop the server[/dim]")
 
         # 启动 MCP 服务器
         try:
             asyncio.run(run_server())
         except KeyboardInterrupt:
-            console.print("\n[yellow]Shutting down server...[/yellow]")
+            server_console.print("\n[yellow]Shutting down server...[/yellow]")
         except Exception as e:
-            console.print(f"\n[red]Server error: {e}[/red]")
+            server_console.print(f"\n[red]Server error: {e}[/red]")
             raise typer.Exit(1)
 
     except Exception as e:
-        console.print(f"[red]Unexpected error: {e}[/red]")
+        server_console.print(f"[red]Unexpected error: {e}[/red]")
         raise typer.Exit(1)
 
 

--- a/tests/unit/test_mcp_stdio_output.py
+++ b/tests/unit/test_mcp_stdio_output.py
@@ -1,0 +1,48 @@
+"""Regression tests for the MCP server process output boundary."""
+
+import pytest
+import typer
+
+from dbjavagenix import cli
+
+
+def test_server_startup_diagnostics_use_stderr(monkeypatch, capsys):
+    async def complete_server():
+        return None
+
+    monkeypatch.setattr(cli, "run_server", complete_server)
+
+    cli.server()
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "Starting DBJavaGenix MCP Server" in captured.err
+    assert "Starting MCP server in stdio mode" in captured.err
+
+
+def test_server_failure_diagnostics_use_stderr(monkeypatch, capsys):
+    async def failing_server():
+        raise RuntimeError("controlled failure")
+
+    monkeypatch.setattr(cli, "run_server", failing_server)
+
+    with pytest.raises(typer.Exit) as error:
+        cli.server()
+
+    captured = capsys.readouterr()
+    assert error.value.exit_code == 1
+    assert captured.out == ""
+    assert "Server error: controlled failure" in captured.err
+
+
+def test_server_interrupt_diagnostics_use_stderr(monkeypatch, capsys):
+    async def interrupted_server():
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(cli, "run_server", interrupted_server)
+
+    cli.server()
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "Shutting down server" in captured.err


### PR DESCRIPTION
Closes #127

## 关联 Issue

- #127 `:bug: fix(mcp): 阻止服务启动日志污染 stdout`
- 发现来源：#125 的 npm tarball 安装后 wrapper smoke。该 smoke 捕获到 Python 后端在 MCP JSON-RPC stdio transport 就绪前向 stdout 写入 Rich 横幅与启动诊断。

## 背景（Situation）

`index.js` 自身已经将 wrapper 诊断写入 stderr，但它以继承的标准流启动 Python 后端。`dbjavagenix server` 使用默认 Rich `Console()`，会在 `asyncio.run(run_server())` 之前把横幅、零配置提示、能力列表，以及错误和关闭信息写到 stdout。

对于 MCP stdio transport，stdout 是 JSON-RPC 消息通道；任何普通文本都可能被客户端当作非法协议帧。该问题不依赖数据库连接或业务请求即可触发。

## 任务（Task）

- server 模式下将所有人类可读诊断路由至 stderr；stdout 仅保留给 MCP transport。
- 保持 version、init、generate、tables 等交互式 CLI 命令的既有 stdout 行为。
- 增加可捕获 stdout/stderr 的回归测试，覆盖正常、异常和中断路径。

## 行动（Action）

- 为 `show_ascii_icon` 增加可选 `Console` 参数，默认仍使用原有全局 stdout console。
- `server()` 创建 `Console(stderr=True)`，将启动、配置加载、工具能力、就绪、关闭和错误诊断都写入该 console。
- 新增 `tests/unit/test_mcp_stdio_output.py`，以 stubbed `run_server` 精确断言每条路径的 stdout 为空、stderr 含对应受控诊断。

提交：`a1dfe3e :bug: fix(mcp): 阻止服务启动日志污染 stdout`

## 验证（Verification）

Windows 11 x86_64，本地 Python 3.10.1 环境执行：

```text
PYTHONPATH=src python -m pytest tests/unit/ -q
667 passed in 5.31s

python -m ruff check src/dbjavagenix/cli.py tests/unit/test_mcp_stdio_output.py
python -m ruff format --check src/dbjavagenix/cli.py tests/unit/test_mcp_stdio_output.py

git -c core.whitespace=cr-at-eol diff --check
```

说明：`cli.py` 保持仓库既有 CRLF 行尾；Windows 本地 Git 的默认 whitespace 设置会将合法 CRLF 误报为尾随空白，因此 diff 检查显式允许 `cr-at-eol`。Linux CI 的格式门禁仍使用普通 LF checkout。

## 实验与证据（Evidence）

| 路径 | `run_server` 行为 | stdout 断言 | stderr 断言 |
| --- | --- | --- | --- |
| 正常启动 | 正常返回 | 严格为空 | 含 `Starting DBJavaGenix MCP Server` 与 `Starting MCP server in stdio mode` |
| 服务异常 | 抛出 `RuntimeError("controlled failure")` | 严格为空 | 含 `Server error: controlled failure`，并以 exit code 1 退出 |
| 用户中断 | 抛出 `KeyboardInterrupt` | 严格为空 | 含 `Shutting down server` |

测试覆盖 Python server 函数内 transport 启动前、异常和中断时的文本输出边界。尚未在本 PR 中执行真实 MCP 客户端与数据库的端到端会话；#125 的 tarball wrapper smoke 将在该协议修复合并后恢复并作为独立发布边界验证。

## 兼容性、风险与回滚

不改 JSON-RPC payload、工具注册、数据库连接、配置解析或 Node wrapper 的 stdio 继承关系。唯一可见变化是 server 的人类可读诊断从 stdout 移到 stderr，符合 MCP stdio 协议用途；交互式命令仍沿用 stdout。

风险在于外部脚本若错误地解析 server stdout 的启动文案会失去该文案，但这些文案本不属于协议输出。回滚只需恢复 `server()` 的局部 stderr console 路由并删除相应测试；不涉及数据迁移、持久化状态或用户数据。