### PR TITLE
:wrench: chore(repository): 统一 Dockerfile 主页元数据

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     UV_LINK_MODE=copy \
     UV_COMPILE_BYTECODE=1
 
-# 编译某些原生扩展(如 psycopg2-binary 的依赖)需要的工具,
-# 在 builder 阶段一次性装上,运行镜像不带。
+# builder 阶段只保留解析和安装依赖所需的最小系统组件；
+# runtime 阶段不继承这些 apt 层，只复制已构建的虚拟环境和源码。
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Closes #129

## 关联 Issue

- #129 `:wrench: chore(repository): 统一 Dockerfile 主页元数据`
- 目标是以可审计、格式合规的当前提交替换仓库主页中 `Dockerfile` 的历史长标题；不重写历史提交。

## 背景（Situation）

GitHub 仓库首页按路径展示最近一次提交。`Dockerfile` 仍显示 `build(p1.5): Dockerize + docker build 进 CI`，而 #126 已将其它主页残留文件刷新为 Gitmoji + Conventional Commits 格式。本文件 builder 注释还将实际仅安装 `curl ca-certificates` 的命令描述为“编译原生扩展工具”，与当前 Docker 层不一致。

## 任务（Task）

- 刷新 `Dockerfile` 的主页最后提交元数据。
- 使 builder 注释准确描述最小系统组件及 runtime 复制边界。
- 保持 Docker build context、基础镜像、依赖安装、非 root 用户和 MCP stdio ENTRYPOINT 完全不变。

## 行动（Action）

仅更新 `Dockerfile` 中 `apt-get install` 前两行说明：builder 保留解析/安装依赖所需的最小系统组件；runtime 不继承 builder apt 层，只复制已构建虚拟环境与源码。

提交：`4937cec :wrench: chore(repository): 统一 Dockerfile 主页元数据`

## 验证（Verification）

本地执行：

```text
git diff --check
```

结果：无空白错误；差异严格限于 `Dockerfile` 的两行注释。没有改变 Docker 指令、镜像层、命令、环境变量或入口，因此未重复本地构建镜像。PR CI 的 `Docker image smoke test` 会重新执行完整 build、Python import 以及非 root runtime 检查；结果以 CI 完成后的记录为准。

## 实验与证据（Evidence）

| 核对项 | 变更前 | 变更后 | 结论 |
| --- | --- | --- | --- |
| `RUN apt-get install` | `curl ca-certificates` | 未变 | 不影响依赖层内容 |
| 构建阶段说明 | 声称编译原生扩展工具 | 描述最小系统组件与层边界 | 与实际指令一致 |
| runtime `COPY` / `USER` / `ENTRYPOINT` | 现有实现 | 未变 | 不改变运行身份或 MCP 启动方式 |
| 路径最后提交标题 | 历史 `build(p1.5)` 长标题 | 本 PR 合并后为规范维护标题 | 解决主页元数据残留 |

本 PR 不执行数据库迁移、不触及镜像发布，也不主张性能、镜像体积或运行时行为发生改善。

## 兼容性、风险与回滚

兼容性影响为零：Dockerfile 的有效指令未变。唯一风险是说明文字翻译/语义不准确，已通过逐行核对对应 `RUN` 和 runtime `COPY` 指令缓解，另由既有 Docker CI smoke 兜底。回滚为 revert `4937cec`；不会删除镜像、修改 registry、影响数据库或用户数据。