### PR TITLE
:lock: security(package): 收紧 npm 发布文件边界

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,6 +212,24 @@ jobs:
           mvn --version
           uv run python scripts/verify_java_compile.py
 
+  npm-package:
+    name: NPM package contract
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Verify packed wrapper contract
+        run: |
+          node --version
+          npm --version
+          npm run verify:package
+
   docker:
     name: Docker image smoke test
     runs-on: ubuntu-latest
@@ -272,7 +290,7 @@ jobs:
   ci-success:
     name: Required CI status
     if: always()
-    needs: [metadata, quality, format, integration, templates, java-compile, docker, package]
+    needs: [metadata, quality, format, integration, templates, java-compile, npm-package, docker, package]
     runs-on: ubuntu-latest
     steps:
       - name: Fail when any required job failed or was cancelled

--- a/docs/development.md
+++ b/docs/development.md
@@ -75,6 +75,9 @@ PYTHONPATH=src python scripts/verify_mcp_apps.py
 
 # 渲染并用 Java 21 / Maven 编译 sb35-java21 固定 fixture
 PYTHONPATH=src python scripts/verify_java_compile.py
+
+# 验证 npm tarball 只包含运行时文件，并保留 MCP stdout 边界
+npm run verify:package
 ```
 
 ### 6. 验证安装

--- a/package.json
+++ b/package.json
@@ -7,8 +7,17 @@
     "dbjavagenix-mcp": "./index.js"
   },
   "scripts": {
-    "start": "node index.js"
+    "start": "node index.js",
+    "verify:package": "node scripts/verify_npm_package.js"
   },
+  "files": [
+    "index.js",
+    "src/dbjavagenix/**/*.py",
+    "src/dbjavagenix/**/*.mustache",
+    "src/dbjavagenix/config/*.yaml",
+    "pyproject.toml",
+    "requirements.txt"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ZhaoXingPeng/DBJavaGenix.git"

--- a/scripts/verify_npm_package.js
+++ b/scripts/verify_npm_package.js
@@ -1,0 +1,142 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const { execFileSync, spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const ROOT = path.resolve(__dirname, "..");
+const PACKAGE_NAME = "dbjavagenix-mcp-server";
+const REQUIRED_PATHS = [
+  "index.js",
+  "package.json",
+  "pyproject.toml",
+  "requirements.txt",
+  "README.md",
+  "LICENSE",
+  "src/dbjavagenix/cli.py",
+  "src/dbjavagenix/config/default_type_mapping.yaml",
+  "src/dbjavagenix/templates/java/sb35-java21/entity.mustache",
+];
+const FORBIDDEN_PREFIXES = [
+  ".claude/",
+  ".github/",
+  ".idea/",
+  ".vscode/",
+  "docs/",
+  "htmlcov/",
+  "iteration-plan/",
+  "src/dbjavagenix.egg-info/",
+  "tests/",
+];
+const FORBIDDEN_SUFFIXES = [".pyc"];
+
+function npmCommand() {
+  return process.platform === "win32" ? "npm.cmd" : "npm";
+}
+
+function runNpm(args, cwd = ROOT) {
+  try {
+    return execFileSync(npmCommand(), args, {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      shell: process.platform === "win32",
+    });
+  } catch (error) {
+    const stdout = error.stdout ? error.stdout.toString() : "";
+    const stderr = error.stderr ? error.stderr.toString() : "";
+    throw new Error(`npm ${args.join(" ")} failed:\n${stdout}${stderr}`, { cause: error });
+  }
+}
+
+function readManifest(args) {
+  const output = runNpm(args);
+  const manifest = JSON.parse(output);
+  assert.equal(manifest.length, 1, "npm pack must return exactly one manifest entry");
+  return manifest[0];
+}
+
+function assertManifest(manifest) {
+  const paths = new Set(manifest.files.map((file) => file.path));
+  const missing = REQUIRED_PATHS.filter((file) => !paths.has(file));
+  assert.deepEqual(missing, [], `npm package is missing runtime files: ${missing.join(", ")}`);
+
+  const forbidden = [...paths].filter((file) =>
+    FORBIDDEN_PREFIXES.some((prefix) => file.startsWith(prefix)) ||
+    FORBIDDEN_SUFFIXES.some((suffix) => file.endsWith(suffix)),
+  );
+  assert.deepEqual(forbidden, [], `npm package contains forbidden files: ${forbidden.join(", ")}`);
+}
+
+function replaceInstalledBackend(packageRoot, markerPath) {
+  const backendRoot = path.join(packageRoot, "src", "dbjavagenix");
+  fs.writeFileSync(path.join(backendRoot, "__init__.py"), "# package smoke backend\n", "utf8");
+  fs.writeFileSync(
+    path.join(backendRoot, "cli.py"),
+    [
+      "import os",
+      "import sys",
+      "from pathlib import Path",
+      "",
+      'Path(os.environ["DBJAVAGENIX_PACKAGE_SMOKE_MARKER"]).write_text("started\\n", encoding="utf-8")',
+      'print("package smoke backend started", file=sys.stderr)',
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+}
+
+function verifyInstalledWrapper(archivePath, temporaryRoot) {
+  const installRoot = path.join(temporaryRoot, "installed");
+  runNpm(["install", "--ignore-scripts", "--no-audit", "--no-fund", "--prefix", installRoot, archivePath]);
+
+  const packageRoot = path.join(installRoot, "node_modules", PACKAGE_NAME);
+  const entryPoint = path.join(packageRoot, "index.js");
+  assert.ok(fs.existsSync(path.join(packageRoot, "src", "dbjavagenix", "cli.py")));
+
+  const backendMarker = path.join(temporaryRoot, "package-smoke-backend.txt");
+  replaceInstalledBackend(packageRoot, backendMarker);
+  const result = spawnSync(process.execPath, [entryPoint], {
+    cwd: packageRoot,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      DBJAVAGENIX_PACKAGE_SMOKE_MARKER: backendMarker,
+    },
+  });
+
+  assert.equal(result.status, 0, `installed wrapper failed: ${result.stderr}`);
+  assert.ok(fs.existsSync(backendMarker), "wrapper did not run the installed Python backend");
+  assert.equal(result.stdout, "", "wrapper must reserve stdout for MCP JSON-RPC");
+  assert.match(result.stderr, /Starting Python backend in stdio mode/);
+  assert.match(result.stderr, /package smoke backend started/);
+}
+
+function main() {
+  const dryRunManifest = readManifest(["pack", "--dry-run", "--json"]);
+  assertManifest(dryRunManifest);
+
+  const temporaryRoot = fs.mkdtempSync(path.join(os.tmpdir(), "dbjavagenix-npm-package-"));
+  try {
+    const packedManifest = readManifest([
+      "pack",
+      "--json",
+      "--pack-destination",
+      temporaryRoot,
+    ]);
+    assertManifest(packedManifest);
+    const archivePath = path.join(temporaryRoot, packedManifest.filename);
+    assert.ok(fs.existsSync(archivePath), `npm archive was not created: ${archivePath}`);
+    verifyInstalledWrapper(archivePath, temporaryRoot);
+    console.log(
+      `NPM package contract valid: ${dryRunManifest.entryCount} files, ` +
+        `${dryRunManifest.unpackedSize} unpacked bytes`,
+    );
+  } finally {
+    fs.rmSync(temporaryRoot, { recursive: true, force: true });
+  }
+}
+
+main();


### PR DESCRIPTION
## 关联 Issue

Closes #125

## 背景（Situation）

Node wrapper 原先没有显式 npm `files` 白名单。默认打包会随工作树状态带入测试、CI、开发文档、IDE 元数据、bytecode、egg-info 甚至本地配置，扩大意外发布面。初版目录白名单实验还证明递归目录会带入不应发布的缓存和构建元数据。

## 任务（Task）

为 npm tarball 建立可重复的最小发布文件契约：保留 wrapper 所需 Python 源码、模板、配置、依赖描述、README、LICENSE 和运行时元数据；拒绝本地/开发路径，并验证安装后 wrapper 的 stdout/stderr 边界。

## 行动（Action）

- 在 `package.json` 使用精确 `files` 白名单，避免依赖工作树黑名单。
- 新增 `scripts/verify_npm_package.js`，同时检查 dry-run manifest、真实 tarball、必需/禁止路径和临时安装 wrapper smoke。
- 增加 Node 22 `NPM package contract` CI job，并在开发指南记录命令。
- 复用 #128 已修正的 server stdout 边界；不改变 Python API 或 Docker 发布物。
- 没有做什么：不发布 registry、不修改项目版本、不读取或公开本地配置内容、不改变数据库行为。

## 验证（Verification）

环境：Windows 11 x86_64；Node 22.17.0；Python 3.10.1。

- `node --check scripts/verify_npm_package.js`：通过。
- `npm run verify:package`：`NPM package contract valid: 98 files, 739316 unpacked bytes`。
- `PYTHONPATH=src python -m pytest tests/unit/ -q`：667 passed。
- `python -m ruff check src/ tests/ scripts/`：通过。
- `npm pack --dry-run --json` 与真实 tarball 安装 smoke：manifest、wrapper 路径和 stdout 空值断言通过。

## 实验与证据（Evidence）

| 阶段 | 输入与实际结果 | 结论 |
| --- | --- | --- |
| 原始工作树 | 284 个文件，其中 170 个为禁止路径 | 默认 npm 发布面过宽 |
| 目录白名单草案 | 233 个文件，仍含 `.pyc` 和 `src/dbjavagenix.egg-info/` | 目录级白名单不足够严格 |
| 精确白名单 | 98 个文件、739316 bytes；必需路径存在、禁止路径为零 | tarball manifest 符合契约 |
| 安装后 smoke | 原始 `src/dbjavagenix/cli.py` 存在；临时 marker backend 被 wrapper 调起；stdout 严格为空、stderr 有诊断 | 安装路径和协议边界可重放 |

临时 backend 只替换安装副本，不改 tarball，不执行数据库工具，也不代表真实 MCP 客户端会话。

## 兼容性、风险与回滚

- 公共 API / 数据格式 / 迁移：`dbjavagenix-mcp` bin、`index.js` 和 Python runtime 路径保持；只移除不应作为运行时依赖的包内容。
- 风险与已知限制：新增运行时资源必须同时加入白名单和断言；未执行 registry 发布或真实客户端互操作。
- 回滚：revert `33c40cb` 可恢复旧发布清单，不涉及数据库或用户数据。
- 后续 Issue：若发现安装后缺少动态资源，补充精确白名单和回归测试后再发布。