### PR TITLE
:bug: fix(codegen): 修复真实数据库模板生成链路

### DIFF
--- a/src/dbjavagenix/database/codegen_tools.py
+++ b/src/dbjavagenix/database/codegen_tools.py
@@ -381,7 +381,7 @@ class CodegenGenerator:
         template_base_path = Path(__file__).parent.parent / "templates" / "java"
 
         if category == "common":
-            template_path = template_base_path / template_file
+            template_path = template_base_path / "common" / template_file
         else:
             template_path = template_base_path / category / template_file
 

--- a/tests/integration/test_real_metadata_contract.py
+++ b/tests/integration/test_real_metadata_contract.py
@@ -13,6 +13,7 @@ from typing import Any
 import pytest
 
 from dbjavagenix.core.models import DatabaseConfig, DatabaseType
+from dbjavagenix.database.codegen_tools import CodegenAnalyzer, CodegenGenerator
 from dbjavagenix.database.connection_manager import ConnectionManager
 from dbjavagenix.database.introspection import DatabaseIntrospector
 
@@ -64,6 +65,57 @@ def _assert_child_metadata_contract(metadata: dict[str, Any], expected_schema: s
         ("region_code", 2),
     ]
     assert all(index["unique"] is False for index in composite_index)
+
+
+async def _assert_real_codegen_contract(
+    fixture: dict[str, Any], expected_schema: str
+) -> dict[str, Any]:
+    """Exercise analysis and rendering with metadata returned by a live database."""
+    analyzer = CodegenAnalyzer(fixture["introspector"].connection_manager)
+    analysis = await analyzer.analyze_table_for_codegen(
+        fixture["connection_id"], CHILD_TABLE, schema=expected_schema
+    )
+
+    assert analysis["table_name"] == CHILD_TABLE
+    assert analysis["table_info"]["schema"] == expected_schema
+    columns = {column["name"]: column for column in analysis["table_info"]["columns"]}
+    assert {"id", "parent_id", "region_code", "created_at"} <= set(columns)
+    assert columns["id"]["primary_key"] is True
+    assert columns["id"]["auto_increment"] is True
+    assert columns["parent_id"]["nullable"] is False
+    assert analysis["relationships"]["primary_keys"] == ["id"]
+    assert analysis["relationships"]["foreign_keys"] == [
+        {
+            "constraint_name": "contract_child_parent_fk",
+            "column_name": "parent_id",
+            "referenced_table": PARENT_TABLE,
+            "referenced_column": "id",
+        }
+    ]
+    assert analysis["template_context"]["tableName"] == CHILD_TABLE
+    assert {column["name"] for column in analysis["template_context"]["columns"]} >= {
+        "id",
+        "parent_id",
+        "region_code",
+        "created_at",
+    }
+
+    generated = await CodegenGenerator().generate_code(
+        analysis, template_category="MybatisPlus-Mixed"
+    )
+
+    assert generated["generation_statistics"] == {
+        "total_files": 7,
+        "success_files": 7,
+        "error_files": 0,
+    }
+    assert all("error" not in file for file in generated["generated_code"].values())
+    entity = generated["generated_code"]["entity.mustache"]["code"]
+    assert "public class ContractChild" in entity
+    assert "private Long id;" in entity
+    assert "private Long parentId;" in entity
+
+    return analysis
 
 
 @pytest.fixture
@@ -192,3 +244,22 @@ def test_postgresql_describe_table_scopes_real_metadata_to_schema(
         ]
         == fixture["schema"]
     )
+
+
+@pytest.mark.asyncio
+async def test_mysql_real_metadata_reaches_template_generation(
+    mysql_contract_metadata: dict[str, Any],
+) -> None:
+    await _assert_real_codegen_contract(mysql_contract_metadata, mysql_contract_metadata["schema"])
+
+
+@pytest.mark.asyncio
+async def test_postgresql_real_metadata_reaches_schema_scoped_template_generation(
+    postgres_contract_metadata: dict[str, Any],
+) -> None:
+    fixture = postgres_contract_metadata
+    analysis = await _assert_real_codegen_contract(fixture, fixture["schema"])
+
+    # ``public.contract_child`` only has a UUID id; these fields prove the
+    # non-public relation was analyzed and passed to the renderer.
+    assert {column["name"] for column in analysis["table_info"]["columns"]} != {"id"}

--- a/tests/unit/test_codegen_analyzer.py
+++ b/tests/unit/test_codegen_analyzer.py
@@ -257,3 +257,13 @@ async def test_generator_does_not_require_unused_table_info(monkeypatch):
         "success_files": 6,
         "error_files": 0,
     }
+
+
+@pytest.mark.asyncio
+async def test_generator_loads_mybatis_plus_config_from_common_templates():
+    code = await CodegenGenerator()._render_template(
+        "mybatis_plus_config.mustache", {"basePackage": "com.example"}, "common"
+    )
+
+    assert "package com.example.config;" in code
+    assert "class MybatisPlusConfig" in code


### PR DESCRIPTION
## 关联 Issue

Closes #135

## 背景（Situation）

PR #133 已在 MySQL 8.0 和 PostgreSQL 16-alpine 中验证真实元数据归一化，但没有把该数据继续送入 CodegenAnalyzer 与 CodegenGenerator。为填补该空白，本 PR 先增加 live 数据库到内存模板渲染的覆盖；合并前 CI 首次执行随即暴露了旧生成器的公共模板路径缺陷。

## 任务（Task）

在可回收 Testcontainers fixture 上验证真实数据库到生成器的链路，并修复 MyBatis-Plus 一步生成遗漏公共配置模板的问题。

非目标：不新增方言、模板、生产数据库行为或 CI 策略；不把模板渲染成功宣称为 Java/Spring 项目可编译、生产权限兼容或性能结论。

## 行动（Action）

- 3266548：在 tests/integration/test_real_metadata_contract.py 新增共享断言，执行 ConnectionManager -> DatabaseIntrospector -> CodegenAnalyzer -> CodegenGenerator。
- 新断言核对 contract_child 的 schema、关键列、自增/非空属性、主键、外键、模板上下文和 MybatisPlus-Mixed 的 7 个内存文件。
- PostgreSQL 使用 dbjg_contract.contract_child，同时保留仅有 UUID id 的 public.contract_child 反例，证明显式 schema 不会在生成路径丢失。
- e0d2ea2：修复 CodegenGenerator 对 category=common 的查找路径，改为 templates/java/common/具体模板文件，使 mybatis_plus_config.mustache 被实际加载。
- 增加单元回归，直接验证公共 MyBatis-Plus 配置模板按 basePackage 渲染。

## 验证（Verification）

当前 HEAD：e0d2ea2b1d4a6b96354d4302a25591bb3a89a60b

Windows 11 / Python 3.12.12 / uv 0.9.17：

| 命令 | 结果 |
| --- | --- |
| uv run --python 3.12 --extra dev --extra integration python -m pytest tests/unit/ --no-cov -q | 669 passed，8.82s |
| uv run --python 3.12 --extra dev --extra integration python -m pytest tests/integration/test_real_metadata_contract.py --no-docker --no-cov -q | 4 skipped，0.08s，符合显式无 Docker 条件 |
| 同一 MySQL 型别结构的 CodegenGenerator 内存复现 | 修复前 7 total / 6 success / 1 error；修复后 7 total / 7 success / 0 error |
| ruff check 与 ruff format --check（3 个改动文件） | passed，3 files already formatted |
| 全部 Java 模板基线 | 25 个模板全部渲染成功 |

初始 HEAD 3266548 的完整合并前检查中，Python 3.11/3.12/3.13、format、templates、Java compile、npm、Docker 和 Python package 均通过；Database integration tests 失败，Required CI status 因此失败。失败日志与 job 链接见下方证据，未发生合并。

## 实验与证据（Evidence）

初始容器实验实际启动了 mysql:8.0 和 postgres:16-alpine。9 个 integration tests 中 7 通过、2 个新增链路测试失败；两方言均先成功得到真实元数据，再在生成阶段出现相同统计：total_files=7、success_files=6、error_files=1。

失败文件：mybatis_plus_config.mustache。

错误：模板文件不存在: src/dbjavagenix/templates/java/mybatis_plus_config.mustache。

实际文件位于 src/dbjavagenix/templates/java/common/mybatis_plus_config.mustache。根因与 MySQL/PostgreSQL 驱动、schema、外键或容器启动无关；两种数据库的同一错误证明它位于公共生成器路径。初始失败 job：https://github.com/ZhaoXingPeng/DBJavaGenix/actions/runs/34214352683/job/102022480520

| 数据库 | 实验输入 | 链路断言 |
| --- | --- | --- |
| MySQL mysql:8.0 | 自增 id、非空 parent_id、外键、(parent_id, region_code) 复合索引 | 真实结构进入分析结果和模板上下文；修复前揭露公共模板缺失 |
| PostgreSQL postgres:16-alpine | dbjg_contract.contract_child 与 public.contract_child(id UUID) 同名反例 | 非 public schema 数据没有退化为仅 id；修复前同样揭露公共模板缺失 |

本机没有 docker CLI，不能再次运行容器；修复后的真实容器验证保留给此 PR 当前 HEAD 的下一次合并前 CI。已测本地边界是单元回归、模板解析、完整单元集与生成器的 7/0 内存复现。

未测边界：生成项目的 Java 依赖编译、SQLite 集成级 fixture、生产权限/版本矩阵、性能和并发。这些均不由本 PR 的结论覆盖。

## 兼容性、风险与回滚

- 兼容性：修复旧的一步生成路径，使 MybatisPlus 和 MybatisPlus-Mixed 的公共分页配置与既有模板清单一致；不更改 API、数据库写操作、包内容或模板文本。
- 风险：公共模板目录未来调整时可能再次失配；新增直接渲染单元测试和真实数据库生成链路共同覆盖该边界。
- 回滚：revert e0d2ea2 可恢复旧行为；若同时撤销覆盖则 revert 3266548。两者都不影响用户数据。
- 合并条件：不在 e0d2ea2 推送后轮询 CI。准备 squash 合并时，只检查该最新 HEAD 的 required checks；任何 pending、cancelled 或 failure 都不合并。