### PR TITLE
:sparkles: feat(connection): 增加 MCP 连接释放工具

### DIFF
--- a/.claude/skills/java-codegen-from-db/SKILL.md
+++ b/.claude/skills/java-codegen-from-db/SKILL.md
@@ -216,6 +216,11 @@ LLM **必须**把 schema 概述、命名推断和模板推荐呈现给用户，�
 
 如果目标文件已存在,生成 `*.codegen.bak` 备份,告诉用户怎么回滚(`mv x.bak x`)。
 
+### 5.4 释放连接
+
+工作流结束或用户决定中止时,调用 **`db_disconnect`** with
+`{"connection_id": "<connection_id>"}`。释放后的 ID 不应继续用于查询或生成。
+
 ---
 
 ## 错误处理与重试规则
@@ -252,6 +257,7 @@ LLM **必须**把 schema 概述、命名推断和模板推荐呈现给用户，�
          codegen_render_dto         (×1 per 表, 仅 sb35-java21)
 
 [写盘]   (内置于上述工具,Phase 3 后拆出 file_write_to_project)
+[收尾]   db_disconnect                 (会话结束时释放连接)
 ```
 
 ## 设计原则

--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -86,6 +86,7 @@ En el cliente LLM, di "**Genera código Spring Boot a partir de las tres tablas 
 5. Llamará a `ai_recommend_template` para recomendar → detectará RBAC y recomendará `MybatisPlus-Mixed`
 6. Usará `codegen_build_context` + 5 `codegen_render_*` para generar por capas, devolviendo code-diff en cada capa
 7. Tras la confirmación del usuario, escribirá en disco
+8. Al finalizar la sesión, llamará a `db_disconnect(connection_id)` para liberar la conexión
 
 ## Capacidades principales (Fase 1 → 5)
 
@@ -126,11 +127,11 @@ En el cliente LLM, di "**Genera código Spring Boot a partir de las tres tablas 
 - Logs estructurados: `DBJAVAGENIX_LOG_FORMAT=json` permite salida de JSON en una sola línea, ideal para Loki/ELK
 - [Manual de despliegue](docs/deployment.md): 3 modos de despliegue + 6 escenarios de troubleshooting
 
-## Resumen de herramientas (33 en total)
+## Resumen de herramientas (34 en total)
 
 | Categoría | Herramienta |
 |------|------|
-| Conexión / Consulta | db_connect_test / db_query_databases / db_query_tables / db_query_table_exists / db_query_execute |
+| Conexión / Consulta | db_connect_test / db_disconnect / db_query_databases / db_query_tables / db_query_table_exists / db_query_execute |
 | Estructura de tabla | db_table_describe / db_table_columns / db_table_primary_keys / db_table_foreign_keys / db_table_indexes |
 | Algoritmos de grafo de schema | schema_topo_order / schema_cluster_tables / schema_check_cycles |
 | Generación de código (atómica) | codegen_build_context / codegen_render_entity / codegen_render_dao / codegen_render_service / codegen_render_controller / codegen_render_dto / codegen_render_mapper |
@@ -162,7 +163,7 @@ Consulta [`iteration-plan/01-target-architecture.md`](iteration-plan/01-target-a
 ```
 [ Capa Skills ]  Define "cómo hacerlo" — .claude/skills/*.md  Flujo de 5 fases explícito
        ↓
-[ Capa MCP ]     Proporciona "qué se puede hacer" — 33 herramientas  Contexto transferido explícitamente
+[ Capa MCP ]     Proporciona "qué se puede hacer" — 34 herramientas  Contexto transferido explícitamente
        ↓
 [ Capa Apps ]    Hace los resultados "visibles" — 4 componentes de UI (mermaid/dashboard/code-diff/tree)
 ```

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -85,6 +85,7 @@ LLM クライアントで、例えば **「myapp データベースの sys_user 
 5. `ai_recommend_template` でテンプレートを推薦し、RBAC を検出して `MybatisPlus-Mixed` を提案する
 6. `codegen_build_context` + 5 つの `codegen_render_*` でレイヤーごとに生成し、各レイヤーの code-diff を返す
 7. ユーザーの確認後にファイルへ書き込む
+8. セッション終了時に `db_disconnect(connection_id)` を呼び出して接続を解放する
 
 ## 主な機能（Phase 1 → 5）
 
@@ -130,11 +131,11 @@ LLM クライアントで、例えば **「myapp データベースの sys_user 
 - 構造化ログ: `DBJAVAGENIX_LOG_FORMAT=json` で Loki / ELK に適した 1 行 JSON を出力
 - [デプロイガイド](docs/deployment.md): 3 つのデプロイ方式 + 6 つのトラブルシューティング事例
 
-## ツール一覧（33 個）
+## ツール一覧（34 個）
 
 | カテゴリ | ツール |
 |------|------|
-| 接続 / クエリ | db_connect_test / db_query_databases / db_query_tables / db_query_table_exists / db_query_execute |
+| 接続 / クエリ | db_connect_test / db_disconnect / db_query_databases / db_query_tables / db_query_table_exists / db_query_execute |
 | テーブル構造 | db_table_describe / db_table_columns / db_table_primary_keys / db_table_foreign_keys / db_table_indexes |
 | スキーマグラフアルゴリズム | schema_topo_order / schema_cluster_tables / schema_check_cycles |
 | コード生成（アトミック） | codegen_build_context / codegen_render_entity / codegen_render_dao / codegen_render_service / codegen_render_controller / codegen_render_dto / codegen_render_mapper |
@@ -166,7 +167,7 @@ LLM クライアントで、例えば **「myapp データベースの sys_user 
 ```
 [ Skills 層 ]  「方法」を定義 — .claude/skills/*.md  明示的な 5 段階ワークフロー
        ↓
-[ MCP 層 ]     「できること」を提供 — 33 ツール  context を明示的に受け渡し
+[ MCP 層 ]     「できること」を提供 — 34 ツール  context を明示的に受け渡し
        ↓
 [ Apps 層 ]    結果を「見える化」 — 4 つの UI コンポーネント（mermaid/dashboard/code-diff/tree）
 ```

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ graph LR
     Skills[".claude/skills/<br/>java-codegen-from-db<br/>springboot-migration"]
     Skills -->|按需调用| MCP
 
-    subgraph MCP[MCP Server 33 工具]
+    subgraph MCP[MCP Server 34 工具]
         direction TB
         DB[db_* 连接 / 查询 / 描述]
         Atom[codegen_build_context<br/>codegen_render_entity/dao/service/<br/>controller/dto/mapper]
@@ -90,6 +90,7 @@ SQL Server 的类型映射保留为后续扩展准备，但尚未实现运行时
 5. 调用 `ai_recommend_template` 推荐 → 检测到 RBAC,推 `MybatisPlus-Mixed`
 6. 用 `codegen_build_context` + 6 个 `codegen_render_*` 分层生成,每层返回 code-diff
 7. 用户确认后写盘
+8. 会话结束时调用 `db_disconnect(connection_id)` 释放连接
 
 ## 核心能力 (Phase 1 → 5)
 
@@ -130,11 +131,11 @@ SQL Server 的类型映射保留为后续扩展准备，但尚未实现运行时
 - 结构化日志: `DBJAVAGENIX_LOG_FORMAT=json` 可输出单行 JSON,适合 Loki/ELK
 - [部署手册](docs/deployment.md): 3 种部署模式 + 6 个排障场景
 
-## 工具总览 (33 个)
+## 工具总览 (34 个)
 
 | 类别 | 工具 |
 |------|------|
-| 连接 / 查询 | db_connect_test / db_query_databases / db_query_tables / db_query_table_exists / db_query_execute |
+| 连接 / 查询 | db_connect_test / db_disconnect / db_query_databases / db_query_tables / db_query_table_exists / db_query_execute |
 | 表结构 | db_table_describe / db_table_columns / db_table_primary_keys / db_table_foreign_keys / db_table_indexes |
 | Schema 图算法 | schema_topo_order / schema_cluster_tables / schema_check_cycles |
 | 代码生成 (atomic) | codegen_build_context / codegen_render_entity / codegen_render_dao / codegen_render_service / codegen_render_controller / codegen_render_dto / codegen_render_mapper |
@@ -166,7 +167,7 @@ SQL Server 的类型映射保留为后续扩展准备，但尚未实现运行时
 ```
 [ Skills 层 ]  定义"怎么做" — .claude/skills/*.md  显式 5 阶段工作流
        ↓
-[ MCP 层 ]     提供"能做什么" — 33 个原子工具  context 显式传递
+[ MCP 层 ]     提供"能做什么" — 34 个原子工具  context 显式传递
        ↓
 [ Apps 层 ]    让结果"看得见" — 4 个 UI 组件 (mermaid/dashboard/code-diff/tree)
 ```
@@ -187,7 +188,7 @@ SQL Server 的类型映射保留为后续扩展准备，但尚未实现运行时
 | [docs/screenshots/README.md](docs/screenshots/README.md) | MCP Apps 4 组件客户端兼容性 |
 | [docs/algorithms-overview.md](docs/algorithms-overview.md) | v0.2.1 schema 图算法 (topo / cluster / cycle) |
 | [docs/design-patterns-catalog.md](docs/design-patterns-catalog.md) | 生成器与生成代码中的设计模式 |
-| [docs/adr/](docs/adr/) | 14 个 ADR (架构 / 原子 / 渐进 / 规则 / 不引依赖 / schema 算法 / 规范配置 / MCP v3 / 1h 缓存 / agentic / 多方言 / SDK 契约 / 工具契约 / 元数据契约) |
+| [docs/adr/](docs/adr/) | 15 个 ADR (架构 / 原子 / 渐进 / 规则 / 不引依赖 / schema 算法 / 规范配置 / MCP v3 / 1h 缓存 / agentic / 多方言 / SDK 契约 / 工具契约 / 元数据契约 / 连接生命周期) |
 | [.claude/skills/java-codegen-from-db/SKILL.md](.claude/skills/java-codegen-from-db/SKILL.md) | 主 Skill: 代码生成 5 阶段工作流 |
 | [.claude/skills/springboot-migration/SKILL.md](.claude/skills/springboot-migration/SKILL.md) | 第二 Skill: Spring Boot 2.7→3.x 迁移 |
 

--- a/docs/adr/015-connection-lifecycle.md
+++ b/docs/adr/015-connection-lifecycle.md
@@ -1,0 +1,44 @@
+# ADR-015: MCP 连接生命周期与显式释放
+
+- **状态**: Accepted
+- **日期**: 2026-09-09
+- **关联 Issue**: #209
+- **关联实现**: `src/dbjavagenix/database/mcp_tools.py`
+
+## 背景
+
+`ConnectionManager` 已经能够按 connection ID 关闭连接，但公共 MCP 合同只
+暴露 `db_connect_test`。长生命周期客户端无法在探索完成、重试失败或切换数据库
+时主动释放连接，连接对象和脱敏配置会一直保留到 server 进程退出。
+
+## 决定
+
+新增 `db_disconnect(connection_id)` 作为显式连接生命周期工具：
+
+1. handler 只负责校验参数、调用 `ConnectionManager.close_connection()` 和序列化
+   响应，不复制连接状态或驱动逻辑。
+2. 成功关闭返回 `success=true`；未知、空值和重复关闭统一返回
+   `success=false`、`error=connection_not_found`。
+3. 关闭异常返回 `disconnect_failed`，异常文本经过现有凭据脱敏边界后再返回。
+4. 工具加入 canonical MCP 列表和 progressive discovery 元数据；默认 progressive
+   可见集合不变，客户端可通过 `search_tools("disconnect")` 发现它。
+5. 客户端在会话结束时调用该工具；不引入连接池、TTL、后台回收或自动关闭策略。
+
+## 备选方案
+
+- 仅依赖进程退出时的 `__del__`：无法覆盖长会话中的提前释放和异常重试，已拒绝。
+- 增加后台 TTL：可能误杀仍在使用的连接，并引入不可预测的时序，已拒绝。
+- 在 handler 内直接操作驱动连接：会重复生命周期逻辑，绕过 `ConnectionManager`，已拒绝。
+
+## 影响
+
+- 连接建立和查询 API 保持兼容，旧客户端无需立即改造。
+- 释放后的 connection ID 不可继续使用；后续查询收到既有的连接不存在错误。
+- 显式释放降低长生命周期会话的资源占用，但不承诺性能收益或自动回收。
+
+## 验证
+
+- 单元测试覆盖工具 schema、成功关闭后的连接与配置清理、未知/空值/重复 ID、
+  异常脱敏以及 canonical server dispatch。
+- 使用 SQLite in-memory manager 和 monkeypatch 验证，不伪造真实 MySQL/PostgreSQL
+  连接释放结果。

--- a/docs/adr/016-async-database-boundary.md
+++ b/docs/adr/016-async-database-boundary.md
@@ -1,0 +1,45 @@
+# ADR-016: 将同步数据库调用移出 MCP 事件循环
+
+- **状态**: Accepted
+- **日期**: 2026-09-09
+- **关联 Issue**: #211
+- **关联实现**: `src/dbjavagenix/database/connection_manager.py`
+
+## 背景
+
+MCP handler 使用 `async def`，但数据库驱动和元数据 introspector 仍是同步实现。
+网络等待或大型 SQLite 查询会占住事件循环，使同一会话的健康检查、取消和其他连接请求
+延迟。SQLite 默认还会拒绝跨线程使用连接；多个 worker 直接共享一个连接也可能交叉使用
+cursor。
+
+## 决定
+
+1. 在 MCP 数据库边界统一使用 `asyncio.to_thread`；保留同步 `ConnectionManager` API，
+   供 CLI、测试和外部调用方继续使用。
+2. `ConnectionManager` 为每个 connection ID 建立可重入锁，锁覆盖健康探测、cursor
+   生命周期、SQL 执行和关闭；不同连接不共享这把锁。
+3. SQLite 连接启用 `check_same_thread=False`，但只有在上述连接锁保护下交给 worker。
+4. 异步 analyzer 通过 worker 中的短生命周期 event loop 执行，输入输出合同保持不变。
+5. 取消异步 handler 不强杀底层驱动调用；worker 返回后由 context manager 关闭 cursor，
+   连接仍可被显式 `db_disconnect` 释放。
+
+## 备选方案
+
+- 替换原生异步 MySQL/PostgreSQL 驱动：迁移成本高且会改变方言、事务和依赖边界，暂不采用。
+- 只在 handler 外包线程、不加连接锁：会留下 SQLite thread-affinity 和 cursor 交叉风险，
+  不采用。
+- 为每个请求建立新连接：增加连接开销并破坏现有 connection ID 生命周期，不采用。
+
+## 影响
+
+- 同步公共 API、SQL、事务提交/回滚、权限和 MCP 文本/Raw Response 保持不变。
+- 同一连接的数据库阶段串行，不同连接可以并行等待；不宣称生产吞吐提升。
+- worker 调度带来少量开销；驱动额外的线程绑定限制需要在真实 MySQL/PostgreSQL 环境
+  单独验证。
+
+## 验证
+
+- 受控 60ms 阻塞 driver + heartbeat 证明事件循环仍获调度。
+- fake cursor 实验覆盖同连接最大并发为 1、跨连接同时进入和 close 等待 SQL body 完成。
+- SQLite in-memory worker 查询和现有 SQLite MCP/codegen 合同继续通过；真实网络数据库
+  线程模型不在本地实验范围内。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -26,3 +26,4 @@
 ### v0.3 (数据库元数据契约)
 - [ADR-014: 统一数据库元数据描述契约](014-metadata-introspection-contract.md)
 - [ADR-015: MCP 连接生命周期与显式释放](015-connection-lifecycle.md)
+- [ADR-016: 将同步数据库调用移出 MCP 事件循环](016-async-database-boundary.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -25,3 +25,4 @@
 
 ### v0.3 (数据库元数据契约)
 - [ADR-014: 统一数据库元数据描述契约](014-metadata-introspection-contract.md)
+- [ADR-015: MCP 连接生命周期与显式释放](015-connection-lifecycle.md)

--- a/docs/demo-script.md
+++ b/docs/demo-script.md
@@ -49,7 +49,7 @@
 ```
 
 **说**:
-> "33 个工具就绪,modules 全部 OK。注意 progressive 模式 — 初始只暴露 6 个 always-visible 工具,启动 token 从 3300 降到 985。"
+> "34 个工具就绪,modules 全部 OK。注意 progressive 模式 — 初始只暴露 6 个 always-visible 工具,启动 token 从 3300 降到 985。"
 
 ### [0:45] 任务输入 (10 秒)
 
@@ -99,7 +99,7 @@
 **做**: `server_metrics` 看一下累积调用。
 
 **说**:
-> "整个流程透明可观测,33 个工具,5 阶段 Skill 编排,4 个 MCP App 组件。代码在 [github.com/ZhaoXingPeng/DBJavaGenix](https://github.com/ZhaoXingPeng/DBJavaGenix),完整迭代方案在 iteration-plan/ 目录。"
+> "整个流程透明可观测,34 个工具,5 阶段 Skill 编排,4 个 MCP App 组件。会话结束后调用 db_disconnect 释放连接。代码在 [github.com/ZhaoXingPeng/DBJavaGenix](https://github.com/ZhaoXingPeng/DBJavaGenix),完整迭代方案在 iteration-plan/ 目录。"
 
 ---
 
@@ -116,7 +116,7 @@
 
 打开 README.md 的 mermaid 架构图,讲三层:
 - **Skills**: `.claude/skills/java-codegen-from-db/SKILL.md` — 看一眼"5 阶段工作流"
-- **MCP 33 工具**: 强调 atomic 拆分 (db_codegen_generate → 7 个原子工具) 与 schema 图算法
+- **MCP 34 工具**: 强调 atomic 拆分 (db_codegen_generate → 7 个原子工具) 与 schema 图算法,以及显式 db_disconnect 生命周期
 - **Apps**: 4 个 UI 组件,客户端按 _meta 渲染
 
 提一句:

--- a/src/dbjavagenix/database/atomic_codegen_tools.py
+++ b/src/dbjavagenix/database/atomic_codegen_tools.py
@@ -23,6 +23,7 @@ P2.2: 原子化代码生成工具 - 把 db_codegen_generate 拆为 7 个职责�
 """
 
 import json
+import asyncio
 import logging
 from typing import Any, Dict, List
 
@@ -35,6 +36,20 @@ from ..generator.template_context import apply_generation_options
 from ..utils.json_serialization import dumps as _json_dumps
 
 logger = logging.getLogger(__name__)
+
+
+async def _run_db_call(callable_obj, *args, **kwargs):
+    """Run blocking database work outside the MCP event loop."""
+    return await asyncio.to_thread(callable_obj, *args, **kwargs)
+
+
+async def _run_async_db_call(callable_obj, *args, **kwargs):
+    """Run an async analyzer in a worker when it performs blocking I/O."""
+
+    def run():
+        return asyncio.run(callable_obj(*args, **kwargs))
+
+    return await _run_db_call(run)
 
 
 # ============================================================
@@ -221,10 +236,11 @@ async def handle_codegen_build_context(arguments: Dict[str, Any]) -> List[TextCo
             database = config.database or "information_schema"
 
         # 收集所有表名用于前缀分析(沿用旧逻辑)
-        all_table_names = _collect_all_table_names(connection_id, config)
+        all_table_names = await _run_db_call(_collect_all_table_names, connection_id, config)
 
         analyzer = CodegenAnalyzer(connection_manager)
-        analysis = await analyzer.analyze_table_for_codegen(
+        analysis = await _run_async_db_call(
+            analyzer.analyze_table_for_codegen,
             connection_id,
             table_name,
             all_table_names=all_table_names,

--- a/src/dbjavagenix/database/connection_manager.py
+++ b/src/dbjavagenix/database/connection_manager.py
@@ -2,6 +2,7 @@
 Database connection manager for DBJavaGenix MCP tools
 """
 import uuid
+import threading
 from typing import Dict, List, Any, Optional
 import pymysql
 import sqlite3
@@ -22,6 +23,8 @@ class ConnectionManager:
     def __init__(self):
         self.connections: Dict[str, Any] = {}
         self.connection_configs: Dict[str, DatabaseConfig] = {}
+        self._registry_lock = threading.RLock()
+        self._connection_locks: Dict[str, Any] = {}
     
     def create_connection(self, config: DatabaseConfig) -> str:
         """
@@ -74,16 +77,19 @@ class ConnectionManager:
                 )
                 connection.autocommit = True
             elif config.type == DatabaseType.SQLITE:
-                connection = sqlite3.connect(config.database)
+                # MCP handlers may execute this connection in a worker thread.
+                connection = sqlite3.connect(config.database, check_same_thread=False)
                 connection.row_factory = sqlite3.Row  # Enable dict-like access
             else:
                 raise DatabaseConnectionError(f"Unsupported database type: {config.type}")
             
-            self.connections[connection_id] = connection
-            # Store config without sensitive data for reference
-            safe_config = config.model_copy()
-            safe_config.password = "***"  # Mask password
-            self.connection_configs[connection_id] = safe_config
+            with self._registry_lock:
+                self.connections[connection_id] = connection
+                self._connection_locks[connection_id] = threading.RLock()
+                # Store config without sensitive data for reference
+                safe_config = config.model_copy()
+                safe_config.password = "***"  # Mask password
+                self.connection_configs[connection_id] = safe_config
             
             logger.info(f"Created connection {connection_id} to {config.type}://{config.host}:{config.port}")
             return connection_id
@@ -106,23 +112,47 @@ class ConnectionManager:
         Raises:
             DatabaseConnectionError: If connection not found
         """
-        if connection_id not in self.connections:
-            raise DatabaseConnectionError(f"Connection {connection_id} not found")
-        
-        connection = self.connections[connection_id]
-        
-        # Test connection is still alive
+        lock = self._connection_lock_for(connection_id)
+        with lock:
+            with self._registry_lock:
+                connection = self.connections.get(connection_id)
+            if connection is None:
+                raise DatabaseConnectionError(f"Connection {connection_id} not found")
+
+            try:
+                if getattr(connection, "closed", 0):
+                    raise DatabaseConnectionError("connection is closed")
+                if hasattr(connection, "ping"):
+                    connection.ping(reconnect=True)
+            except Exception as exc:
+                logger.warning("Connection %s is dead, removing: %s", connection_id, exc)
+                self._remove_connection(connection_id, connection)
+                raise DatabaseConnectionError(
+                    f"Connection {connection_id} is no longer valid"
+                ) from exc
+            return connection
+
+    def _connection_lock_for(self, connection_id: str) -> Any:
+        """Return a per-connection lock, including for legacy test doubles."""
+        with self._registry_lock:
+            if connection_id not in self.connections:
+                raise DatabaseConnectionError(f"Connection {connection_id} not found")
+            # A few integrations inject a connection directly into the public
+            # mapping. Lazily creating the lock preserves that compatibility.
+            return self._connection_locks.setdefault(connection_id, threading.RLock())
+
+    def _remove_connection(self, connection_id: str, connection: Any) -> None:
+        """Close and remove a connection while its per-connection lock is held."""
         try:
-            if getattr(connection, "closed", 0):
-                raise DatabaseConnectionError("connection is closed")
-            if hasattr(connection, 'ping'):
-                connection.ping(reconnect=True)
-        except Exception as e:
-            logger.warning(f"Connection {connection_id} is dead, removing: {e}")
-            self.close_connection(connection_id)
-            raise DatabaseConnectionError(f"Connection {connection_id} is no longer valid")
-        
-        return connection
+            connection.close()
+        except Exception as exc:
+            logger.error("Error closing connection %s: %s", connection_id, exc)
+        finally:
+            with self._registry_lock:
+                self.connections.pop(connection_id, None)
+                self.connection_configs.pop(connection_id, None)
+                self._connection_locks.pop(connection_id, None)
+        logger.info("Closed connection %s", connection_id)
     
     def close_connection(self, connection_id: str) -> bool:
         """
@@ -134,21 +164,17 @@ class ConnectionManager:
         Returns:
             True if connection was closed, False if not found
         """
-        if connection_id not in self.connections:
-            return False
-        
-        try:
-            connection = self.connections[connection_id]
-            connection.close()
-            self.connections.pop(connection_id, None)
-            self.connection_configs.pop(connection_id, None)
-            logger.info(f"Closed connection {connection_id}")
-            return True
-        except Exception as e:
-            logger.error(f"Error closing connection {connection_id}: {e}")
-            # Remove from dict anyway
-            self.connections.pop(connection_id, None)
-            self.connection_configs.pop(connection_id, None)
+        with self._registry_lock:
+            if connection_id not in self.connections:
+                return False
+            lock = self._connection_locks.setdefault(connection_id, threading.RLock())
+
+        with lock:
+            with self._registry_lock:
+                connection = self.connections.get(connection_id)
+            if connection is None:
+                return False
+            self._remove_connection(connection_id, connection)
             return True
     
     def get_connection_info(self, connection_id: str) -> Optional[DatabaseConfig]:
@@ -161,7 +187,8 @@ class ConnectionManager:
         Returns:
             Database configuration or None if not found
         """
-        config = self.connection_configs.get(connection_id)
+        with self._registry_lock:
+            config = self.connection_configs.get(connection_id)
         return config.model_copy(deep=True) if config else None
     
     def list_connections(self) -> Dict[str, Dict[str, Any]]:
@@ -171,15 +198,18 @@ class ConnectionManager:
         Returns:
             Dict of connection_id -> connection_info
         """
+        with self._registry_lock:
+            configs = list(self.connection_configs.items())
+            active_ids = set(self.connections)
         result = {}
-        for conn_id, config in self.connection_configs.items():
+        for conn_id, config in configs:
             result[conn_id] = {
                 "type": config.type,
                 "host": config.host,
                 "port": config.port,
                 "database": config.database,
                 "username": config.username,
-                "status": "active" if conn_id in self.connections else "closed"
+                "status": "active" if conn_id in active_ids else "closed"
             }
         return result
     
@@ -194,12 +224,34 @@ class ConnectionManager:
         Yields:
             Database cursor
         """
-        connection = self.get_connection(connection_id)
-        cursor = connection.cursor()
-        try:
-            yield cursor
-        finally:
-            cursor.close()
+        lock = self._connection_lock_for(connection_id)
+        with lock:
+            with self._registry_lock:
+                connection = self.connections.get(connection_id)
+            if connection is None:
+                raise DatabaseConnectionError(f"Connection {connection_id} not found")
+            try:
+                if getattr(connection, "closed", 0):
+                    raise DatabaseConnectionError("connection is closed")
+                if hasattr(connection, "ping"):
+                    connection.ping(reconnect=True)
+            except Exception as exc:
+                logger.warning("Connection %s is dead, removing: %s", connection_id, exc)
+                self._remove_connection(connection_id, connection)
+                raise DatabaseConnectionError(
+                    f"Connection {connection_id} is no longer valid"
+                ) from exc
+            try:
+                cursor = connection.cursor()
+            except Exception as exc:
+                self._remove_connection(connection_id, connection)
+                raise DatabaseConnectionError(
+                    f"Connection {connection_id} is no longer valid"
+                ) from exc
+            try:
+                yield cursor
+            finally:
+                cursor.close()
     
     def execute_query(self, connection_id: str, query: str, params: Optional[tuple] = None) -> List[Dict[str, Any]]:
         """
@@ -255,7 +307,12 @@ class ConnectionManager:
     
     def __del__(self):
         """Clean up connections on destruction"""
-        for connection_id in list(self.connections.keys()):
+        try:
+            with self._registry_lock:
+                connection_ids = list(self.connections.keys())
+        except Exception:
+            connection_ids = []
+        for connection_id in connection_ids:
             try:
                 self.close_connection(connection_id)
             except Exception:

--- a/src/dbjavagenix/database/mcp_tools.py
+++ b/src/dbjavagenix/database/mcp_tools.py
@@ -353,7 +353,23 @@ def get_connection_tools() -> List[Tool]:
                 "required": ["host", "port", "username", "password", "database_type"]
             }
         ),
-        
+
+        Tool(
+            name="db_disconnect",
+            description="Close an existing database connection session",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "connection_id": {
+                        "type": "string",
+                        "description": "Connection identifier returned by db_connect_test",
+                        "minLength": 1,
+                    }
+                },
+                "required": ["connection_id"],
+            },
+        ),
+
         Tool(
             name="db_query_databases",
             description="List all databases on the server",
@@ -694,6 +710,66 @@ async def handle_db_connect_test(arguments: Dict[str, Any]) -> List[TextContent]
             type="text",
             text=f"Unexpected error: {safe_error}\n\nRaw Response: {_json_dumps(error_response, ensure_ascii=False)}"
         )]
+
+
+async def handle_db_disconnect(arguments: Dict[str, Any]) -> List[TextContent]:
+    """Close a connection session and return a stable lifecycle response."""
+    raw_connection_id = arguments.get("connection_id") if isinstance(arguments, dict) else None
+    connection_id = raw_connection_id.strip() if isinstance(raw_connection_id, str) else ""
+
+    if not connection_id:
+        response = {
+            "success": False,
+            "error": "connection_not_found",
+            "connection_id": None,
+            "message": "Connection not found",
+        }
+        return [TextContent(
+            type="text",
+            text=f"Failed to disconnect connection: {response['message']}\n\n"
+                 f"Raw Response: {_json_dumps(response, ensure_ascii=False)}",
+        )]
+
+    try:
+        closed = connection_manager.close_connection(connection_id)
+    except Exception as exc:
+        safe_error = redact_sensitive_text(exc)
+        logger.error("Unexpected error in db_disconnect: %s", safe_error)
+        response = {
+            "success": False,
+            "error": "disconnect_failed",
+            "connection_id": connection_id,
+            "message": safe_error,
+        }
+        return [TextContent(
+            type="text",
+            text=f"Failed to disconnect connection: {safe_error}\n\n"
+                 f"Raw Response: {_json_dumps(response, ensure_ascii=False)}",
+        )]
+
+    if not closed:
+        response = {
+            "success": False,
+            "error": "connection_not_found",
+            "connection_id": connection_id,
+            "message": "Connection not found",
+        }
+        return [TextContent(
+            type="text",
+            text=f"Failed to disconnect connection: {response['message']}\n\n"
+                 f"Raw Response: {_json_dumps(response, ensure_ascii=False)}",
+        )]
+
+    response = {
+        "success": True,
+        "connection_id": connection_id,
+        "message": "Connection closed successfully",
+    }
+    return [TextContent(
+        type="text",
+        text=f"Database connection closed.\n\nRaw Response: "
+             f"{_json_dumps(response, ensure_ascii=False)}",
+    )]
 
 
 async def handle_db_query_databases(arguments: Dict[str, Any]) -> List[TextContent]:

--- a/src/dbjavagenix/database/mcp_tools.py
+++ b/src/dbjavagenix/database/mcp_tools.py
@@ -1,6 +1,7 @@
 """
 MCP tools for database connection and basic query operations
 """
+import asyncio
 import json
 import logging
 import os
@@ -54,6 +55,54 @@ _LOCKING_READ_CLAUSES = (
     ("FOR", "KEY", "SHARE"),
     ("LOCK", "IN", "SHARE", "MODE"),
 )
+
+
+async def _run_db_call(callable_obj, *args, **kwargs):
+    """Run one blocking database operation outside the MCP event loop."""
+    return await asyncio.to_thread(callable_obj, *args, **kwargs)
+
+
+async def _run_db_query(connection_id: str, query: str, params: Optional[tuple] = None):
+    """Execute SQL in a worker while preserving the two-argument call contract."""
+    if params is None:
+        return await _run_db_call(connection_manager.execute_query, connection_id, query)
+    return await _run_db_call(connection_manager.execute_query, connection_id, query, params)
+
+
+async def _run_async_db_call(callable_obj, *args, **kwargs):
+    """Run an async analyzer in a worker when its internals perform blocking I/O."""
+    def run():
+        return asyncio.run(callable_obj(*args, **kwargs))
+
+    return await _run_db_call(run)
+
+
+def _connect_and_probe(config: DatabaseConfig) -> tuple[str, str]:
+    """Create a connection and perform the initial blocking connectivity probe."""
+    connection_id = connection_manager.create_connection(config)
+    connection_manager.get_connection(connection_id)
+    server_info = ""
+    try:
+        if config.type == DatabaseType.MYSQL:
+            with connection_manager.get_cursor(connection_id) as cursor:
+                cursor.execute("SELECT VERSION() as version")
+                result = cursor.fetchone()
+                if result:
+                    version = result[0] if isinstance(result, tuple) else result["version"]
+                    server_info = f"MySQL {version}"
+        elif config.type == DatabaseType.POSTGRESQL:
+            with connection_manager.get_cursor(connection_id) as cursor:
+                cursor.execute("SELECT version() AS version")
+                result = cursor.fetchone()
+                if result:
+                    version = result[0] if isinstance(result, tuple) else result["version"]
+                    server_info = f"PostgreSQL {version}"
+        elif config.type == DatabaseType.SQLITE:
+            server_info = "SQLite"
+    except Exception as exc:
+        logger.warning("Could not get server info: %s", exc)
+        server_info = f"{config.type.value} (version unknown)"
+    return connection_id, server_info
 
 
 def _resolve_codegen_output_path(base_dir: Path, relative_path: object) -> Path:
@@ -633,37 +682,7 @@ async def handle_db_connect_test(arguments: Dict[str, Any]) -> List[TextContent]
             charset=arguments.get("charset", "utf8mb4")
         )
         
-        # Create connection
-        connection_id = connection_manager.create_connection(config)
-        
-        # Test basic connectivity
-        connection = connection_manager.get_connection(connection_id)
-        
-        # Get server information
-        server_info = ""
-        try:
-            if config.type == DatabaseType.MYSQL:
-                with connection_manager.get_cursor(connection_id) as cursor:
-                    cursor.execute("SELECT VERSION() as version")
-                    result = cursor.fetchone()
-                    if result:
-                        server_info = f"MySQL {result[0] if isinstance(result, tuple) else result['version']}"
-
-            elif config.type == DatabaseType.POSTGRESQL:
-                with connection_manager.get_cursor(connection_id) as cursor:
-                    cursor.execute("SELECT version() AS version")
-                    result = cursor.fetchone()
-                    if result:
-                        server_info = (
-                            f"PostgreSQL {result[0] if isinstance(result, tuple) else result['version']}"
-                        )
-
-            elif config.type == DatabaseType.SQLITE:
-                server_info = "SQLite"
-                
-        except Exception as e:
-            logger.warning(f"Could not get server info: {e}")
-            server_info = f"{config.type.value} (version unknown)"
+        connection_id, server_info = await _run_db_call(_connect_and_probe, config)
         
         response = {
             "success": True,
@@ -731,7 +750,7 @@ async def handle_db_disconnect(arguments: Dict[str, Any]) -> List[TextContent]:
         )]
 
     try:
-        closed = connection_manager.close_connection(connection_id)
+        closed = await _run_db_call(connection_manager.close_connection, connection_id)
     except Exception as exc:
         safe_error = redact_sensitive_text(exc)
         logger.error("Unexpected error in db_disconnect: %s", safe_error)
@@ -815,7 +834,7 @@ async def handle_db_query_databases(arguments: Dict[str, Any]) -> List[TextConte
         else:
             raise MCPServiceError(f"Listing databases not implemented for {config.type}")
         
-        results = connection_manager.execute_query(connection_id, query)
+        results = await _run_db_query(connection_id, query)
         
         # Extract database names
         databases = []
@@ -906,9 +925,9 @@ async def handle_db_query_tables(arguments: Dict[str, Any]) -> List[TextContent]
             raise MCPServiceError(f"Listing tables not implemented for {config.type}")
         
         if params is None:
-            results = connection_manager.execute_query(connection_id, query)
+            results = await _run_db_query(connection_id, query)
         else:
-            results = connection_manager.execute_query(connection_id, query, params)
+            results = await _run_db_query(connection_id, query, params)
         
         # Extract table names
         tables = []
@@ -994,7 +1013,7 @@ async def handle_db_query_table_exists(arguments: Dict[str, Any]) -> List[TextCo
             FROM information_schema.TABLES
             WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s
             """
-            results = connection_manager.execute_query(connection_id, query, (database, table))
+            results = await _run_db_query(connection_id, query, (database, table))
 
         elif config.type == DatabaseType.POSTGRESQL:
             schema_filter = "AND table_schema = %s" if schema else ""
@@ -1007,7 +1026,7 @@ async def handle_db_query_table_exists(arguments: Dict[str, Any]) -> List[TextCo
               {schema_filter}
             """.format(schema_filter=schema_filter)
             params = (database, table, schema) if schema else (database, table)
-            results = connection_manager.execute_query(connection_id, query, params)
+            results = await _run_db_query(connection_id, query, params)
             
         elif config.type == DatabaseType.SQLITE:
             query = """
@@ -1015,7 +1034,7 @@ async def handle_db_query_table_exists(arguments: Dict[str, Any]) -> List[TextCo
             FROM sqlite_master 
             WHERE type='table' AND name = ?
             """
-            results = connection_manager.execute_query(connection_id, query, (table,))
+            results = await _run_db_query(connection_id, query, (table,))
             
         else:
             raise MCPServiceError(f"Table existence check not implemented for {config.type}")
@@ -1083,7 +1102,7 @@ async def handle_db_query_execute(arguments: Dict[str, Any]) -> List[TextContent
 
         query = _apply_query_limit(query, limit)
 
-        results = connection_manager.execute_query(connection_id, query)
+        results = await _run_db_query(connection_id, query)
         
         response = {
             "success": True,
@@ -1249,7 +1268,7 @@ async def handle_db_table_describe(arguments: Dict[str, Any]) -> List[TextConten
         include_java_types = arguments.get("include_java_types", True)
         introspector = DatabaseIntrospector(connection_manager)
         config = introspector.get_config(connection_id)
-        metadata = introspector.describe_table(connection_id, table, schema)
+        metadata = await _run_db_call(introspector.describe_table, connection_id, table, schema)
         columns = []
         java_imports = set()
 
@@ -1386,11 +1405,14 @@ async def handle_db_table_columns(arguments: Dict[str, Any]) -> List[TextContent
             WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s
             ORDER BY ORDINAL_POSITION
             """
-            results = connection_manager.execute_query(connection_id, query, (database, table))
+            results = await _run_db_query(connection_id, query, (database, table))
 
         elif config.type == DatabaseType.POSTGRESQL:
-            columns = DatabaseIntrospector(connection_manager).get_columns(
-                connection_id, table, schema
+            columns = await _run_db_call(
+                DatabaseIntrospector(connection_manager).get_columns,
+                connection_id,
+                table,
+                schema,
             )
             results = [
                 {
@@ -1409,8 +1431,11 @@ async def handle_db_table_columns(arguments: Dict[str, Any]) -> List[TextContent
             ]
             
         elif config.type == DatabaseType.SQLITE:
-            columns = DatabaseIntrospector(connection_manager).get_columns(
-                connection_id, table, schema
+            columns = await _run_db_call(
+                DatabaseIntrospector(connection_manager).get_columns,
+                connection_id,
+                table,
+                schema,
             )
             results = [
                 {
@@ -1516,11 +1541,14 @@ async def handle_db_table_primary_keys(arguments: Dict[str, Any]) -> List[TextCo
               AND CONSTRAINT_NAME = 'PRIMARY'
             ORDER BY ORDINAL_POSITION
             """
-            results = connection_manager.execute_query(connection_id, query, (database, table))
+            results = await _run_db_query(connection_id, query, (database, table))
 
         elif config.type == DatabaseType.POSTGRESQL:
-            primary_keys = DatabaseIntrospector(connection_manager).get_primary_keys(
-                connection_id, table, schema
+            primary_keys = await _run_db_call(
+                DatabaseIntrospector(connection_manager).get_primary_keys,
+                connection_id,
+                table,
+                schema,
             )
             results = [
                 {"COLUMN_NAME": column_name, "ORDINAL_POSITION": position}
@@ -1528,8 +1556,11 @@ async def handle_db_table_primary_keys(arguments: Dict[str, Any]) -> List[TextCo
             ]
             
         elif config.type == DatabaseType.SQLITE:
-            primary_keys = DatabaseIntrospector(connection_manager).get_primary_keys(
-                connection_id, table, schema
+            primary_keys = await _run_db_call(
+                DatabaseIntrospector(connection_manager).get_primary_keys,
+                connection_id,
+                table,
+                schema,
             )
             results = [
                 {"COLUMN_NAME": column_name, "ORDINAL_POSITION": position}
@@ -1626,11 +1657,14 @@ async def handle_db_table_foreign_keys(arguments: Dict[str, Any]) -> List[TextCo
               AND kcu.REFERENCED_TABLE_NAME IS NOT NULL
             ORDER BY kcu.ORDINAL_POSITION
             """
-            results = connection_manager.execute_query(connection_id, query, (database, table))
+            results = await _run_db_query(connection_id, query, (database, table))
 
         elif config.type == DatabaseType.POSTGRESQL:
-            foreign_keys = DatabaseIntrospector(connection_manager).get_foreign_keys(
-                connection_id, table, schema
+            foreign_keys = await _run_db_call(
+                DatabaseIntrospector(connection_manager).get_foreign_keys,
+                connection_id,
+                table,
+                schema,
             )
             results = [
                 {
@@ -1646,8 +1680,11 @@ async def handle_db_table_foreign_keys(arguments: Dict[str, Any]) -> List[TextCo
             ]
             
         elif config.type == DatabaseType.SQLITE:
-            foreign_keys = DatabaseIntrospector(connection_manager).get_foreign_keys(
-                connection_id, table, schema
+            foreign_keys = await _run_db_call(
+                DatabaseIntrospector(connection_manager).get_foreign_keys,
+                connection_id,
+                table,
+                schema,
             )
             results = [
                 {
@@ -1764,11 +1801,14 @@ async def handle_db_table_indexes(arguments: Dict[str, Any]) -> List[TextContent
               AND TABLE_NAME = %s
             ORDER BY INDEX_NAME, SEQ_IN_INDEX
             """
-            results = connection_manager.execute_query(connection_id, query, (database, table))
+            results = await _run_db_query(connection_id, query, (database, table))
 
         elif config.type == DatabaseType.POSTGRESQL:
-            indexes = DatabaseIntrospector(connection_manager).get_indexes(
-                connection_id, table, schema
+            indexes = await _run_db_call(
+                DatabaseIntrospector(connection_manager).get_indexes,
+                connection_id,
+                table,
+                schema,
             )
             results = [
                 {
@@ -1784,8 +1824,11 @@ async def handle_db_table_indexes(arguments: Dict[str, Any]) -> List[TextContent
             ]
 
         elif config.type == DatabaseType.SQLITE:
-            indexes = DatabaseIntrospector(connection_manager).get_indexes(
-                connection_id, table, schema
+            indexes = await _run_db_call(
+                DatabaseIntrospector(connection_manager).get_indexes,
+                connection_id,
+                table,
+                schema,
             )
             results = [
                 {
@@ -2074,7 +2117,8 @@ async def handle_db_codegen_analyze(arguments: Dict[str, Any]) -> List[TextConte
         project_path = arguments.get("project_path")
         proj_struct = _detect_project_structure(project_path)
         project_root = str(proj_struct["project_root"]) if proj_struct.get("project_root") else None
-        analysis_result = await analyzer.analyze_table_for_codegen(
+        analysis_result = await _run_async_db_call(
+            analyzer.analyze_table_for_codegen,
             connection_id,
             table_name,
             template_category=template_category,
@@ -2283,7 +2327,9 @@ async def handle_db_codegen_generate(arguments: Dict[str, Any]) -> List[TextCont
         
         # ===== STEP 1: 获取数据库所有表名以支持前缀分析 =====
         logger.info("🔍 Getting all table names for package structure optimization...")
-        all_table_names = _collect_codegen_table_names(connection_id, table_name)
+        all_table_names = await _run_db_call(
+            _collect_codegen_table_names, connection_id, table_name
+        )
         logger.info(f"Found {len(all_table_names)} tables for prefix analysis: {all_table_names}")
         
         # ===== STEP 2: 分析表结构（包含前缀优化） =====
@@ -2293,7 +2339,8 @@ async def handle_db_codegen_generate(arguments: Dict[str, Any]) -> List[TextCont
         
         # Step 1: Analyze table structure with all table names for prefix optimization
         _ps = _detect_project_structure(project_path)
-        analysis_result = await analyzer.analyze_table_for_codegen(
+        analysis_result = await _run_async_db_call(
+            analyzer.analyze_table_for_codegen,
             connection_id,
             table_name,
             all_table_names=all_table_names,  # 传递所有表名用于前缀分析

--- a/src/dbjavagenix/database/visualization_tools.py
+++ b/src/dbjavagenix/database/visualization_tools.py
@@ -5,6 +5,7 @@ P3.1: 可视化工具 - 跨表 ER 图生成。
   - db_render_er_diagram: 给定多个表名,生成 Mermaid erDiagram (附加 mcp-apps/mermaid meta)
 """
 
+import asyncio
 import logging
 from typing import Any, Dict, List
 
@@ -81,8 +82,13 @@ async def handle_db_render_er_diagram(arguments: Dict[str, Any]) -> List[TextCon
         all_fks: List[ERForeignKey] = []
 
         for table_name in tables:
-            columns, fks = _collect_table_for_er(
-                connection_id, database, table_name, config.type, include_non_pk
+            columns, fks = await asyncio.to_thread(
+                _collect_table_for_er,
+                connection_id,
+                database,
+                table_name,
+                config.type,
+                include_non_pk,
             )
             er_tables.append(ERTable(name=table_name, columns=columns))
             all_fks.extend(fks)

--- a/src/dbjavagenix/server/mcp_server.py
+++ b/src/dbjavagenix/server/mcp_server.py
@@ -18,6 +18,7 @@ from ..database.mcp_tools import (
     get_codegen_tools,
     get_springboot_project_tools,
     handle_db_connect_test,
+    handle_db_disconnect,
     handle_db_query_databases,
     handle_db_query_tables, 
     handle_db_query_table_exists,

--- a/src/dbjavagenix/utils/tool_registry.py
+++ b/src/dbjavagenix/utils/tool_registry.py
@@ -47,6 +47,12 @@ _REGISTRY: Dict[str, ToolMetadata] = {
         always_visible=True,
         description_brief=("建立数据库连接 (" + "/".join(supported_database_display_names()) + ")"),
     ),
+    "db_disconnect": ToolMetadata(
+        name="db_disconnect",
+        tags={"disconnect", "close", "connection", "release", "cleanup", "session"},
+        category="connection",
+        description_brief="关闭并释放数据库连接会话",
+    ),
     "db_query_databases": ToolMetadata(
         name="db_query_databases",
         tags={"list", "databases", "schemas"},

--- a/tests/unit/test_async_db_boundary.py
+++ b/tests/unit/test_async_db_boundary.py
@@ -1,0 +1,180 @@
+"""Regression tests for the async MCP/database boundary."""
+
+import asyncio
+import threading
+import time
+
+import pytest
+
+from dbjavagenix.core.models import DatabaseConfig, DatabaseType
+from dbjavagenix.database import mcp_tools
+from dbjavagenix.database.connection_manager import ConnectionManager
+
+
+@pytest.fixture
+def sqlite_config():
+    return DatabaseConfig(
+        type=DatabaseType.SQLITE,
+        host="",
+        port=0,
+        database=":memory:",
+        username="",
+        password="",
+    )
+
+
+class _BlockingCursor:
+    description = None
+
+    def __init__(self, state):
+        self.state = state
+
+    def execute(self, _query, _params=()):
+        with self.state["lock"]:
+            self.state["active"] += 1
+            self.state["max_active"] = max(self.state["max_active"], self.state["active"])
+        self.state["entered"].set()
+        self.state["release"].wait(timeout=2)
+        with self.state["lock"]:
+            self.state["active"] -= 1
+
+    def close(self):
+        self.state["closed_cursors"] += 1
+
+
+class _BlockingConnection:
+    closed = 0
+
+    def __init__(self, state):
+        self.state = state
+
+    def cursor(self):
+        return _BlockingCursor(self.state)
+
+    def close(self):
+        self.closed = 1
+
+
+def _state():
+    return {
+        "lock": threading.Lock(),
+        "active": 0,
+        "max_active": 0,
+        "entered": threading.Event(),
+        "release": threading.Event(),
+        "closed_cursors": 0,
+    }
+
+
+def _manager_with_fake_connection(config, state):
+    manager = ConnectionManager()
+    connection_id = manager.create_connection(config)
+    manager.connections[connection_id] = _BlockingConnection(state)
+    return manager, connection_id
+
+
+@pytest.mark.asyncio
+async def test_mcp_query_keeps_event_loop_running_during_blocking_driver(monkeypatch):
+    started = threading.Event()
+
+    def blocking_execute(connection_id, query):
+        assert connection_id == "db-1"
+        assert query.endswith("LIMIT 100")
+        started.set()
+        time.sleep(0.06)
+        return []
+
+    monkeypatch.setattr(mcp_tools.connection_manager, "execute_query", blocking_execute)
+
+    ticks = 0
+
+    async def heartbeat():
+        nonlocal ticks
+        deadline = asyncio.get_running_loop().time() + 0.04
+        while asyncio.get_running_loop().time() < deadline:
+            ticks += 1
+            await asyncio.sleep(0.002)
+
+    await asyncio.gather(
+        mcp_tools.handle_db_query_execute({"connection_id": "db-1", "query": "SELECT 1"}),
+        heartbeat(),
+    )
+
+    assert started.is_set()
+    assert ticks >= 2
+
+
+@pytest.mark.asyncio
+async def test_sqlite_connection_can_be_used_by_worker_thread(sqlite_config):
+    manager = ConnectionManager()
+    connection_id = manager.create_connection(sqlite_config)
+    try:
+        rows = await asyncio.to_thread(manager.execute_query, connection_id, "SELECT 1 AS value")
+        assert rows == [{"value": 1}]
+    finally:
+        manager.close_connection(connection_id)
+
+
+@pytest.mark.asyncio
+async def test_same_connection_queries_are_serialized(sqlite_config):
+    state = _state()
+    manager, connection_id = _manager_with_fake_connection(sqlite_config, state)
+
+    first = asyncio.create_task(asyncio.to_thread(manager.execute_query, connection_id, "SELECT 1"))
+    assert await asyncio.to_thread(state["entered"].wait, 1)
+    second = asyncio.create_task(
+        asyncio.to_thread(manager.execute_query, connection_id, "SELECT 2")
+    )
+    await asyncio.sleep(0.02)
+    assert state["max_active"] == 1
+
+    state["release"].set()
+    await asyncio.gather(first, second)
+    assert state["closed_cursors"] == 2
+    manager.close_connection(connection_id)
+
+
+@pytest.mark.asyncio
+async def test_different_connections_can_execute_in_parallel(sqlite_config):
+    first_state = _state()
+    second_state = _state()
+    manager, first_id = _manager_with_fake_connection(sqlite_config, first_state)
+    second_id = manager.create_connection(sqlite_config)
+    manager.connections[second_id] = _BlockingConnection(second_state)
+
+    first = asyncio.create_task(asyncio.to_thread(manager.execute_query, first_id, "SELECT 1"))
+    second = asyncio.create_task(asyncio.to_thread(manager.execute_query, second_id, "SELECT 2"))
+    await asyncio.wait_for(
+        asyncio.gather(
+            asyncio.to_thread(first_state["entered"].wait, 1),
+            asyncio.to_thread(second_state["entered"].wait, 1),
+        ),
+        timeout=1,
+    )
+    assert first_state["max_active"] == second_state["max_active"] == 1
+
+    first_state["release"].set()
+    second_state["release"].set()
+    await asyncio.gather(first, second)
+    manager.close_connection(first_id)
+    manager.close_connection(second_id)
+
+
+@pytest.mark.asyncio
+async def test_close_waits_for_query_and_cleans_connection(sqlite_config):
+    state = _state()
+    manager, connection_id = _manager_with_fake_connection(sqlite_config, state)
+
+    query = asyncio.create_task(asyncio.to_thread(manager.execute_query, connection_id, "SELECT 1"))
+    assert await asyncio.to_thread(state["entered"].wait, 1)
+    close = asyncio.create_task(asyncio.to_thread(manager.close_connection, connection_id))
+    await asyncio.sleep(0.02)
+    assert not close.done()
+
+    state["release"].set()
+    result, closed = await asyncio.gather(query, close)
+    assert result == []
+    assert closed is True
+    assert connection_id not in manager.connections
+    assert connection_id not in manager.connection_configs
+    assert connection_id not in manager._connection_locks

--- a/tests/unit/test_mcp_disconnect.py
+++ b/tests/unit/test_mcp_disconnect.py
@@ -1,0 +1,117 @@
+"""Regression tests for the public MCP connection lifecycle tool."""
+
+import json
+
+import pytest
+
+from dbjavagenix.core.models import DatabaseConfig, DatabaseType
+from dbjavagenix.database import mcp_tools
+from dbjavagenix.database.connection_manager import ConnectionManager
+from dbjavagenix.utils.tool_registry import search_tools_by_query
+
+
+def _raw_payload(response):
+    return json.loads(response[0].text.split("Raw Response:", 1)[1].strip())
+
+
+def _sqlite_config(database=":memory:"):
+    return DatabaseConfig(
+        type=DatabaseType.SQLITE,
+        host="",
+        port=0,
+        database=database,
+        username="",
+        password="secret",
+    )
+
+
+def test_disconnect_tool_schema_requires_only_non_empty_connection_id():
+    tool = next(tool for tool in mcp_tools.get_connection_tools() if tool.name == "db_disconnect")
+
+    assert tool.inputSchema["required"] == ["connection_id"]
+    assert tool.inputSchema["properties"] == {
+        "connection_id": {
+            "type": "string",
+            "description": "Connection identifier returned by db_connect_test",
+            "minLength": 1,
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_disconnect_success_removes_connection_and_masked_config(monkeypatch):
+    manager = ConnectionManager()
+    connection_id = manager.create_connection(_sqlite_config())
+    monkeypatch.setattr(mcp_tools, "connection_manager", manager)
+
+    response = await mcp_tools.handle_db_disconnect({"connection_id": connection_id})
+
+    assert _raw_payload(response) == {
+        "success": True,
+        "connection_id": connection_id,
+        "message": "Connection closed successfully",
+    }
+    assert connection_id not in manager.connections
+    assert connection_id not in manager.connection_configs
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("arguments", [{}, {"connection_id": ""}, {"connection_id": "   "}])
+async def test_disconnect_empty_id_returns_connection_not_found(monkeypatch, arguments):
+    def fail_if_called(_connection_id):
+        raise AssertionError("empty IDs must be rejected before touching the manager")
+
+    monkeypatch.setattr(mcp_tools.connection_manager, "close_connection", fail_if_called)
+
+    response = await mcp_tools.handle_db_disconnect(arguments)
+
+    assert _raw_payload(response) == {
+        "success": False,
+        "error": "connection_not_found",
+        "connection_id": None,
+        "message": "Connection not found",
+    }
+
+
+@pytest.mark.asyncio
+async def test_disconnect_unknown_and_repeated_id_are_stable_failures(monkeypatch):
+    manager = ConnectionManager()
+    connection_id = manager.create_connection(_sqlite_config())
+    monkeypatch.setattr(mcp_tools, "connection_manager", manager)
+
+    first = _raw_payload(await mcp_tools.handle_db_disconnect({"connection_id": connection_id}))
+    repeated = _raw_payload(await mcp_tools.handle_db_disconnect({"connection_id": connection_id}))
+    unknown = _raw_payload(await mcp_tools.handle_db_disconnect({"connection_id": "missing"}))
+
+    assert first["success"] is True
+    assert repeated == {
+        "success": False,
+        "error": "connection_not_found",
+        "connection_id": connection_id,
+        "message": "Connection not found",
+    }
+    assert unknown["error"] == "connection_not_found"
+    assert unknown["success"] is False
+
+
+@pytest.mark.asyncio
+async def test_disconnect_exception_is_redacted(monkeypatch):
+    def fail(_connection_id):
+        raise RuntimeError("jdbc:mysql://reader:db-secret@db/app")
+
+    monkeypatch.setattr(mcp_tools.connection_manager, "close_connection", fail)
+
+    response = await mcp_tools.handle_db_disconnect({"connection_id": "conn-1"})
+    payload = _raw_payload(response)
+
+    assert payload["success"] is False
+    assert payload["error"] == "disconnect_failed"
+    assert payload["message"] == "jdbc:mysql://reader:***@db/app"
+    assert "db-secret" not in response[0].text
+
+
+def test_disconnect_is_discoverable_by_progressive_registry():
+    results = search_tools_by_query("disconnect")
+
+    assert results
+    assert results[0]["name"] == "db_disconnect"

--- a/tests/unit/test_server_dispatch.py
+++ b/tests/unit/test_server_dispatch.py
@@ -55,6 +55,22 @@ async def test_dispatch_resolves_handler_from_canonical_name(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_disconnect_is_dispatchable_from_canonical_name(monkeypatch):
+    calls = []
+
+    async def fake_disconnect(arguments):
+        calls.append(arguments)
+        return [TextContent(type="text", text="closed")]
+
+    monkeypatch.setattr(mcp_server, "handle_db_disconnect", fake_disconnect)
+
+    result = await mcp_server.handle_call_tool("db_disconnect", {"connection_id": "conn-1"})
+
+    assert result[0].text == "closed"
+    assert calls == [{"connection_id": "conn-1"}]
+
+
+@pytest.mark.asyncio
 async def test_unknown_tool_returns_structured_error(monkeypatch):
     monkeypatch.setattr(mcp_server, "_tool_handlers", lambda: {})
 


### PR DESCRIPTION
## 关联 Issue

Closes #209

## 背景（Situation）

`ConnectionManager` 已有 `close_connection()`，但 MCP 只公开 `db_connect_test`。长生命周期客户端无法在探索结束、重试失败或切换数据库时主动释放连接，连接对象和脱敏配置会保留到 server 退出。

## 任务（Task）

新增成对的 `db_disconnect(connection_id)` 生命周期入口，保持现有同步关闭语义，并让工具在 canonical dispatch、tool registry、progressive discovery 和文档中一致可发现。

## 行动（Action）

- 在 `get_connection_tools()` 增加只要求非空 `connection_id` 的 `db_disconnect` schema。
- 新增 `handle_db_disconnect()`，复用 `ConnectionManager.close_connection()`，统一输出 `Raw Response` JSON。
- 有效 ID 返回 `success=true`；未知、空值和重复关闭返回 `success=false`、`error=connection_not_found`。
- 关闭异常返回 `disconnect_failed`，沿用 `redact_sensitive_text()` 脱敏。
- 导入 canonical server handler，补齐 registry 搜索标签和连接生命周期 ADR/Skill/README/演示文档。

## 验证（Verification）

环境：Windows，Python 3.10.1，pytest 9.0.3，仓库 `PYTHONPATH=src`。

- `PYTHONPATH=src pytest -q tests/unit` → **769 passed**。
- `ruff check .` → **All checks passed!**
- `git diff --check` → 通过。
- `PYTHONPATH=src pytest -q` → 未执行完整集合：`tests/test_database.py` 在收集阶段要求外部 `DBJAVAGENIX_TEST_DB_HOST`，当前环境未提供真实 MySQL，未伪造该结果。

## 实验与证据（Evidence）

使用当前 `_all_tools()` 和 progressive 过滤器做本地 schema 复测（按仓库 benchmark 的 `json.dumps(..., ensure_ascii=False)` 与 `chars // 4` 估算）：

| 模式 | 工具数 | schema chars | 约 tokens |
|---|---:|---:|---:|
| default | 34 | 20,870 | 5,217 |
| progressive | 6 | 4,603 | 1,150 |

`db_disconnect` 在 progressive 模式不加入 always-visible 集合，因此保留原有 6 工具启动暴露面，可通过 `search_tools("disconnect")` 发现。实验仅测量工具合同和 SQLite in-memory 生命周期，不宣称真实 MySQL/PostgreSQL 连接性能或释放结果。

## 兼容性、风险与回滚

- 不改变连接建立参数、驱动配置、事务提交或 CLI 行为；旧客户端无需立即调用新工具。
- 释放后的 ID 按预期不可继续查询；重复关闭得到稳定 `connection_not_found`。
- 不引入连接池、TTL、后台线程或自动回收，避免误杀仍在使用的连接。
- 回滚方式：恢复本 PR 的单个提交 `c9f62ce`，不涉及用户数据库数据。