### PR TITLE
:test_tube: test(mcp): 覆盖 SQLite 文件查询契约

### DIFF
--- a/tests/integration/test_sqlite_mcp_query_contract.py
+++ b/tests/integration/test_sqlite_mcp_query_contract.py
@@ -1,0 +1,101 @@
+"""File-backed SQLite coverage for public MCP query handlers."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Generator
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from dbjavagenix.core.models import DatabaseConfig, DatabaseType
+from dbjavagenix.database import mcp_tools
+
+
+SPECIAL_TABLE = "odd'table"
+
+
+def _raw_payload(response: list[Any]) -> dict[str, Any]:
+    return json.loads(response[0].text.split("Raw Response:", 1)[1].strip())
+
+
+@pytest.fixture
+def sqlite_mcp_query_file(tmp_path: Path) -> Generator[dict[str, str], None, None]:
+    """Create one SQLite file through the same global manager used by handlers."""
+    database_path = tmp_path / "mcp-query-contract.db"
+    connection_id = mcp_tools.connection_manager.create_connection(
+        DatabaseConfig(
+            type=DatabaseType.SQLITE,
+            host="",
+            port=0,
+            database=str(database_path),
+            username="",
+            password="",
+        )
+    )
+    try:
+        mcp_tools.connection_manager.execute_query(
+            connection_id,
+            'CREATE TABLE "odd\'table" (id INTEGER PRIMARY KEY, name TEXT NOT NULL)',
+        )
+        yield {
+            "connection_id": connection_id,
+            "database": str(database_path),
+        }
+    finally:
+        mcp_tools.connection_manager.close_connection(connection_id)
+
+
+@pytest.mark.asyncio
+async def test_sqlite_mcp_discovery_raw_response_handles_special_table_name(
+    sqlite_mcp_query_file: dict[str, str],
+) -> None:
+    fixture = sqlite_mcp_query_file
+
+    tables = await mcp_tools.handle_db_query_tables(fixture)
+    exists = await mcp_tools.handle_db_query_table_exists({**fixture, "table": SPECIAL_TABLE})
+    missing = await mcp_tools.handle_db_query_table_exists({**fixture, "table": "missing_table"})
+
+    assert _raw_payload(tables) == {
+        "success": True,
+        "database": fixture["database"],
+        "schema": None,
+        "tables": [SPECIAL_TABLE],
+        "table_references": [{"table_name": SPECIAL_TABLE, "schema": None}],
+        "count": 1,
+    }
+    assert _raw_payload(exists)["exists"] is True
+    assert _raw_payload(missing)["exists"] is False
+
+
+@pytest.mark.asyncio
+async def test_sqlite_mcp_query_keeps_empty_result_json_and_rejects_insert(
+    sqlite_mcp_query_file: dict[str, str],
+) -> None:
+    fixture = sqlite_mcp_query_file
+    empty = await mcp_tools.handle_db_query_execute(
+        {
+            "connection_id": fixture["connection_id"],
+            "query": "SELECT id, name FROM \"odd'table\" WHERE name = 'missing'",
+            "limit": 2,
+        }
+    )
+    rejected = await mcp_tools.handle_db_query_execute(
+        {
+            "connection_id": fixture["connection_id"],
+            "query": "INSERT INTO \"odd'table\" (name) VALUES ('blocked')",
+        }
+    )
+
+    assert _raw_payload(empty) == {
+        "success": True,
+        "query": "SELECT id, name FROM \"odd'table\" WHERE name = 'missing' LIMIT 2",
+        "row_count": 0,
+        "data": [],
+    }
+    assert _raw_payload(rejected)["success"] is False
+    assert _raw_payload(rejected)["error"] == "query_failed"
+    assert mcp_tools.connection_manager.execute_query(
+        fixture["connection_id"], 'SELECT COUNT(*) AS count FROM "odd\'table"'
+    ) == [{"count": 0}]


### PR DESCRIPTION
## 关联 Issue

Closes #145

Issue #145 的验收目标是用真实 SQLite 文件连接验证公共 MCP 查询 handler 的 discovery、exists、empty query、read-only rejection 与可 JSON 解析 Raw Response，而不是只验证其内部 SQL 字符串。

## 背景（Situation）

现有 MCP 查询测试大多 monkeypatch connection_manager，覆盖 SQL 形状、错误 JSON 与 limit/锁安全。但它们没有共同经过 public handler -> global connection_manager -> sqlite3 file -> TextContent/Raw Response 的组合路径。特殊标识符、空结果、参数化存在性检查与 response 前缀/JSON 可能因此只在集成时失配。

## 任务（Task）

增加无需 Docker 和凭据的 SQLite 文件集成测试，通过 mcp_tools.connection_manager 本体调用 db_query_tables、db_query_table_exists 与 db_query_execute。

非目标：不修改运行时代码、MySQL/PostgreSQL 方言、schema 隔离或所有 MCP handler；不把 SQLite 标识符行为推广到服务器数据库。

## 行动（Action）

- 新增 tests/integration/test_sqlite_mcp_query_contract.py。
- 在 tmp_path/mcp-query-contract.db 用 mcp_tools.connection_manager 创建实际 SQLite 连接，创建 `odd'table`，并在 finally 中关闭同一全局连接。
- discovery：验证 db_query_tables 的 tables/table_references/count Raw Response JSON 含特殊表名。
- exists：验证同一特殊表名为 true、missing_table 为 false，两个 Raw Response 都经 json.loads。
- empty query：`SELECT id, name FROM "odd'table" WHERE name = 'missing'` 在 limit=2 下返回 success=true、row_count=0、data=[] 与追加的 LIMIT 2。
- write rejection：对同一表的 INSERT 返回 success=false/query_failed；随后直接 COUNT 确认真实文件表仍为 0 行。

## 验证（Verification）

提交：f8f2429

环境：Windows / Python 3.12.12 / SQLite 3.50.4 / uv 0.9.17。

| 命令 | 结果 |
| --- | --- |
| pytest tests/integration/test_sqlite_mcp_query_contract.py --no-cov -q | 2 passed，0.53s |
| pytest tests/integration/ --no-docker --no-cov -q | 3 passed，9 skipped，0.51s；9 项为显式无 Docker 的 Testcontainers 用例 |
| pytest tests/unit/ --no-cov -q | 680 passed，7.09s |
| ruff check / ruff format --check 目标文件 | passed / 1 file already formatted |
| scripts/validate_commit_title.py | OK |

## 实验与证据（Evidence）

| 调用 | 真实输入 | Raw Response 关键断言 |
| --- | --- | --- |
| db_query_tables | 文件 SQLite，表名 `odd'table` | success=true，tables=[`odd'table`]，table_references 含 schema=null，count=1 |
| db_query_table_exists | `odd'table` / missing_table | success=true，exists=true / false |
| db_query_execute | `SELECT ... FROM "odd'table" WHERE name = 'missing'`，limit=2 | success=true，query 后缀 `LIMIT 2`，row_count=0，data=[] |
| db_query_execute | `INSERT INTO "odd'table" ...` | success=false，error=query_failed；后续真实 COUNT=0 |

特殊表名同时覆盖 SQLite catalog 参数化查询、SQL tokenizer 的 quoted identifier 与 quoted literal。测试并不把表名直接插入 public handler 的 existence SQL；handler 使用 SQLite `?` 参数。每个 handler 的 Raw Response 都由 json.loads 读取，文本前缀不是机器合同的替代。

已测：文件连接生命周期、全局 manager、SQLite catalog、特殊标识符、空结果、Raw Response、read-only 写入拒绝与真实零行。

未测：MySQL/PostgreSQL 特殊标识符和 schema、真实数据库空结果、所有 MCP handler、并发、权限、性能和客户端 UI 展示。

## 兼容性、风险与回滚

- 兼容性：仅新增集成测试，无 API、SQL、模板、配置、包或数据迁移变化。
- 风险：全局 manager 连接若泄漏会污染随后测试；fixture 用 finally close_connection，完整 integration + unit 连跑证明本地无泄漏。
- ADR：不需要。此 PR 不引入架构决策，只验证已有公共边界。
- 回滚：revert f8f2429 即可移除测试，不影响用户文件或数据库。
- 合并条件：推送后不查询中间 CI；准备 squash merge 时，仅检查 #146 的最新 HEAD required checks，非 SUCCESS 不合并。