### PR TITLE
:lock: security(query): 拒绝带锁的 SELECT 查询

### DIFF
--- a/src/dbjavagenix/database/mcp_tools.py
+++ b/src/dbjavagenix/database/mcp_tools.py
@@ -44,6 +44,14 @@ _READ_ONLY_FORBIDDEN_WORDS = {
     "UPDATE",
 }
 
+_LOCKING_READ_CLAUSES = (
+    ("FOR", "UPDATE"),
+    ("FOR", "NO", "KEY", "UPDATE"),
+    ("FOR", "SHARE"),
+    ("FOR", "KEY", "SHARE"),
+    ("LOCK", "IN", "SHARE", "MODE"),
+)
+
 
 def _resolve_codegen_output_path(base_dir: Path, relative_path: object) -> Path:
     """Resolve a generated filename while keeping it inside its output directory."""
@@ -130,6 +138,19 @@ def _tokenize_read_only_sql(query: str) -> List[tuple[str, str]]:
     return tokens
 
 
+def _contains_locking_read_clause(tokens: List[tuple[str, str]]) -> bool:
+    """Return whether a token stream contains a row-locking SELECT clause."""
+    for clause in _LOCKING_READ_CLAUSES:
+        clause_length = len(clause)
+        for start in range(len(tokens) - clause_length + 1):
+            if all(
+                tokens[start + offset] == ("word", keyword)
+                for offset, keyword in enumerate(clause)
+            ):
+                return True
+    return False
+
+
 def _validate_read_only_query(query: Any) -> str:
     """Validate and normalize one SQL SELECT statement for the public query tool."""
     if not isinstance(query, str):
@@ -153,6 +174,9 @@ def _validate_read_only_query(query: Any) -> str:
     first_word = next((value for kind, value in tokens if kind == "word"), None)
     if first_word not in {"SELECT", "WITH"}:
         raise MCPServiceError("Only SELECT queries are allowed for security reasons")
+
+    if _contains_locking_read_clause(tokens):
+        raise MCPServiceError("Only non-locking read-only SELECT queries are allowed")
 
     depth = 0
     top_level_select = first_word == "SELECT"

--- a/tests/unit/test_mcp_query_safety.py
+++ b/tests/unit/test_mcp_query_safety.py
@@ -1,5 +1,7 @@
 """Regression tests for the public read-only SQL query tool."""
 
+import json
+
 import pytest
 
 from dbjavagenix.database import mcp_tools
@@ -32,6 +34,63 @@ async def test_db_query_execute_rejects_non_read_only_sql(monkeypatch, query):
 
     assert "Only" in response[0].text or "comments" in response[0].text
     assert called is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "query",
+    [
+        "SELECT id FROM users FOR UPDATE",
+        "SELECT id FROM users FOR SHARE",
+        "SELECT id FROM users FOR KEY SHARE",
+        "SELECT id FROM users FOR NO KEY UPDATE",
+        "SELECT id FROM users LOCK IN SHARE MODE",
+        "WITH locked_rows AS (SELECT id FROM users FOR SHARE) SELECT id FROM locked_rows",
+    ],
+)
+async def test_db_query_execute_rejects_locking_read_clauses(monkeypatch, query):
+    called = False
+
+    def execute_query(*_args, **_kwargs):
+        nonlocal called
+        called = True
+        return []
+
+    monkeypatch.setattr(mcp_tools.connection_manager, "execute_query", execute_query)
+
+    response = await mcp_tools.handle_db_query_execute({"connection_id": "test", "query": query})
+
+    payload = json.loads(response[0].text.split("Raw Response:", 1)[1].strip())
+    assert "non-locking" in response[0].text
+    assert payload["success"] is False
+    assert payload["error"] == "query_failed"
+    assert called is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "query",
+    [
+        "SELECT 1 AS share",
+        "SELECT 1 AS lock",
+        "SELECT 'LOCK IN SHARE MODE' AS note",
+    ],
+)
+async def test_db_query_execute_preserves_lock_words_in_aliases_and_literals(monkeypatch, query):
+    received = []
+
+    monkeypatch.setattr(
+        mcp_tools.connection_manager,
+        "execute_query",
+        lambda _connection_id, executed_query: received.append(executed_query) or [],
+    )
+
+    response = await mcp_tools.handle_db_query_execute(
+        {"connection_id": "test", "query": query, "limit": 3}
+    )
+
+    assert "Query executed successfully" in response[0].text
+    assert received == [f"{query} LIMIT 3"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 关联 Issue

Closes #139

Issue #139 的验收目标是让 db_query_execute 的“只读 SELECT”契约禁止实际获取行锁的读语法，拒绝路径保持 Raw Response JSON 可解析且不触发数据库执行。

## 背景（Situation）

公共 MCP 查询工具的验证器已禁止 DDL/DML、SELECT INTO、注释和多语句，但遗漏了不会出现 UPDATE 词的锁定读。复现表明 SELECT ... FOR SHARE、SELECT ... FOR KEY SHARE 和 SELECT ... LOCK IN SHARE MODE 会通过验证并到达执行层。它们能获取共享锁、阻塞写路径，因此与工具对调用方承诺的无副作用只读查询不一致。

## 任务（Task）

在现有轻量 SQL tokenizer 上补足 row-locking SELECT clause 的结构化拒绝，并用 handler 级回归同时验证拒绝错误 envelope、零执行调用和合法近似输入。

非目标：不引入完整 SQL parser、权限系统、数据库超时控制或额外方言；不改变 SELECT 结果格式、limit 规则和其他 MCP 工具。

## 行动（Action）

- 在 mcp_tools.py 定义锁定读 token 序列：FOR UPDATE、FOR NO KEY UPDATE、FOR SHARE、FOR KEY SHARE、LOCK IN SHARE MODE。
- 新增 _contains_locking_read_clause，在 tokenizer 返回的相邻 word token 中精确匹配，不跨越符号、括号或 quoted token。
- 在只读验证的 DML/DDL 检查前返回 `Only non-locking read-only SELECT queries are allowed`。
- 新增 6 个拒绝案例，包括嵌套 CTE 内的 FOR SHARE；每例断言 Raw Response JSON 为 success=false / error=query_failed，且 execute_query 未调用。
- 新增 3 个反例：`AS share`、`AS lock`、以及 `'LOCK IN SHARE MODE'` 字符串仍以 LIMIT 3 正常执行。

## 验证（Verification）

提交：10774cd

当前 Windows 环境 / Python 3.12.12 / uv 0.9.17：

| 命令 | 结果 |
| --- | --- |
| uv run --python 3.12 --extra dev python -m pytest tests/unit/test_mcp_query_safety.py tests/unit/test_mcp_error_json.py tests/unit/test_server_dispatch.py --no-cov -q | 39 passed，0.61s |
| uv run --python 3.12 --extra dev python -m pytest tests/unit/ --no-cov -q | 678 passed，6.42s |
| uv run --python 3.12 --extra dev python scripts/verify_templates.py | 25 个 Java 模板全部渲染成功 |
| ruff check / ruff format --check 目标文件 | passed / 1 file already formatted |
| python scripts/validate_commit_title.py --title ':lock: security(query): 拒绝带锁的 SELECT 查询' | OK |

## 实验与证据（Evidence）

初始验证器复现（无需连接数据库）显示下列 SQL 原样返回，说明旧实现会把它们交给 ConnectionManager.execute_query：

```sql
SELECT id FROM users FOR SHARE
SELECT id FROM users FOR KEY SHARE
SELECT id FROM users LOCK IN SHARE MODE
```

修复后的 handler 回归将每种锁模式的 execute_query 替换为记录桩：6/6 均在验证阶段返回可 JSON 解析的 `success=false, error=query_failed`，记录调用次数为 0。嵌套 CTE 也被拒绝，因为其中的 SELECT 仍会获取锁。

相反，`SELECT 1 AS share`、`SELECT 1 AS lock` 和 `SELECT 'LOCK IN SHARE MODE' AS note` 的 token 不构成锁定 clause；三者均执行为原 SQL 加 `LIMIT 3`。这说明检测识别 SQL 结构而非粗暴禁止单词。

未测：实际数据库锁等待时长、方言未记录的新锁语法、资源型 read functions 和数据库权限。这些不在本 PR 的安全结论内。

## 兼容性、风险与回滚

- 兼容性：正确的无锁 SELECT 和 WITH ... SELECT 保持兼容。此前被错误允许的锁定读现在将收到既有 `query_failed` envelope，这是预期的安全行为变化。
- 风险：轻量 tokenizer 不是完整 parser；本实现只匹配相邻结构化 token，新增反例覆盖别名和引用内容。未知方言语法将另行以方言测试立项。
- ADR：不需要。该变更只收紧单一工具的既有安全契约，没有引入跨模块边界或新的架构决策。
- 回滚：revert 10774cd 即可恢复旧验证规则，不涉及数据库迁移、保存状态或发布物。
- 合并条件：本次推送后不查询中间 CI；准备 squash merge 时仅核对 PR 最新提交的 required checks，任何 pending、cancelled 或 failure 均不合并。