### PR TITLE
:bug: fix(query): 收紧 FETCH 分页与 PostgreSQL 字符串解析

### DIFF
--- a/docs/roadmap-v0.3.md
+++ b/docs/roadmap-v0.3.md
@@ -44,6 +44,10 @@
   返回值的 Raw Response JSON 序列化。特殊标识符、空结果和表达式/复合键的更多真实跨方言组合、
   未记录的锁语法、查询资源限制与其他 MCP handler 仍未形成完整合同。
 
+  当前分支补充 PostgreSQL dollar-quoted literal 的 tokenizer 支持，并将 PostgreSQL/SQLite
+  的 `FETCH FIRST/NEXT ... ONLY` 纳入结果上限重写；`WITH TIES` 在无法证明不超限时明确拒绝。
+  该项仍需真实方言实例验证，当前只计入本地回归证据。
+
 ## 优先级路线
 
 优先级只表示依赖关系，不代表预先承诺实现结果。每项工作开始前都要创建独立 Issue。

--- a/src/dbjavagenix/database/mcp_tools.py
+++ b/src/dbjavagenix/database/mcp_tools.py
@@ -55,6 +55,7 @@ _LOCKING_READ_CLAUSES = (
     ("FOR", "KEY", "SHARE"),
     ("LOCK", "IN", "SHARE", "MODE"),
 )
+_DOLLAR_QUOTE_PATTERN = re.compile(r"\$(?:[A-Za-z_][A-Za-z0-9_]*)?\$")
 
 
 def _query_result_json_default(value: object) -> object:
@@ -122,6 +123,17 @@ def _tokenize_read_only_sql(query: str) -> List[tuple[str, str]]:
 
         if query.startswith("/*", index) or query.startswith("--", index) or char == "#":
             raise MCPServiceError("SQL comments are not allowed in read-only queries")
+
+        dollar_quote = _DOLLAR_QUOTE_PATTERN.match(query, index)
+        if dollar_quote:
+            delimiter = dollar_quote.group(0)
+            end = query.find(delimiter, dollar_quote.end())
+            if end < 0:
+                raise MCPServiceError("Unterminated dollar-quoted value in SQL query")
+            end += len(delimiter)
+            tokens.append(("quoted", query[index:end]))
+            index = end
+            continue
 
         if char in "'\"`":
             quote = char
@@ -200,6 +212,13 @@ def _validate_read_only_query(query: Any) -> str:
     if _contains_locking_read_clause(tokens):
         raise MCPServiceError("Only non-locking read-only SELECT queries are allowed")
 
+    if re.search(
+        r"\bFETCH\s+(?:FIRST|NEXT)\s+\d+\s+ROWS?\s+WITH\s+TIES\b",
+        _mask_sql_literals(normalized),
+        re.IGNORECASE,
+    ):
+        raise MCPServiceError("FETCH WITH TIES is not supported because it can exceed the row limit")
+
     depth = 0
     top_level_select = first_word == "SELECT"
     for kind, value in tokens:
@@ -228,19 +247,8 @@ def _validate_read_only_query(query: Any) -> str:
 
 
 def _has_top_level_limit_clause(query: str) -> bool:
-    tokens = _tokenize_read_only_sql(query)
-    depth = 0
-    for index, (kind, value) in enumerate(tokens):
-        if kind == "symbol":
-            if value == "(":
-                depth += 1
-            elif value == ")":
-                depth -= 1
-        elif kind == "word" and value == "LIMIT" and depth == 0:
-            next_token = tokens[index + 1] if index + 1 < len(tokens) else None
-            if next_token and (next_token[0] == "symbol" or next_token[1] == "ALL"):
-                return True
-    return False
+    """Return whether a query contains a cap understood by the rewriter."""
+    return _top_level_limit_span(query) is not None
 
 
 def _top_level_limit_span(query: str) -> tuple[int, int, int | None] | None:
@@ -250,30 +258,7 @@ def _top_level_limit_span(query: str) -> tuple[int, int, int | None] | None:
     cannot affect the server-side result cap. The optional ``LIMIT offset,count``
     form returns the row-count span rather than the offset span.
     """
-    masked = list(query)
-    index = 0
-    while index < len(masked):
-        if masked[index] not in "'\"`":
-            index += 1
-            continue
-        quote = masked[index]
-        index += 1
-        while index < len(masked):
-            masked[index] = " "
-            if query[index] == quote:
-                if index + 1 < len(masked) and query[index + 1] == quote:
-                    masked[index + 1] = " "
-                    index += 2
-                    continue
-                index += 1
-                break
-            if query[index] == "\\" and quote == "'" and index + 1 < len(masked):
-                masked[index + 1] = " "
-                index += 2
-                continue
-            index += 1
-
-    masked_query = "".join(masked)
+    masked_query = _mask_sql_literals(query)
 
     def is_top_level(position: int) -> bool:
         depth = 0
@@ -294,7 +279,55 @@ def _top_level_limit_span(query: str) -> tuple[int, int, int | None] | None:
         if is_top_level(match.start()):
             value = match.group(1).upper()
             return match.start(1), match.end(1), None if value == "ALL" else int(value)
+
+    fetch_form = re.compile(
+        r"\bFETCH\s+(?:FIRST|NEXT)\s+(\d+)\s+ROWS?\s+ONLY\b", re.IGNORECASE
+    )
+    for match in fetch_form.finditer(masked_query):
+        if is_top_level(match.start()):
+            return match.start(1), match.end(1), int(match.group(1))
     return None
+
+
+def _mask_sql_literals(query: str) -> str:
+    """Replace quoted SQL literals with spaces while preserving offsets."""
+    masked = list(query)
+    index = 0
+    while index < len(masked):
+        dollar_quote = _DOLLAR_QUOTE_PATTERN.match(query, index)
+        if dollar_quote:
+            delimiter = dollar_quote.group(0)
+            end = query.find(delimiter, dollar_quote.end())
+            if end < 0:
+                for position in range(index, len(masked)):
+                    masked[position] = " "
+                break
+            end += len(delimiter)
+            for position in range(index, end):
+                masked[position] = " "
+            index = end
+            continue
+
+        if masked[index] not in "'\"`":
+            index += 1
+            continue
+        quote = masked[index]
+        index += 1
+        while index < len(masked):
+            masked[index] = " "
+            if query[index] == quote:
+                if index + 1 < len(masked) and query[index + 1] == quote:
+                    masked[index + 1] = " "
+                    index += 2
+                    continue
+                index += 1
+                break
+            if query[index] == "\\" and quote == "'" and index + 1 < len(masked):
+                masked[index + 1] = " "
+                index += 2
+                continue
+            index += 1
+    return "".join(masked)
 
 
 def _apply_query_limit(query: str, limit: int) -> str:

--- a/tests/unit/test_mcp_query_safety.py
+++ b/tests/unit/test_mcp_query_safety.py
@@ -94,6 +94,118 @@ async def test_db_query_execute_preserves_lock_words_in_aliases_and_literals(mon
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "query",
+    [
+        "SELECT $$LIMIT 99; UPDATE users SET name = 'x'$$ AS body",
+        "SELECT $tag$FOR SHARE; (nested)$tag$ AS body",
+    ],
+)
+async def test_db_query_execute_ignores_keywords_inside_dollar_quoted_literals(monkeypatch, query):
+    received = []
+
+    monkeypatch.setattr(
+        mcp_tools.connection_manager,
+        "execute_query",
+        lambda _connection_id, executed_query: received.append(executed_query) or [],
+    )
+
+    response = await mcp_tools.handle_db_query_execute(
+        {"connection_id": "test", "query": query, "limit": 3}
+    )
+
+    assert "Query executed successfully" in response[0].text
+    assert received == [f"{query} LIMIT 3"]
+
+
+@pytest.mark.asyncio
+async def test_db_query_execute_rejects_unterminated_dollar_quoted_literal(monkeypatch):
+    called = False
+
+    def execute_query(*_args, **_kwargs):
+        nonlocal called
+        called = True
+        return []
+
+    monkeypatch.setattr(mcp_tools.connection_manager, "execute_query", execute_query)
+
+    response = await mcp_tools.handle_db_query_execute(
+        {"connection_id": "test", "query": "SELECT $tag$missing", "limit": 3}
+    )
+
+    assert "Unterminated dollar-quoted" in response[0].text
+    assert called is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("query", "expected"),
+    [
+        (
+            "SELECT id FROM users FETCH FIRST 100 ROWS ONLY",
+            "SELECT id FROM users FETCH FIRST 3 ROWS ONLY",
+        ),
+        (
+            "SELECT id FROM users FETCH NEXT 2 ROW ONLY",
+            "SELECT id FROM users FETCH NEXT 2 ROW ONLY",
+        ),
+        (
+            "SELECT * FROM (SELECT id FROM users FETCH FIRST 100 ROWS ONLY) AS rows",
+            "SELECT * FROM (SELECT id FROM users FETCH FIRST 100 ROWS ONLY) AS rows LIMIT 3",
+        ),
+    ],
+)
+async def test_db_query_execute_applies_limit_to_top_level_fetch(monkeypatch, query, expected):
+    received = []
+
+    monkeypatch.setattr(
+        mcp_tools.connection_manager,
+        "execute_query",
+        lambda _connection_id, executed_query: received.append(executed_query) or [],
+    )
+
+    response = await mcp_tools.handle_db_query_execute(
+        {"connection_id": "test", "query": query, "limit": 3}
+    )
+
+    assert "Query executed successfully" in response[0].text
+    assert received == [expected]
+
+
+@pytest.mark.asyncio
+async def test_db_query_execute_rejects_fetch_with_ties_before_execution(monkeypatch):
+    called = False
+
+    def execute_query(*_args, **_kwargs):
+        nonlocal called
+        called = True
+        return []
+
+    monkeypatch.setattr(mcp_tools.connection_manager, "execute_query", execute_query)
+
+    response = await mcp_tools.handle_db_query_execute(
+        {
+            "connection_id": "test",
+            "query": "SELECT id FROM users FETCH FIRST 10 ROWS WITH TIES",
+            "limit": 3,
+        }
+    )
+
+    assert "FETCH WITH TIES" in response[0].text
+    assert called is False
+
+
+def test_has_top_level_limit_clause_matches_supported_fetch_forms():
+    assert mcp_tools._has_top_level_limit_clause("SELECT 1 FETCH FIRST 2 ROWS ONLY") is True
+    assert (
+        mcp_tools._has_top_level_limit_clause(
+            "SELECT * FROM (SELECT 1 FETCH FIRST 2 ROWS ONLY) AS rows"
+        )
+        is False
+    )
+
+
+@pytest.mark.asyncio
 async def test_db_query_execute_accepts_cte_and_trailing_semicolon(monkeypatch):
     received = []
 


### PR DESCRIPTION
## 关联 Issue

Closes #153

## 背景（Situation）

公共 `db_query_execute` 的只读校验器只识别单引号、双引号和反引号字符串。PostgreSQL 的 dollar-quoted literal 会被拆成普通 token，字符串中的 `UPDATE`、锁词、括号或分号可能被误判。与此同时，PostgreSQL/SQLite 支持的 `FETCH FIRST/NEXT n ROWS ONLY` 没有进入结果上限重写路径，调用方的 `limit` 在该语法下无法可靠约束返回行数。

## 任务（Task）

在不改变 SQL 权限、Raw Response 或既有 LIMIT/CTE 语义的前提下，补齐 PostgreSQL dollar-quoted literal 解析，并将 top-level `FETCH FIRST/NEXT ... ONLY` 纳入结果上限约束；无法证明不超限的 `WITH TIES` 在执行前明确拒绝。

## 行动（Action）

- 在 `src/dbjavagenix/database/mcp_tools.py` 增加无标签和 ASCII 标签 dollar delimiter 的 quoted token 处理，未闭合 literal 返回明确校验错误。
- 将 SQL literal masking 提取为共享函数，避免 LIMIT/FETCH 检测扫描字符串内部关键字；新增 top-level FETCH 数值 span 替换。
- 对 `FETCH ... WITH TIES` 增加执行前拒绝，防止“看似有上限、实际可能超限”的语义。
- 扩展 `tests/unit/test_mcp_query_safety.py`，覆盖 dollar literal 关键字/伪多语句、未闭合、FETCH 大小上限、嵌套 FETCH、WITH TIES 和 helper 判断。
- 更新 `docs/roadmap-v0.3.md` 的查询契约进度。
- 没有做什么：不引入完整 SQL parser，不支持 Oracle/SQL Server 的 TOP 专有语法，不改变查询权限、事务、数据库数据或 JSON envelope。

## 验证（Verification）

环境：Windows 10.0.26200，Python 3.10.1，pytest 9.0.3，SQLite 查询 fixture。

- `$env:PYTHONPATH='src'; python -m pytest tests/unit/ -q`：`688 passed in 5.24s`。
- `$env:PYTHONPATH='src'; python -m pytest tests/integration/test_sqlite_mcp_query_contract.py -q --no-cov`：`2 passed in 0.49s`。
- `python -m ruff check src/dbjavagenix/database/mcp_tools.py tests/unit/test_mcp_query_safety.py`：`All checks passed`。
- `python -m ruff format --check src/dbjavagenix/database/mcp_tools.py tests/unit/test_mcp_query_safety.py`：`1 file already formatted`。
- `git diff --check`：无输出。
- 未运行 CI、真实 PostgreSQL/MySQL 或跨方言性能测试；提交后未查询或轮询 CI。

## 实验与证据（Evidence）

回归输入包含 `$$...$$` 和 `$tag$...$tag$` literal，其中嵌入分页词、锁词、关键字、括号与分号；tokenizer 将其作为单一 quoted token，handler 实际收到原 SQL 并仅在末尾追加请求上限。对 `FETCH FIRST 100 ROWS ONLY`，请求 `limit=3` 后实际发送 `FETCH FIRST 3 ROWS ONLY`；已有 `FETCH NEXT 2 ROW ONLY` 保持较小上限。嵌套子查询的 FETCH 不被重写，外层改用 `LIMIT 3`。未闭合 dollar literal 与 `WITH TIES` 均在 monkeypatch 的 `execute_query` 之前返回错误，调用次数为 0。

这些结果来自 pytest 原始终端输出和受控 stub 输入；没有把 SQLite 不支持的 FETCH 执行结果冒充真实数据库证据，也没有推断性能收益。

## 兼容性、风险与回滚

- 兼容性：既有单引号/双引号/反引号、SELECT/CTE、LIMIT/OFFSET、锁拒绝和 JSON 错误合同保持不变；新增语法只扩大合法 PostgreSQL 查询范围。
- 风险：复杂方言分页、参数化 FETCH、外部 SQL 扩展仍可能不被轻量 parser 接受；无法证明上限时选择拒绝，避免资源限制失效。
- 回滚：恢复提交 `46a57d0` 即可撤销 tokenizer 与 FETCH 逻辑，不涉及用户数据。
- 后续 Issue：在真实 PostgreSQL/SQLite 版本矩阵验证 FETCH 语法，并评估其他 MCP handler 的统一 SQL 上限合同。