### PR TITLE
:bug: fix(codegen): 统一真实生成的 DTO 包路径

### DIFF
--- a/scripts/verify_java_compile.py
+++ b/scripts/verify_java_compile.py
@@ -3,12 +3,17 @@
 from __future__ import annotations
 
 import argparse
+import asyncio
 import shutil
 import subprocess
 import tempfile
 from pathlib import Path
 
 import pystache
+
+from dbjavagenix.core.models import DatabaseConfig, DatabaseType
+from dbjavagenix.database.codegen_tools import CodegenAnalyzer, CodegenGenerator
+from dbjavagenix.database.connection_manager import ConnectionManager
 
 ROOT = Path(__file__).resolve().parents[1]
 TEMPLATE_ROOT = ROOT / "src" / "dbjavagenix" / "templates" / "java" / "sb35-java21"
@@ -160,6 +165,67 @@ def render_fixture(project_dir: Path) -> list[Path]:
     return rendered_files
 
 
+def render_real_sqlite_fixture(project_dir: Path) -> list[Path]:
+    """Generate sb35-java21 sources from metadata in a disposable SQLite file."""
+    database_path = project_dir / "invoice.db"
+    manager = ConnectionManager()
+    connection_id = manager.create_connection(
+        DatabaseConfig(
+            type=DatabaseType.SQLITE,
+            host="",
+            port=0,
+            database=str(database_path),
+            username="",
+            password="",
+        )
+    )
+    try:
+        manager.execute_query(
+            connection_id,
+            """
+            CREATE TABLE invoice (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                amount DECIMAL(12, 2) NOT NULL,
+                created_at DATETIME NOT NULL
+            )
+            """,
+        )
+        analysis = asyncio.run(
+            CodegenAnalyzer(manager).analyze_table_for_codegen(
+                connection_id, "invoice", template_category="sb35-java21"
+            )
+        )
+        # The sb35-java21 service and controller import this DTO when enabled.
+        analysis["template_context"]["generateDto"] = True
+        generated = asyncio.run(
+            CodegenGenerator().generate_code(
+                analysis,
+                template_category="sb35-java21",
+                generation_config={
+                    "package_name": FIXTURE_PACKAGE,
+                    "author": "DBJavaGenix CI",
+                },
+            )
+        )
+    finally:
+        manager.close_connection(connection_id)
+
+    errors = [entry["error"] for entry in generated["generated_code"].values() if "error" in entry]
+    if errors:
+        raise RuntimeError(f"Real SQLite generation failed: {'; '.join(errors)}")
+
+    source_root = project_dir / "src" / "main" / "java"
+    rendered_files: list[Path] = []
+    for generated_file in generated["generated_code"].values():
+        output_path = source_root / generated_file["filename"]
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(generated_file["code"], encoding="utf-8")
+        rendered_files.append(output_path)
+
+    (project_dir / "pom.xml").write_text(POM, encoding="utf-8")
+    return rendered_files
+
+
 def build_maven_command(maven: str) -> list[str]:
     """Build the explicit, batch-mode compile command for a rendered fixture."""
     return [maven, "-B", "-ntp", "-DskipTests", "clean", "compile"]
@@ -174,32 +240,41 @@ def cleanup_fixture(project_dir: Path, *, keep_fixture: bool, compile_succeeded:
 
 
 def verify_java_compile(*, keep_fixture: bool = False) -> int:
-    """Render and compile the fixture, retaining it only when requested or on failure."""
+    """Compile template and real-metadata fixtures, retaining failures for diagnostics."""
     maven = shutil.which("mvn")
     if maven is None:
         print("Maven executable 'mvn' was not found on PATH")
         return 1
 
-    project_dir = Path(tempfile.mkdtemp(prefix="dbjavagenix-java-compile-"))
-    compile_succeeded = False
-    try:
-        rendered_files = render_fixture(project_dir)
-        command = build_maven_command(maven)
-        print(f"Rendered {len(rendered_files)} sb35-java21 files to {project_dir}", flush=True)
-        print("$ " + " ".join(command), flush=True)
-        result = subprocess.run(command, cwd=project_dir, text=True, check=False)
-        if result.returncode != 0:
-            print("Java compile failed")
-            return result.returncode
-        compile_succeeded = True
-        print("Generated Java compile smoke passed")
-        return 0
-    finally:
-        cleanup_fixture(
-            project_dir,
-            keep_fixture=keep_fixture,
-            compile_succeeded=compile_succeeded,
-        )
+    fixtures = (
+        ("template context", render_fixture),
+        ("real SQLite metadata", render_real_sqlite_fixture),
+    )
+    for fixture_name, render in fixtures:
+        project_dir = Path(tempfile.mkdtemp(prefix="dbjavagenix-java-compile-"))
+        compile_succeeded = False
+        try:
+            rendered_files = render(project_dir)
+            command = build_maven_command(maven)
+            print(
+                f"Rendered {len(rendered_files)} sb35-java21 {fixture_name} files to {project_dir}",
+                flush=True,
+            )
+            print("$ " + " ".join(command), flush=True)
+            result = subprocess.run(command, cwd=project_dir, text=True, check=False)
+            if result.returncode != 0:
+                print(f"Java compile failed for {fixture_name} fixture")
+                return result.returncode
+            compile_succeeded = True
+        finally:
+            cleanup_fixture(
+                project_dir,
+                keep_fixture=keep_fixture,
+                compile_succeeded=compile_succeeded,
+            )
+
+    print("Generated Java compile smoke passed for template and real SQLite metadata fixtures")
+    return 0
 
 
 def main() -> int:

--- a/src/dbjavagenix/database/atomic_codegen_tools.py
+++ b/src/dbjavagenix/database/atomic_codegen_tools.py
@@ -500,7 +500,8 @@ def _compute_file_path(
     package_name = context.get("package", "com.example")
     package_path = package_name.replace(".", "/")
     if file_path.endswith(".java"):
-        return f"{package_path}/{file_path}"
+        normalized_path = "/".join(part for part in file_path.split("/") if part)
+        return f"{package_path}/{normalized_path}"
     return f"resources/{file_path}"
 
 

--- a/src/dbjavagenix/database/codegen_tools.py
+++ b/src/dbjavagenix/database/codegen_tools.py
@@ -306,6 +306,8 @@ class CodegenGenerator:
                 service_package = f"{package_name}.service.{package_suffix}"
                 entity_package = f"{package_name}.entity.{package_suffix}"
                 dao_package = f"{package_name}.dao.{package_suffix}"
+                dto_package = f"{package_name}.dto.{package_suffix}"
+                vo_package = f"{package_name}.vo.{package_suffix}"
                 # 修复serviceImpl包路径问题
                 service_impl_package = f"{package_name}.service.impl.{package_suffix}"
             else:
@@ -313,6 +315,8 @@ class CodegenGenerator:
                 service_package = f"{package_name}.service"
                 entity_package = f"{package_name}.entity"
                 dao_package = f"{package_name}.dao"
+                dto_package = f"{package_name}.dto"
+                vo_package = f"{package_name}.vo"
                 # 修复serviceImpl包路径问题
                 service_impl_package = f"{package_name}.service.impl"
 
@@ -327,6 +331,8 @@ class CodegenGenerator:
                     "servicePackage": service_package,
                     "entityPackage": entity_package,
                     "daoPackage": dao_package,
+                    "dtoPackage": dto_package,
+                    "voPackage": vo_package,
                     # 添加serviceImpl包路径
                     "serviceImplPackage": service_impl_package,
                     "author": author,
@@ -415,7 +421,7 @@ class CodegenGenerator:
                     path_parts = file_path.split("/")
                     if len(path_parts) > 1:
                         # 移除表名路径，让所有表共享同一个包结构
-                        relative_dir = "/".join(path_parts[:-1])
+                        relative_dir = "/".join(part for part in path_parts[:-1] if part)
                         filename = path_parts[-1]
                         # 构建带包路径的完整路径，不包含表名子包
                         return f"{package_path}/{relative_dir}/{filename}"

--- a/tests/unit/test_atomic_codegen_tools.py
+++ b/tests/unit/test_atomic_codegen_tools.py
@@ -413,8 +413,7 @@ class TestComputeFilePath:
             "package": "com.example.app",
         }
         path = _compute_file_path("entity.mustache", ctx, mapping)
-        assert "com/example/app" in path
-        assert path.endswith("SysUser.java")
+        assert path == "com/example/app/entity/SysUser.java"
 
     def test_xml_path_uses_resources_prefix(self):
         mapping = {"mapper.mustache": "mapper/{className}Dao.xml"}

--- a/tests/unit/test_codegen_analyzer.py
+++ b/tests/unit/test_codegen_analyzer.py
@@ -260,6 +260,51 @@ async def test_generator_does_not_require_unused_table_info(monkeypatch):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("package_suffix", "expected_dto_package", "expected_vo_package"),
+    [
+        ("", "com.dbjavagenix.generated.dto", "com.dbjavagenix.generated.vo"),
+        (
+            "billing",
+            "com.dbjavagenix.generated.dto.billing",
+            "com.dbjavagenix.generated.vo.billing",
+        ),
+    ],
+)
+async def test_generator_rebuilds_dto_and_vo_packages_with_requested_base_package(
+    monkeypatch, package_suffix, expected_dto_package, expected_vo_package
+):
+    generator = CodegenGenerator()
+    rendered_contexts = []
+
+    async def render_template(template_file, context, _category):
+        rendered_contexts.append((template_file, context.copy()))
+        return "// generated"
+
+    monkeypatch.setattr(generator, "_render_template", render_template)
+    result = await generator.generate_code(
+        {
+            "table_name": "invoice",
+            "template_context": {
+                "className": "Invoice",
+                "package": "com.example",
+                "packageSuffix": package_suffix,
+            },
+        },
+        template_category="sb35-java21",
+        generation_config={"package_name": "com.dbjavagenix.generated"},
+    )
+
+    assert rendered_contexts
+    assert {context["dtoPackage"] for _, context in rendered_contexts} == {expected_dto_package}
+    assert {context["voPackage"] for _, context in rendered_contexts} == {expected_vo_package}
+    expected_suffix = f"/{package_suffix}" if package_suffix else ""
+    assert result["generated_code"]["dto.mustache"]["filename"] == (
+        f"com/dbjavagenix/generated/dto{expected_suffix}/InvoiceDTO.java"
+    )
+
+
+@pytest.mark.asyncio
 async def test_generator_loads_mybatis_plus_config_from_common_templates():
     code = await CodegenGenerator()._render_template(
         "mybatis_plus_config.mustache", {"basePackage": "com.example"}, "common"

--- a/tests/unit/test_java_compile_smoke.py
+++ b/tests/unit/test_java_compile_smoke.py
@@ -12,6 +12,7 @@ TEMPLATES = _SCRIPT["TEMPLATES"]
 build_maven_command = _SCRIPT["build_maven_command"]
 cleanup_fixture = _SCRIPT["cleanup_fixture"]
 render_fixture = _SCRIPT["render_fixture"]
+render_real_sqlite_fixture = _SCRIPT["render_real_sqlite_fixture"]
 
 
 def test_rendered_fixture_contains_every_java_layer(tmp_path):
@@ -31,6 +32,34 @@ def test_rendered_fixture_contains_every_java_layer(tmp_path):
         assert "{{" not in rendered
         assert "}}" not in rendered
         assert f"package {CONTEXT[package_key]};" in rendered
+
+
+def test_real_sqlite_fixture_uses_generated_package_paths_and_closes_database(tmp_path):
+    files = render_real_sqlite_fixture(tmp_path)
+
+    assert len(files) == len(TEMPLATES) == 6
+    assert {path.relative_to(tmp_path / "src" / "main" / "java").as_posix() for path in files} == {
+        "com/dbjavagenix/compilefixture/entity/Invoice.java",
+        "com/dbjavagenix/compilefixture/dao/InvoiceDao.java",
+        "com/dbjavagenix/compilefixture/dto/InvoiceDTO.java",
+        "com/dbjavagenix/compilefixture/service/InvoiceService.java",
+        "com/dbjavagenix/compilefixture/service/impl/InvoiceServiceImpl.java",
+        "com/dbjavagenix/compilefixture/controller/InvoiceController.java",
+    }
+    dto = next(path for path in files if path.name == "InvoiceDTO.java").read_text(encoding="utf-8")
+    service = next(path for path in files if path.name == "InvoiceService.java").read_text(
+        encoding="utf-8"
+    )
+    controller = next(path for path in files if path.name == "InvoiceController.java").read_text(
+        encoding="utf-8"
+    )
+    assert "package com.dbjavagenix.compilefixture.dto;" in dto
+    assert "import com.dbjavagenix.compilefixture.dto.InvoiceDTO;" in service
+    assert "import com.dbjavagenix.compilefixture.dto.InvoiceDTO;" in controller
+
+    database_path = tmp_path / "invoice.db"
+    database_path.unlink()
+    assert not database_path.exists()
 
 
 def test_fixture_pom_locks_java_and_spring_boot_versions():


### PR DESCRIPTION
## 关联 Issue

Closes #147

本 PR 修复真实数据库代码生成时 DTO/VO 包路径与 Java package/import 不一致的问题。

## 背景（Situation）

当 generation_config 覆盖基础包名时，生成器遗漏 dtoPackage 与 voPackage；带表前缀或空 packageSuffix 时还可能产生双斜杠路径，导致 InvoiceDTO.java 无法被 Service 和 Controller 正确导入。

## 任务（Task）

统一 DTO/VO 包上下文、输出路径和 Java package/import，保证自定义基础包名、表前缀子包和无后缀配置一致，并通过真实 SQLite 文件 fixture 与 Java 编译验证。

## 行动（Action）

- 补齐 CodegenAnalyzer 上下文中的 dtoPackage、voPackage 重建逻辑。
- 规范 CodegenGenerator 与 atomic MCP 路径计算，消除空路径段。
- 增加 DTO/VO 包重建、后缀路径、atomic 路径和 import 回归测试。
- 增加 SQLite 文件元数据到临时 Maven 工程的真实生成与编译 smoke。
- 没有做：未修改数据库 schema、SQL、模板分类语义或公共 MCP 输入字段。

## 验证（Verification）

环境：Windows；Python 3.12.12；SQLite 3.50.4；Java 21.0.12.1；Maven 3.9.16。

- 单元测试：683 passed。
- Java 模板渲染：All Java templates rendered successfully。
- Java 编译 smoke：6 files BUILD SUCCESS。
- Ruff check：All checks passed；git diff --check 无输出。

## 实验与证据（Evidence）

固定创建 invoice 表，包含自增主键、DECIMAL 和 DATETIME 字段，经 ConnectionManager、CodegenAnalyzer 和 CodegenGenerator 生成六个 sb35-java21 文件。DTO package 与 Service/Controller import 均为 com.dbjavagenix.compilefixture.dto，随后 Maven clean compile 成功；fixture 成功后自动清理。

## 兼容性、风险与回滚

保留已有模板上下文和层级规则；真实 MySQL/PostgreSQL 生成未在本机重复，Maven 实验依赖缓存或网络。本 PR 不宣称性能收益。恢复提交 b48f93d 可撤销本主题，不涉及用户数据迁移；后续补充真实数据库权限与版本矩阵。