### PR TITLE
:test_tube: test(sqlite): 覆盖文件数据库代码生成契约

### DIFF
--- a/tests/integration/test_sqlite_file_codegen_contract.py
+++ b/tests/integration/test_sqlite_file_codegen_contract.py
@@ -1,0 +1,146 @@
+"""File-backed SQLite coverage for metadata and code generation.
+
+SQLite does not need Testcontainers, but an in-memory connection does not
+exercise a database file's connection lifecycle. This fixture runs the public
+``ConnectionManager -> DatabaseIntrospector -> CodegenAnalyzer`` path against
+a temporary file and then renders the MyBatis-Plus mixed templates in memory.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from dbjavagenix.core.models import DatabaseConfig, DatabaseType
+from dbjavagenix.database.codegen_tools import CodegenAnalyzer, CodegenGenerator
+from dbjavagenix.database.connection_manager import ConnectionManager
+from dbjavagenix.database.introspection import DatabaseIntrospector
+
+
+PARENT_TABLE = "contract_parent"
+CHILD_TABLE = "contract_child"
+COMPOSITE_INDEX = "contract_child_parent_region_idx"
+
+
+@pytest.fixture
+def sqlite_file_contract(
+    tmp_path: Path,
+) -> Generator[dict[str, Any], None, None]:
+    """Create the relational contract in a real, disposable SQLite file."""
+    database_path = tmp_path / "sqlite-contract.db"
+    manager = ConnectionManager()
+    connection_id = manager.create_connection(
+        DatabaseConfig(
+            type=DatabaseType.SQLITE,
+            host="",
+            port=0,
+            database=str(database_path),
+            username="",
+            password="",
+        )
+    )
+    try:
+        manager.execute_query(connection_id, "PRAGMA foreign_keys = ON")
+        manager.execute_query(
+            connection_id,
+            f"""
+            CREATE TABLE {PARENT_TABLE} (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                external_code TEXT NOT NULL UNIQUE
+            )
+            """,
+        )
+        manager.execute_query(
+            connection_id,
+            f"""
+            CREATE TABLE {CHILD_TABLE} (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                parent_id INTEGER NOT NULL,
+                region_code TEXT NOT NULL,
+                created_at DATETIME NOT NULL,
+                FOREIGN KEY (parent_id) REFERENCES {PARENT_TABLE} (id)
+            )
+            """,
+        )
+        manager.execute_query(
+            connection_id,
+            f"CREATE INDEX {COMPOSITE_INDEX} ON {CHILD_TABLE} (parent_id, region_code)",
+        )
+        yield {
+            "connection_id": connection_id,
+            "database_path": database_path,
+            "introspector": DatabaseIntrospector(manager),
+            "manager": manager,
+        }
+    finally:
+        manager.close_connection(connection_id)
+
+
+@pytest.mark.asyncio
+async def test_file_backed_sqlite_metadata_reaches_template_generation(
+    sqlite_file_contract: dict[str, Any],
+) -> None:
+    fixture = sqlite_file_contract
+    expected_schema = str(fixture["database_path"])
+    introspector = fixture["introspector"]
+
+    metadata = introspector.describe_table(fixture["connection_id"], CHILD_TABLE)
+
+    assert fixture["database_path"].is_file()
+    assert metadata["name"] == CHILD_TABLE
+    assert metadata["schema"] == expected_schema
+    assert metadata["primary_keys"] == ["id"]
+    columns = {column["name"]: column for column in metadata["columns"]}
+    assert {"id", "parent_id", "region_code", "created_at"} <= set(columns)
+    assert columns["id"]["primary_key"] is True
+    assert columns["id"]["auto_increment"] is True
+    assert columns["parent_id"]["nullable"] is False
+    assert columns["region_code"]["nullable"] is False
+    # SQLite PRAGMA exposes a stable numeric foreign-key id, not a DDL name.
+    assert metadata["foreign_keys"] == [
+        {
+            "constraint_name": "0",
+            "column_name": "parent_id",
+            "referenced_table": PARENT_TABLE,
+            "referenced_column": "id",
+        }
+    ]
+    composite_index = [
+        index for index in metadata["indexes"] if index["key_name"] == COMPOSITE_INDEX
+    ]
+    assert [(index["column_name"], index["seq_in_index"]) for index in composite_index] == [
+        ("parent_id", 1),
+        ("region_code", 2),
+    ]
+    assert all(index["unique"] is False for index in composite_index)
+
+    analyzer = CodegenAnalyzer(fixture["manager"])
+    analysis = await analyzer.analyze_table_for_codegen(fixture["connection_id"], CHILD_TABLE)
+
+    assert analysis["table_info"]["schema"] == expected_schema
+    assert analysis["relationships"]["primary_keys"] == ["id"]
+    assert analysis["relationships"]["foreign_keys"] == metadata["foreign_keys"]
+    assert {column["name"] for column in analysis["template_context"]["columns"]} >= {
+        "id",
+        "parent_id",
+        "region_code",
+        "created_at",
+    }
+
+    generated = await CodegenGenerator().generate_code(
+        analysis, template_category="MybatisPlus-Mixed"
+    )
+
+    assert generated["generation_statistics"] == {
+        "total_files": 7,
+        "success_files": 7,
+        "error_files": 0,
+    }
+    assert all("error" not in file for file in generated["generated_code"].values())
+    entity = generated["generated_code"]["entity.mustache"]["code"]
+    assert "public class ContractChild" in entity
+    assert "private Long id;" in entity
+    assert "private Long parentId;" in entity


### PR DESCRIPTION
## 关联 Issue

Closes #137

Issue #137 的验收目标是补齐 SQLite 文件数据库从连接、元数据到内存代码生成的集成级契约，并避免把 SQLite 与容器数据库的 schema 或外键命名语义混为一谈。

## 背景（Situation）

MySQL 8.0 和 PostgreSQL 16-alpine 已通过 #133、#136 获得真实 metadata 及到 MybatisPlus-Mixed 的生成链路覆盖。SQLite 过去只有 :memory: 单元测试：它没有证明文件路径会经 ConnectionManager 保存为 schema identity，也没有覆盖关闭连接、关系 metadata 和 7 个模板的完整生成路径。

## 任务（Task）

增加一个无需 Docker、无需私有凭据的 SQLite 文件数据库集成测试。该测试在 pytest tmp_path 建立 sqlite-contract.db，通过公开 ConnectionManager -> DatabaseIntrospector -> CodegenAnalyzer -> CodegenGenerator 路径完成验证。

非目标：不改变运行时代码、SQLite 方言、模板或 CI；不将内存模板渲染外推为 Java 依赖编译、生产文件锁、并发性能、跨 SQLite 版本或 PostgreSQL 式 schema 隔离。

## 行动（Action）

- 新增 tests/integration/test_sqlite_file_codegen_contract.py。
- fixture 用真实文件连接创建 contract_parent / contract_child，并在 finally 中调用 close_connection。
- DDL 包含 INTEGER PRIMARY KEY AUTOINCREMENT、NOT NULL parent_id/region_code/created_at、FOREIGN KEY(parent_id) 及命名的 (parent_id, region_code) 复合索引。
- 对 describe_table 断言文件路径 schema、主键、自增、非空、SQLite PRAGMA 外键 id、复合索引顺序和非唯一语义。
- 对同一连接调用分析器和 MybatisPlus-Mixed 内存生成，要求 total_files=7、success_files=7、error_files=0；实体必须含 ContractChild、Long id 和 Long parentId。

## 验证（Verification）

提交：23112a35ed43eaa7f0cda508ec3b8f06ec70a991

当前 Windows 环境 / Python 3.12.12 / SQLite 3.50.4 / uv 0.9.17：

| 命令 | 结果 |
| --- | --- |
| uv run --python 3.12 --extra dev --extra integration python -m pytest tests/integration/test_sqlite_file_codegen_contract.py --no-cov -q | 1 passed，0.15s |
| uv run --python 3.12 --extra dev --extra integration python -m pytest tests/integration/ --no-docker --no-cov -q | 1 passed，9 skipped，0.21s；跳过的是 Testcontainers MySQL/PostgreSQL 用例 |
| uv run --python 3.12 --extra dev --extra integration python -m pytest tests/unit/ --no-cov -q | 669 passed，6.48s |
| ruff check / ruff format --check tests/integration/test_sqlite_file_codegen_contract.py | passed / 1 file already formatted |
| python scripts/validate_commit_title.py --title ':test_tube: test(sqlite): 覆盖文件数据库代码生成契约' | OK |

## 实验与证据（Evidence）

| 输入 | 预期 | 实际断言 |
| --- | --- | --- |
| tmp_path/sqlite-contract.db | 文件型 SQLite 连接可由 ConnectionManager 创建和关闭 | is_file 为真；fixture finally 调用 close_connection |
| contract_child | id 自增、parent_id/region_code 非空 | metadata 和 table_info 均保留这些字段 |
| FOREIGN KEY(parent_id) -> contract_parent(id) | SQLite 不提供显式约束名 | PRAGMA 规范化为 constraint_name='0'，同时断言列和引用目标 |
| contract_child_parent_region_idx | parent_id -> region_code 的非唯一复合索引 | seq_in_index=1/2，unique=false |
| MybatisPlus-Mixed | 6 个分类模板加公共配置 | 7/7 内存文件成功，0 error |

SQLite 版本由当前 Python 标准库报告为 3.50.4。该测试不启动 Docker，因此可在没有容器运行面的机器上提供 SQLite 的集成级覆盖；CI integration job 仍会同时运行现有 Testcontainers 测试。

已测边界：文件数据库连接生命周期、统一 metadata、AUTOINCREMENT、NOT NULL、外键、复合索引顺序、真实分析输入与内存渲染。

未测边界：Java 编译、SQLite 生产锁竞争/并发、权限模型、旧 SQLite 版本以及跨数据库 schema 语义；这些不在本 PR 结论中。

## 兼容性、风险与回滚

- 兼容性：仅增加测试，无公开 API、数据格式、模板、数据库写操作或发行物变化。
- 风险：SQLite PRAGMA 只提供数值外键 id；测试以稳定的实际行为为准，不伪造跨方言约束名。临时文件若未关闭会在 Windows 清理时暴露，fixture 已显式 finally 关闭。
- 回滚：revert 23112a3 即可删除该覆盖，不触及用户数据或运行时代码。
- 合并条件：不在本次推送后查询中间 CI。准备 squash merge 时，只检查 PR 最新提交的 required checks；pending、cancelled 或 failure 均不合并。