### PR TITLE
:bug: fix(query): 序列化真实数据库查询结果

### DIFF
--- a/src/dbjavagenix/database/mcp_tools.py
+++ b/src/dbjavagenix/database/mcp_tools.py
@@ -1,6 +1,9 @@
 """
 MCP tools for database connection and basic query operations
 """
+from base64 import b64encode
+from datetime import date, datetime, time, timedelta
+from decimal import Decimal
 import json
 import logging
 import os
@@ -8,6 +11,7 @@ import re
 from functools import lru_cache
 from pathlib import Path, PureWindowsPath
 from typing import Dict, Any, List, Optional
+from uuid import UUID
 
 from mcp.types import Tool, TextContent, ImageContent, EmbeddedResource
 
@@ -51,6 +55,24 @@ _LOCKING_READ_CLAUSES = (
     ("FOR", "KEY", "SHARE"),
     ("LOCK", "IN", "SHARE", "MODE"),
 )
+
+
+def _query_result_json_default(value: object) -> object:
+    """Encode driver result values without losing precision or binary identity."""
+    if isinstance(value, Decimal):
+        return str(value)
+    if isinstance(value, (datetime, date, time)):
+        return value.isoformat()
+    if isinstance(value, UUID):
+        return str(value)
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        return {
+            "encoding": "base64",
+            "data": b64encode(bytes(value)).decode("ascii"),
+        }
+    if isinstance(value, timedelta):
+        return str(value)
+    raise TypeError(f"Object of type {type(value).__name__} is not JSON serializable")
 
 
 def _resolve_codegen_output_path(base_dir: Path, relative_path: object) -> Path:
@@ -1025,7 +1047,9 @@ async def handle_db_query_execute(arguments: Dict[str, Any]) -> List[TextContent
         else:
             result_text = "Query executed successfully. No rows returned."
         
-        result_text += f"\n\nRaw Response: {json.dumps(response, ensure_ascii=False)}"
+        result_text += "\n\nRaw Response: " + json.dumps(
+            response, ensure_ascii=False, default=_query_result_json_default
+        )
         
         return [TextContent(
             type="text",

--- a/tests/unit/test_mcp_error_json.py
+++ b/tests/unit/test_mcp_error_json.py
@@ -1,7 +1,10 @@
 """Regression tests for JSON-serializable MCP error envelopes."""
 
+from datetime import date, datetime, time, timedelta, timezone
+from decimal import Decimal
 import json
 from types import SimpleNamespace
+from uuid import UUID
 
 import pytest
 
@@ -90,6 +93,59 @@ async def test_query_execute_success_raw_response_is_json(monkeypatch):
     payload = _raw_payload(response)
     assert payload["success"] is True
     assert payload["data"] == [{"id": 1, "name": "Alice"}]
+
+
+@pytest.mark.asyncio
+async def test_query_execute_serializes_real_driver_value_types(monkeypatch):
+    monkeypatch.setattr(
+        mcp_tools.connection_manager,
+        "execute_query",
+        lambda *_args, **_kwargs: [
+            {
+                "amount": Decimal("12.30"),
+                "created_at": datetime(2026, 9, 8, 10, 0, tzinfo=timezone.utc),
+                "event_date": date(2026, 9, 8),
+                "event_time": time(10, 0, 1, 234_000),
+                "event_id": UUID("12345678-1234-5678-1234-567812345678"),
+                "payload": b"\x00\xff",
+                "mutable_payload": bytearray(b"ok"),
+                "view_payload": memoryview(b"view"),
+                "duration": timedelta(days=1, seconds=2),
+            }
+        ],
+    )
+
+    response = await mcp_tools.handle_db_query_execute(
+        {"connection_id": "postgresql-1", "query": "SELECT * FROM events", "limit": 5}
+    )
+
+    payload = _raw_payload(response)
+    assert payload == {
+        "success": True,
+        "query": "SELECT * FROM events LIMIT 5",
+        "row_count": 1,
+        "data": [
+            {
+                "amount": "12.30",
+                "created_at": "2026-09-08T10:00:00+00:00",
+                "event_date": "2026-09-08",
+                "event_time": "10:00:01.234000",
+                "event_id": "12345678-1234-5678-1234-567812345678",
+                "payload": {"encoding": "base64", "data": "AP8="},
+                "mutable_payload": {"encoding": "base64", "data": "b2s="},
+                "view_payload": {"encoding": "base64", "data": "dmlldw=="},
+                "duration": "1 day, 0:00:02",
+            }
+        ],
+    }
+
+
+def test_query_result_json_default_rejects_unknown_object():
+    class UnknownDriverValue:
+        pass
+
+    with pytest.raises(TypeError, match="UnknownDriverValue"):
+        mcp_tools._query_result_json_default(UnknownDriverValue())
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 关联 Issue

Closes #141

Issue #141 的验收目标是修复 db_query_execute 在真实数据库值无法直接 JSON 序列化时丢弃查询结果的问题，同时保持 Raw Response JSON 可解析、Decimal 精度和二进制身份。

## 背景（Situation）

db_query_execute 把 driver row 直接置入 response 后使用 json.dumps。MySQL/PostgreSQL 常见的 Decimal、datetime、date/time、UUID、bytes 和 interval/timedelta 不是 JSON 标准类型。查询成功后，响应渲染会抛 TypeError，客户端最终收到 unexpected_error 而不是原始数据。

## 任务（Task）

仅在 db_query_execute 的成功 Raw Response 路径增加受控 default encoder；为驱动类型定义稳定表示，并保证未知对象继续按明确 TypeError 失败。

非目标：不重写全部历史 MCP JSON 调用、不引入 ORM 序列化框架、不修改 SQL、limit、row_count、文本展示或数据库权限。

## 行动（Action）

- 新增 _query_result_json_default。
- Decimal -> 字符串，避免 float 精度丢失。
- datetime/date/time -> 原值 isoformat，不转换 timezone 或 naive/aware 语义。
- UUID -> 规范字符串。
- bytes / bytearray / memoryview -> `{encoding: 'base64', data: 'base64 编码字符串'}`，保留二进制可逆身份。
- timedelta -> 稳定文本表示；未知对象显式抛 TypeError。
- 仅将 handle_db_query_execute 的 Raw Response json.dumps 连接到此 encoder。
- 增加 mixed driver row 回归，覆盖 JSON loads 后完整 payload，以及 unknown object 的直接 TypeError。

## 验证（Verification）

提交：5ba0300

当前 Windows 环境 / Python 3.12.12 / uv 0.9.17：

| 命令 | 结果 |
| --- | --- |
| pytest tests/unit/test_mcp_error_json.py tests/unit/test_mcp_query_safety.py tests/unit/test_server_dispatch.py --no-cov -q | 41 passed，0.61s |
| pytest tests/unit/ --no-cov -q | 680 passed，6.55s |
| pytest tests/integration/ --no-docker --no-cov -q | 1 passed，9 skipped，0.14s；跳过现有 Testcontainers 用例 |
| python scripts/verify_templates.py | 25 个 Java 模板全部渲染成功 |
| ruff check / ruff format --check 目标文件 | passed / 1 file already formatted |
| python scripts/validate_commit_title.py --title ':bug: fix(query): 序列化真实数据库查询结果' | OK |

## 实验与证据（Evidence）

修复前使用受控 driver 返回值 `[{'amount': Decimal('12.30'), 'created_at': datetime(2026, 9, 8, 10, 0)}]` 调用 handler。SQL 被调用后，实际响应为：

```text
Unexpected error: Object of type Decimal is not JSON serializable
Raw Response: {"success": false, "error": "unexpected_error", ...}
```

修复后同一输入的 `json.loads(Raw Response)` 为：

```json
{"success": true, "query": "SELECT amount, created_at FROM ledger LIMIT 5", "row_count": 1, "data": [{"amount": "12.30", "created_at": "2026-09-08T10:00:00"}]}
```

扩展回归覆盖 UTC datetime、date、time、UUID、bytes、bytearray、memoryview 与 timedelta。binary 的三种输入均返回显式 base64 envelope；unknown object 仍抛含类型名的 TypeError，未使用 repr 或隐式字符串化。

已测：handler 成功路径、Raw Response JSON parse、精度保留、二进制编码、未知类型拒绝、现有锁查询安全回归。

未测：真实 MySQL/PostgreSQL 服务器返回的每一种驱动对象、其他 MCP handler 的历史 Raw Response、客户端对 base64 envelope 的展示、性能与大结果集。这些不由本 PR 结论覆盖。

## 兼容性、风险与回滚

- 兼容性：已有 JSON 基础类型保持原样。此前失败的 driver 值现在有明确 JSON 表示，是修复而非 query 行为变化。
- 风险：调用方若期待 bytes 的 Python repr，将改为 base64 envelope；此前该路径本就返回 unexpected_error，因而不存在成功协议的破坏。未知 driver 类型仍故意失败，防止隐式泄漏。
- ADR：不需要。实现只修正一个 MCP handler 的序列化缺陷，未改变模块边界或公共工具集合。
- 回滚：revert 5ba0300 可恢复旧错误行为；不涉及数据库迁移、数据修改或 release artifact。
- 合并条件：推送后不查询中间 CI；准备 squash merge 时只检查当前 PR 最新 HEAD 的 required checks，任何 pending、cancelled 或 failure 均不合并。