### PR TITLE
:wrench: chore(repository): 统一主页文件提交元数据

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,6 +175,7 @@ ehthumbs.db
 Thumbs.db
 
 # Project specific
+# Repository metadata files stay tracked; only local overrides and generated state are ignored.
 .ci-smoke/
 config/local.yaml
 config/dev.yaml

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,4 @@
+SPDX-FileCopyrightText: 2025 Emily Johnson
 SPDX-License-Identifier: MIT
 
 MIT License

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -1,6 +1,7 @@
 # DBJavaGenix Configuration
 # Copy this file to config/local.yaml before adding local credentials.
 # Keep this tracked example limited to non-secret placeholder values.
+# Never replace placeholders here with credentials; keep local overrides untracked.
 
 # Database connection settings
 database:


### PR DESCRIPTION
## 关联 Issue

Closes #159

## 背景（Situation）

GitHub 仓库主页按路径显示最近一次触及该路径的提交摘要。config、.gitignore 和 LICENSE 仍分别继承 init、算法功能提交和 Initial commit 等历史标题，与当前统一的 Gitmoji + Conventional Commits 风格不一致。维护者和审查者难以从主页判断这些入口文件是否属于当前仓库基线；历史 commit object 本身也不应被重写。

## 任务（Task）

用一次可审查、可回滚的 chore(repository) 提交同时触及 config/、.gitignore 和 LICENSE，让三类主页路径共享同一个规范提交摘要，同时确保配置键值、忽略行为和 MIT 授权条款不发生语义变化。

## 行动（Action）

- 在 config/config.example.yaml 增加安全边界说明，明确凭据只放在未跟踪的本地覆盖文件。
- 在 .gitignore 的项目专属区域增加注释，说明仓库元数据保持跟踪、仅忽略本地覆盖和生成状态。
- 在 LICENSE 增加 SPDX-FileCopyrightText: 2025 Emily Johnson，保留原有 SPDX-License-Identifier、MIT 授权和免责声明全文。
- 只保留一次提交 766fea2；未修改运行时代码、依赖、CI、config/test.yaml 或用户未跟踪的 uv.lock。
- 没有做什么：不重写历史 commit object，不修改配置样例的键值，不删除许可证条款。

## 验证（Verification）

环境：Windows，Python 3.10.1；仓库基线 origin/main（bfbf3af）。

- python -c 解析 config/config.example.yaml：解析成功，顶层键为 ai、database、debug、generation、log_file、log_level。
- python scripts/validate_commit_title.py --title ":wrench: chore(repository): 统一主页文件提交元数据"：OK。
- git diff --cached --check：无输出。
- LICENSE 关键段落检查：SPDX-License-Identifier: MIT、MIT License、授权段落均存在。
- 没有运行时测试需要执行；未查询 CI，CI 留待合并前检查最终 HEAD。

## 实验与证据（Evidence）

- 固定输入为 config/config.example.yaml；解析后的顶层键集合保持 {database, ai, generation, debug, log_level, log_file}，只增加注释。
- 许可证条款、免责声明和版权行均保留，只新增机器可读 SPDX 版权元数据。
- 提交 766fea2 的变更路径为 .gitignore、LICENSE、config/config.example.yaml；合并后 GitHub 按路径计算的最近提交摘要将统一使用本 PR 标题。该结论不声称重写旧 commit，也不替代合并后的页面复核。
- 差异只包含注释和 SPDX 元数据，没有 Token、密码、连接串、生成物或本地配置。

## 兼容性、风险与回滚

- 兼容性：YAML 键值和解析结果不变；.gitignore 匹配规则不变；MIT 授权权限和免责声明不变。
- 风险：合并后主页路径摘要从历史标题切换为维护标题，属于预期展示变化；SPDX 版权年份沿用现有版权声明，不改变归属。
- 回滚：恢复单一提交 766fea2 即可，不涉及数据、数据库 schema、依赖或发布物。
- 后续：合并前仅对最终 HEAD 检查一次 required checks；历史不可变 commit 的旧标题保留在审计记录中，不伪造为已重写。
