### PR TITLE
:zap: perf(metadata): 缓存连接级表元数据

### DIFF
--- a/docs/benchmarks/introspection.md
+++ b/docs/benchmarks/introspection.md
@@ -11,16 +11,20 @@ $env:PYTHONPATH = "src"
 python scripts/benchmark_introspection.py --iterations 30 --warmup 5
 ```
 
-输出为 JSON，包含中位数、P95、最小/最大延迟，以及每次描述调用的 SQL 查询次数。固定 schema 包含 `users`、`orders`、复合索引和外键，确保不同提交使用相同输入。
+输出为 JSON，包含冷调用与热调用的中位数、P95、最小/最大延迟，以及 SQL 查询次数。`queries_per_call`
+表示清空缓存后的冷调用往返数，`warm_queries_per_call` 表示缓存命中时每次调用的平均往返数。
+固定 schema 包含 `users`、`orders`、复合索引和外键，确保不同提交使用相同输入。
 
 ## 解释结果
 
-- `queries_per_call` 用于识别 SQL 往返次数变化；它比单次延迟更适合作为代码优化的稳定信号。
+- `queries_per_call` 用于识别冷路径 SQL 往返次数，`warm_queries_per_call` 应在缓存命中时为 0；
+  它们比单次延迟更适合作为代码优化的稳定信号。
 - 延迟受操作系统、Python 版本和当前负载影响。提交 PR 时应附上命令、环境和原始 JSON，不将本地数字写成普遍性能保证。
 - 当前基准只覆盖 SQLite；PostgreSQL/MySQL 对比需要可用的真实实例或 CI 服务后再扩展。
 
 ## 当前范围
 
-当前基准包含 SQLite 自增主键识别所需的 `sqlite_master` DDL 查询，因此固定 schema 的
-`describe_table` 每次调用包含 7 次 SQL 往返。该变化是元数据完整性修复的直接成本，不代表
-性能提升或跨环境结论。后续优化必须先用该基准记录前后结果，并同时确认元数据契约测试仍通过。
+当前基准包含 SQLite 自增主键识别所需的 `sqlite_master` DDL 查询，因此固定 schema 的冷
+`describe_table` 包含 7 次 SQL 往返；连接级缓存的热调用不产生 SQL 往返。延迟受操作系统、
+Python 版本和当前负载影响，不代表性能提升或跨环境结论。后续优化必须同时记录冷/热结果和
+元数据契约测试结果。

--- a/scripts/benchmark_introspection.py
+++ b/scripts/benchmark_introspection.py
@@ -80,7 +80,7 @@ def _percentile(samples: list[float], percentile: float) -> float:
 
 
 def run_benchmark(iterations: int = 30, warmup: int = 5) -> dict[str, Any]:
-    """Measure SQLite ``describe_table`` latency and SQL round trips."""
+    """Measure cold and warm SQLite ``describe_table`` latency and round trips."""
     if iterations < 1:
         raise ValueError("iterations must be at least 1")
     if warmup < 0:
@@ -100,10 +100,16 @@ def run_benchmark(iterations: int = 30, warmup: int = 5) -> dict[str, Any]:
     try:
         for _ in range(warmup):
             introspector.describe_table(connection_id, "orders")
+
+        manager.invalidate_metadata_cache(connection_id)
+        query_count = 0
+        cold_start = time.perf_counter()
+        metadata = introspector.describe_table(connection_id, "orders")
+        cold_ms = (time.perf_counter() - cold_start) * 1000
+        cold_queries = query_count
         query_count = 0
 
         samples: list[float] = []
-        metadata: dict[str, Any] = {}
         for _ in range(iterations):
             start = time.perf_counter()
             metadata = introspector.describe_table(connection_id, "orders")
@@ -118,7 +124,9 @@ def run_benchmark(iterations: int = 30, warmup: int = 5) -> dict[str, Any]:
             "columns": len(metadata["columns"]),
             "indexes": len(metadata["indexes"]),
             "foreign_keys": len(metadata["foreign_keys"]),
-            "queries_per_call": query_count / iterations,
+            "queries_per_call": cold_queries,
+            "warm_queries_per_call": query_count / iterations,
+            "cold_ms": cold_ms,
             "min_ms": min(samples),
             "median_ms": statistics.median(samples),
             "p95_ms": _percentile(samples, 0.95),

--- a/src/dbjavagenix/database/connection_manager.py
+++ b/src/dbjavagenix/database/connection_manager.py
@@ -1,6 +1,10 @@
 """
 Database connection manager for DBJavaGenix MCP tools
 """
+from copy import deepcopy
+from collections import OrderedDict
+import re
+from threading import RLock
 import uuid
 from typing import Dict, List, Any, Optional
 import pymysql
@@ -15,6 +19,32 @@ from .capabilities import SUPPORTED_DATABASE_TYPES, supported_database_type_valu
 
 logger = logging.getLogger(__name__)
 
+_SCHEMA_CHANGE_PATTERN = re.compile(
+    r"^\s*(?:CREATE|ALTER|DROP|RENAME|TRUNCATE|COMMENT)\b", re.IGNORECASE
+)
+_METADATA_CACHE_MAX_ENTRIES = 256
+
+
+def _is_schema_change_query(query: object) -> bool:
+    """Detect schema-changing SQL after optional leading comments."""
+    if not isinstance(query, str):
+        return False
+    remaining = query.lstrip()
+    while remaining:
+        if remaining.startswith("--") or remaining.startswith("#"):
+            newline = remaining.find("\n")
+            if newline < 0:
+                return False
+            remaining = remaining[newline + 1 :].lstrip()
+        elif remaining.startswith("/*"):
+            end = remaining.find("*/", 2)
+            if end < 0:
+                return False
+            remaining = remaining[end + 2 :].lstrip()
+        else:
+            break
+    return bool(_SCHEMA_CHANGE_PATTERN.match(remaining))
+
 
 class ConnectionManager:
     """Manages database connections for MCP tools"""
@@ -22,6 +52,54 @@ class ConnectionManager:
     def __init__(self):
         self.connections: Dict[str, Any] = {}
         self.connection_configs: Dict[str, DatabaseConfig] = {}
+        self._metadata_cache: OrderedDict[
+            tuple[str, str, Optional[str]], Dict[str, Any]
+        ] = OrderedDict()
+        self._metadata_cache_lock = RLock()
+
+    def get_cached_metadata(
+        self, connection_id: str, table_name: str, schema: Optional[str] = None
+    ) -> Optional[Dict[str, Any]]:
+        """Return a deep copy of one connection-scoped metadata entry, if present."""
+        key = (connection_id, table_name, schema)
+        with self._metadata_cache_lock:
+            cached = self._metadata_cache.get(key)
+            if cached is None:
+                return None
+            self._metadata_cache.move_to_end(key)
+            return deepcopy(cached)
+
+    def cache_metadata(
+        self,
+        connection_id: str,
+        table_name: str,
+        schema: Optional[str],
+        metadata: Dict[str, Any],
+    ) -> None:
+        """Store a complete metadata document without sharing mutable references."""
+        key = (connection_id, table_name, schema)
+        with self._metadata_cache_lock:
+            self._metadata_cache.pop(key, None)
+            self._metadata_cache[key] = deepcopy(metadata)
+            while len(self._metadata_cache) > _METADATA_CACHE_MAX_ENTRIES:
+                self._metadata_cache.popitem(last=False)
+
+    def invalidate_metadata_cache(self, connection_id: Optional[str] = None) -> None:
+        """Invalidate all metadata or only entries belonging to one connection."""
+        with self._metadata_cache_lock:
+            if connection_id is None:
+                self._metadata_cache.clear()
+                return
+            stale_keys = [
+                key for key in self._metadata_cache if key[0] == connection_id
+            ]
+            for key in stale_keys:
+                self._metadata_cache.pop(key, None)
+
+    def metadata_cache_size(self) -> int:
+        """Return the number of cached metadata documents for diagnostics/tests."""
+        with self._metadata_cache_lock:
+            return len(self._metadata_cache)
     
     def create_connection(self, config: DatabaseConfig) -> str:
         """
@@ -135,6 +213,7 @@ class ConnectionManager:
             True if connection was closed, False if not found
         """
         if connection_id not in self.connections:
+            self.invalidate_metadata_cache(connection_id)
             return False
         
         try:
@@ -142,6 +221,7 @@ class ConnectionManager:
             connection.close()
             self.connections.pop(connection_id, None)
             self.connection_configs.pop(connection_id, None)
+            self.invalidate_metadata_cache(connection_id)
             logger.info(f"Closed connection {connection_id}")
             return True
         except Exception as e:
@@ -149,6 +229,7 @@ class ConnectionManager:
             # Remove from dict anyway
             self.connections.pop(connection_id, None)
             self.connection_configs.pop(connection_id, None)
+            self.invalidate_metadata_cache(connection_id)
             return True
     
     def get_connection_info(self, connection_id: str) -> Optional[DatabaseConfig]:
@@ -216,6 +297,7 @@ class ConnectionManager:
         Raises:
             DatabaseQueryError: If query execution fails
         """
+        schema_change = _is_schema_change_query(query)
         try:
             with self.get_cursor(connection_id) as cursor:
                 cursor.execute(query, params or ())
@@ -233,11 +315,17 @@ class ConnectionManager:
                         else:  # MySQL
                             result.append(dict(zip(columns, row)))
                     
+                    if schema_change:
+                        self.invalidate_metadata_cache(connection_id)
                     return result
                 else:
+                    if schema_change:
+                        self.invalidate_metadata_cache(connection_id)
                     return []  # No results (e.g., INSERT/UPDATE/DELETE)
                     
         except Exception as e:
+            if schema_change:
+                self.invalidate_metadata_cache(connection_id)
             logger.error(f"Query execution failed: {e}")
             raise DatabaseQueryError(f"Failed to execute query: {str(e)}")
     

--- a/src/dbjavagenix/database/introspection.py
+++ b/src/dbjavagenix/database/introspection.py
@@ -6,6 +6,7 @@ stays in this module so callers do not need to branch on vendor details.
 
 from __future__ import annotations
 
+from copy import deepcopy
 import re
 from typing import Any, Dict, List
 
@@ -519,6 +520,12 @@ class DatabaseIntrospector:
         self, connection_id: str, table_name: str, schema: str | None = None
     ) -> Dict[str, Any]:
         """Return one normalized metadata document for a table."""
+        get_cached = getattr(self.connection_manager, "get_cached_metadata", None)
+        if callable(get_cached):
+            cached = get_cached(connection_id, table_name, schema)
+            if cached is not None:
+                return cached
+
         table = self.get_table(connection_id, table_name, schema)
         resolved_schema = schema or table.get("schema")
         columns = self.get_columns(connection_id, table_name, resolved_schema)
@@ -530,7 +537,7 @@ class DatabaseIntrospector:
             column["primary_key"] = (
                 column.get("primary_key", False) or column["name"] in primary_key_set
             )
-        return {
+        metadata = {
             "name": table["name"],
             "schema": resolved_schema,
             "comment": table.get("comment", ""),
@@ -541,3 +548,7 @@ class DatabaseIntrospector:
             "foreign_keys": foreign_keys,
             "indexes": indexes,
         }
+        cache_metadata = getattr(self.connection_manager, "cache_metadata", None)
+        if callable(cache_metadata):
+            cache_metadata(connection_id, table_name, schema, metadata)
+        return deepcopy(metadata)

--- a/tests/unit/test_connection_manager.py
+++ b/tests/unit/test_connection_manager.py
@@ -88,6 +88,32 @@ class TestCloseConnection:
         assert mgr.close_connection("nope") is False
 
 
+class TestMetadataCache:
+    def test_cache_returns_copies_and_evicts_oldest_entry(self):
+        mgr = ConnectionManager()
+        payload = {"columns": [{"name": "id"}]}
+
+        for index in range(257):
+            mgr.cache_metadata("connection", f"table_{index}", None, payload)
+
+        assert mgr.metadata_cache_size() == 256
+        assert mgr.get_cached_metadata("connection", "table_0") is None
+        cached = mgr.get_cached_metadata("connection", "table_1")
+        assert cached == payload
+        cached["columns"].clear()
+        assert mgr.get_cached_metadata("connection", "table_1") == payload
+
+    def test_invalidate_cache_is_connection_scoped(self):
+        mgr = ConnectionManager()
+        mgr.cache_metadata("connection-a", "users", None, {})
+        mgr.cache_metadata("connection-b", "users", None, {})
+
+        mgr.invalidate_metadata_cache("connection-a")
+
+        assert mgr.get_cached_metadata("connection-a", "users") is None
+        assert mgr.get_cached_metadata("connection-b", "users") == {}
+
+
 class TestListConnections:
     def test_lists_active(self, sqlite_config):
         mgr = ConnectionManager()

--- a/tests/unit/test_database_introspection.py
+++ b/tests/unit/test_database_introspection.py
@@ -78,6 +78,116 @@ def test_sqlite_introspection_returns_normalized_metadata():
         manager.close_connection(connection_id)
 
 
+def test_describe_table_reuses_connection_scoped_cache_and_returns_copies():
+    manager, connection_id = _sqlite_manager()
+    calls = []
+    original_execute = manager.execute_query
+
+    def counted_execute(*args, **kwargs):
+        calls.append((args, kwargs))
+        return original_execute(*args, **kwargs)
+
+    manager.execute_query = counted_execute
+    introspector = DatabaseIntrospector(manager)
+    try:
+        first = introspector.describe_table(connection_id, "orders")
+        assert len(calls) == 7
+        assert manager.metadata_cache_size() == 1
+
+        first["columns"].clear()
+        second = introspector.describe_table(connection_id, "orders")
+
+        assert len(calls) == 7
+        assert second["columns"]
+        assert second is not first
+    finally:
+        manager.close_connection(connection_id)
+
+
+def test_metadata_cache_key_includes_schema():
+    manager, connection_id = _sqlite_manager()
+    calls = []
+    original_execute = manager.execute_query
+
+    def counted_execute(*args, **kwargs):
+        calls.append((args, kwargs))
+        return original_execute(*args, **kwargs)
+
+    manager.execute_query = counted_execute
+    introspector = DatabaseIntrospector(manager)
+    try:
+        introspector.describe_table(connection_id, "orders")
+        introspector.describe_table(connection_id, "orders", "main")
+
+        assert len(calls) == 14
+        assert manager.metadata_cache_size() == 2
+    finally:
+        manager.close_connection(connection_id)
+
+
+def test_schema_change_invalidates_metadata_cache():
+    manager, connection_id = _sqlite_manager()
+    calls = []
+    original_execute = manager.execute_query
+
+    def counted_execute(*args, **kwargs):
+        calls.append((args, kwargs))
+        return original_execute(*args, **kwargs)
+
+    manager.execute_query = counted_execute
+    introspector = DatabaseIntrospector(manager)
+    try:
+        introspector.describe_table(connection_id, "orders")
+        assert manager.metadata_cache_size() == 1
+
+        manager.execute_query(connection_id, "ALTER TABLE orders ADD COLUMN status TEXT")
+        assert manager.metadata_cache_size() == 0
+        refreshed = introspector.describe_table(connection_id, "orders")
+
+        assert [column["name"] for column in refreshed["columns"]][-1] == "status"
+        assert len(calls) == 15
+    finally:
+        manager.close_connection(connection_id)
+
+
+def test_commented_schema_change_invalidates_metadata_cache():
+    manager, connection_id = _sqlite_manager()
+    introspector = DatabaseIntrospector(manager)
+    try:
+        introspector.describe_table(connection_id, "orders")
+        assert manager.metadata_cache_size() == 1
+
+        manager.execute_query(
+            connection_id,
+            "/* migration */ ALTER TABLE orders ADD COLUMN archived INTEGER",
+        )
+
+        assert manager.metadata_cache_size() == 0
+    finally:
+        manager.close_connection(connection_id)
+
+
+def test_closing_connection_clears_metadata_cache():
+    manager, connection_id = _sqlite_manager()
+    DatabaseIntrospector(manager).describe_table(connection_id, "orders")
+
+    assert manager.metadata_cache_size() == 1
+    assert manager.close_connection(connection_id) is True
+    assert manager.metadata_cache_size() == 0
+
+
+def test_metadata_cache_does_not_store_failed_introspection():
+    manager, connection_id = _sqlite_manager()
+    introspector = DatabaseIntrospector(manager)
+    try:
+        with pytest.raises(DatabaseAnalysisError, match="not found"):
+            introspector.describe_table(connection_id, "missing_table")
+
+        assert manager.metadata_cache_size() == 0
+    finally:
+        manager.close_connection(connection_id)
+
+
 def test_sqlite_introspection_detects_autoincrement_primary_key():
     manager = ConnectionManager()
     connection_id = manager.create_connection(

--- a/tests/unit/test_introspection_benchmark.py
+++ b/tests/unit/test_introspection_benchmark.py
@@ -19,7 +19,9 @@ def test_benchmark_reports_contract_and_round_trip_baseline():
     assert result["indexes"] == 2
     assert result["foreign_keys"] == 1
     assert result["queries_per_call"] == 7
+    assert result["warm_queries_per_call"] == 0
     assert 0 < result["median_ms"] <= result["p95_ms"] <= result["max_ms"]
+    assert result["cold_ms"] > 0
 
 
 @pytest.mark.parametrize("iterations, warmup, message", [(0, 1, "at least 1"), (1, -1, "negative")])


### PR DESCRIPTION
## 关联 Issue

Closes #151

## 背景（Situation）

`DatabaseIntrospector.describe_table()` 每次都重新读取表、列、主键、外键和索引元数据。同一 MCP 会话中的表详情、代码生成和可视化请求可能重复命中同一连接与表；SQLite 固定 fixture 的一次冷调用包含 7 次 SQL 往返，真实 catalog 查询成本更高。重复读取增加延迟和数据库负载，且原有实现没有连接生命周期内的缓存/失效边界。

## 任务（Task）

在不改变标准化元数据合同、MCP JSON 或数据库查询语义的前提下，增加连接级表元数据缓存。要求缓存按连接、表和 schema 隔离，返回深拷贝，schema 变更和连接关闭时失效，并用同一 fixture 记录冷/热 SQL 往返与延迟证据。

## 行动（Action）

- `ConnectionManager` 增加线程安全的 OrderedDict LRU 元数据缓存，最多保留 256 条；提供读取、写入、按连接失效、全量条目数诊断接口。
- `DatabaseIntrospector.describe_table()` 在完整合同成功后写入缓存，命中时返回独立深拷贝；异常结果不会写入缓存。
- `ConnectionManager.execute_query()` 识别带可选 SQL 注释前缀的 CREATE、ALTER、DROP、RENAME、TRUNCATE、COMMENT，并在成功或失败后失效对应连接缓存；关闭连接同样清理。
- `scripts/benchmark_introspection.py` 扩展为冷路径和热路径测量，`queries_per_call` 表示冷调用，`warm_queries_per_call` 表示缓存命中平均值。
- 单元测试覆盖深拷贝、schema key、LRU 淘汰、连接隔离、DDL 失效、注释前缀 DDL、关闭清理和异常不缓存；SQLite 文件生成集成契约未改动。
- 没有做什么：不缓存查询数据，不引入 Redis/外部服务，不改变 introspection SQL、权限、MCP 响应字段或跨进程一致性。

## 验证（Verification）

环境：Windows 10.0.26200，Python 3.10.1，pytest 9.0.3，SQLite 内存/文件 fixture。

- `$env:PYTHONPATH='src'; python -m pytest tests/unit/ -q`：`688 passed in 5.46s`。
- `$env:PYTHONPATH='src'; python -m pytest tests/integration/test_sqlite_file_codegen_contract.py -q --no-cov`：`1 passed in 0.11s`。
- `python -m ruff check`（本次修改的 6 个 Python 文件）：`All checks passed`。
- `python -m ruff format --check`（本次修改的 5 个 Python 文件）：`5 files already formatted`。
- `git diff --check`：无输出。
- `python scripts/benchmark_introspection.py --iterations 30 --warmup 5`（当前分支）：冷 `queries_per_call=7`、热 `warm_queries_per_call=0.0`，热中位数 `0.0348 ms`。
- 同一命令在 `origin/main` 临时 worktree：每次 `7.0` 次 SQL，中位数 `0.13765 ms`。
- 以上是本机受控 fixture 的对比，不代表 MySQL/PostgreSQL 或 CI 结果；提交后未查询或轮询 CI。

## 实验与证据（Evidence）

实验固定 `users`、`orders`、外键和复合索引 schema，预热 5 次、采样 30 次。基线 worktree 的 `describe_table` 每次执行 7 次 SQL，P50 为 `0.13765 ms`；当前分支先清空缓存执行一次冷调用（7 次 SQL，`0.2287 ms`），再执行 30 次热调用（0 次 SQL，P50 `0.0348 ms`，P95 `0.0371 ms`）。热路径的改进来自跳过 catalog 往返，冷路径合同和查询次数保持不变。

回归输入还包含带注释的 ALTER、连接关闭、超过 256 条不同 key、不同 schema 和人为抛错的 metadata stub。每种输入均验证缓存不会跨连接/跨 schema 污染，调用方清空返回列表不会影响下一次结果，失败或 schema 变更后会重新读取。

未测边界：真实 MySQL/PostgreSQL 延迟、跨进程共享、极端并发下的重复 miss、生产 DDL 事务语义和缓存容量的业务最优值；这些不由本 PR 的实验结论覆盖。

## 兼容性、风险与回滚

- 兼容性：`describe_table` 返回字段和类型保持不变；没有命中缓存时仍执行原有 7 类 metadata 查询。缓存值不含连接对象、密码或查询数据。
- 风险：外部连接在本进程之外执行 DDL 时无法被本地失效检测，下一次读取可能暂时使用旧缓存；256 条上限会在大 schema 上产生可接受的重新读取。并发 miss 可能重复查询但不会共享可变结果。
- 回滚：恢复提交 `a03ee9c` 即可撤销缓存与 benchmark 变化，不涉及数据库迁移或用户数据。
- 后续 Issue：在真实 MySQL/PostgreSQL fixture 和受控并发基准上测量命中率、P50/P95、错误率，并决定是否需要显式 invalidate API 或更细粒度锁。