### PR TITLE
:zap: perf(mcp): 隔离同步数据库调用与事件循环

### DIFF
--- a/docs/adr/016-async-database-boundary.md
+++ b/docs/adr/016-async-database-boundary.md
@@ -1,0 +1,45 @@
+# ADR-016: 将同步数据库调用移出 MCP 事件循环
+
+- **状态**: Accepted
+- **日期**: 2026-09-09
+- **关联 Issue**: #211
+- **关联实现**: `src/dbjavagenix/database/connection_manager.py`
+
+## 背景
+
+MCP handler 使用 `async def`，但数据库驱动和元数据 introspector 仍是同步实现。
+网络等待或大型 SQLite 查询会占住事件循环，使同一会话的健康检查、取消和其他连接请求
+延迟。SQLite 默认还会拒绝跨线程使用连接；多个 worker 直接共享一个连接也可能交叉使用
+cursor。
+
+## 决定
+
+1. 在 MCP 数据库边界统一使用 `asyncio.to_thread`；保留同步 `ConnectionManager` API，
+   供 CLI、测试和外部调用方继续使用。
+2. `ConnectionManager` 为每个 connection ID 建立可重入锁，锁覆盖健康探测、cursor
+   生命周期、SQL 执行和关闭；不同连接不共享这把锁。
+3. SQLite 连接启用 `check_same_thread=False`，但只有在上述连接锁保护下交给 worker。
+4. 异步 analyzer 通过 worker 中的短生命周期 event loop 执行，输入输出合同保持不变。
+5. 取消异步 handler 不强杀底层驱动调用；worker 返回后由 context manager 关闭 cursor，
+   连接仍可被显式 `db_disconnect` 释放。
+
+## 备选方案
+
+- 替换原生异步 MySQL/PostgreSQL 驱动：迁移成本高且会改变方言、事务和依赖边界，暂不采用。
+- 只在 handler 外包线程、不加连接锁：会留下 SQLite thread-affinity 和 cursor 交叉风险，
+  不采用。
+- 为每个请求建立新连接：增加连接开销并破坏现有 connection ID 生命周期，不采用。
+
+## 影响
+
+- 同步公共 API、SQL、事务提交/回滚、权限和 MCP 文本/Raw Response 保持不变。
+- 同一连接的数据库阶段串行，不同连接可以并行等待；不宣称生产吞吐提升。
+- worker 调度带来少量开销；驱动额外的线程绑定限制需要在真实 MySQL/PostgreSQL 环境
+  单独验证。
+
+## 验证
+
+- 受控 60ms 阻塞 driver + heartbeat 证明事件循环仍获调度。
+- fake cursor 实验覆盖同连接最大并发为 1、跨连接同时进入和 close 等待 SQL body 完成。
+- SQLite in-memory worker 查询和现有 SQLite MCP/codegen 合同继续通过；真实网络数据库
+  线程模型不在本地实验范围内。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -26,3 +26,4 @@
 ### v0.3 (数据库元数据契约)
 - [ADR-014: 统一数据库元数据描述契约](014-metadata-introspection-contract.md)
 - [ADR-015: MCP 连接生命周期与显式释放](015-connection-lifecycle.md)
+- [ADR-016: 将同步数据库调用移出 MCP 事件循环](016-async-database-boundary.md)

--- a/src/dbjavagenix/database/atomic_codegen_tools.py
+++ b/src/dbjavagenix/database/atomic_codegen_tools.py
@@ -23,6 +23,7 @@ P2.2: 原子化代码生成工具 - 把 db_codegen_generate 拆为 7 个职责�
 """
 
 import json
+import asyncio
 import logging
 from typing import Any, Dict, List
 
@@ -35,6 +36,20 @@ from ..generator.template_context import apply_generation_options
 from ..utils.json_serialization import dumps as _json_dumps
 
 logger = logging.getLogger(__name__)
+
+
+async def _run_db_call(callable_obj, *args, **kwargs):
+    """Run blocking database work outside the MCP event loop."""
+    return await asyncio.to_thread(callable_obj, *args, **kwargs)
+
+
+async def _run_async_db_call(callable_obj, *args, **kwargs):
+    """Run an async analyzer in a worker when it performs blocking I/O."""
+
+    def run():
+        return asyncio.run(callable_obj(*args, **kwargs))
+
+    return await _run_db_call(run)
 
 
 # ============================================================
@@ -221,10 +236,11 @@ async def handle_codegen_build_context(arguments: Dict[str, Any]) -> List[TextCo
             database = config.database or "information_schema"
 
         # 收集所有表名用于前缀分析(沿用旧逻辑)
-        all_table_names = _collect_all_table_names(connection_id, config)
+        all_table_names = await _run_db_call(_collect_all_table_names, connection_id, config)
 
         analyzer = CodegenAnalyzer(connection_manager)
-        analysis = await analyzer.analyze_table_for_codegen(
+        analysis = await _run_async_db_call(
+            analyzer.analyze_table_for_codegen,
             connection_id,
             table_name,
             all_table_names=all_table_names,

--- a/src/dbjavagenix/database/connection_manager.py
+++ b/src/dbjavagenix/database/connection_manager.py
@@ -2,6 +2,7 @@
 Database connection manager for DBJavaGenix MCP tools
 """
 import uuid
+import threading
 from typing import Dict, List, Any, Optional
 import pymysql
 import sqlite3
@@ -22,6 +23,8 @@ class ConnectionManager:
     def __init__(self):
         self.connections: Dict[str, Any] = {}
         self.connection_configs: Dict[str, DatabaseConfig] = {}
+        self._registry_lock = threading.RLock()
+        self._connection_locks: Dict[str, Any] = {}
     
     def create_connection(self, config: DatabaseConfig) -> str:
         """
@@ -74,16 +77,19 @@ class ConnectionManager:
                 )
                 connection.autocommit = True
             elif config.type == DatabaseType.SQLITE:
-                connection = sqlite3.connect(config.database)
+                # MCP handlers may execute this connection in a worker thread.
+                connection = sqlite3.connect(config.database, check_same_thread=False)
                 connection.row_factory = sqlite3.Row  # Enable dict-like access
             else:
                 raise DatabaseConnectionError(f"Unsupported database type: {config.type}")
             
-            self.connections[connection_id] = connection
-            # Store config without sensitive data for reference
-            safe_config = config.model_copy()
-            safe_config.password = "***"  # Mask password
-            self.connection_configs[connection_id] = safe_config
+            with self._registry_lock:
+                self.connections[connection_id] = connection
+                self._connection_locks[connection_id] = threading.RLock()
+                # Store config without sensitive data for reference
+                safe_config = config.model_copy()
+                safe_config.password = "***"  # Mask password
+                self.connection_configs[connection_id] = safe_config
             
             logger.info(f"Created connection {connection_id} to {config.type}://{config.host}:{config.port}")
             return connection_id
@@ -106,23 +112,47 @@ class ConnectionManager:
         Raises:
             DatabaseConnectionError: If connection not found
         """
-        if connection_id not in self.connections:
-            raise DatabaseConnectionError(f"Connection {connection_id} not found")
-        
-        connection = self.connections[connection_id]
-        
-        # Test connection is still alive
+        lock = self._connection_lock_for(connection_id)
+        with lock:
+            with self._registry_lock:
+                connection = self.connections.get(connection_id)
+            if connection is None:
+                raise DatabaseConnectionError(f"Connection {connection_id} not found")
+
+            try:
+                if getattr(connection, "closed", 0):
+                    raise DatabaseConnectionError("connection is closed")
+                if hasattr(connection, "ping"):
+                    connection.ping(reconnect=True)
+            except Exception as exc:
+                logger.warning("Connection %s is dead, removing: %s", connection_id, exc)
+                self._remove_connection(connection_id, connection)
+                raise DatabaseConnectionError(
+                    f"Connection {connection_id} is no longer valid"
+                ) from exc
+            return connection
+
+    def _connection_lock_for(self, connection_id: str) -> Any:
+        """Return a per-connection lock, including for legacy test doubles."""
+        with self._registry_lock:
+            if connection_id not in self.connections:
+                raise DatabaseConnectionError(f"Connection {connection_id} not found")
+            # A few integrations inject a connection directly into the public
+            # mapping. Lazily creating the lock preserves that compatibility.
+            return self._connection_locks.setdefault(connection_id, threading.RLock())
+
+    def _remove_connection(self, connection_id: str, connection: Any) -> None:
+        """Close and remove a connection while its per-connection lock is held."""
         try:
-            if getattr(connection, "closed", 0):
-                raise DatabaseConnectionError("connection is closed")
-            if hasattr(connection, 'ping'):
-                connection.ping(reconnect=True)
-        except Exception as e:
-            logger.warning(f"Connection {connection_id} is dead, removing: {e}")
-            self.close_connection(connection_id)
-            raise DatabaseConnectionError(f"Connection {connection_id} is no longer valid")
-        
-        return connection
+            connection.close()
+        except Exception as exc:
+            logger.error("Error closing connection %s: %s", connection_id, exc)
+        finally:
+            with self._registry_lock:
+                self.connections.pop(connection_id, None)
+                self.connection_configs.pop(connection_id, None)
+                self._connection_locks.pop(connection_id, None)
+        logger.info("Closed connection %s", connection_id)
     
     def close_connection(self, connection_id: str) -> bool:
         """
@@ -134,21 +164,17 @@ class ConnectionManager:
         Returns:
             True if connection was closed, False if not found
         """
-        if connection_id not in self.connections:
-            return False
-        
-        try:
-            connection = self.connections[connection_id]
-            connection.close()
-            self.connections.pop(connection_id, None)
-            self.connection_configs.pop(connection_id, None)
-            logger.info(f"Closed connection {connection_id}")
-            return True
-        except Exception as e:
-            logger.error(f"Error closing connection {connection_id}: {e}")
-            # Remove from dict anyway
-            self.connections.pop(connection_id, None)
-            self.connection_configs.pop(connection_id, None)
+        with self._registry_lock:
+            if connection_id not in self.connections:
+                return False
+            lock = self._connection_locks.setdefault(connection_id, threading.RLock())
+
+        with lock:
+            with self._registry_lock:
+                connection = self.connections.get(connection_id)
+            if connection is None:
+                return False
+            self._remove_connection(connection_id, connection)
             return True
     
     def get_connection_info(self, connection_id: str) -> Optional[DatabaseConfig]:
@@ -161,7 +187,8 @@ class ConnectionManager:
         Returns:
             Database configuration or None if not found
         """
-        config = self.connection_configs.get(connection_id)
+        with self._registry_lock:
+            config = self.connection_configs.get(connection_id)
         return config.model_copy(deep=True) if config else None
     
     def list_connections(self) -> Dict[str, Dict[str, Any]]:
@@ -171,15 +198,18 @@ class ConnectionManager:
         Returns:
             Dict of connection_id -> connection_info
         """
+        with self._registry_lock:
+            configs = list(self.connection_configs.items())
+            active_ids = set(self.connections)
         result = {}
-        for conn_id, config in self.connection_configs.items():
+        for conn_id, config in configs:
             result[conn_id] = {
                 "type": config.type,
                 "host": config.host,
                 "port": config.port,
                 "database": config.database,
                 "username": config.username,
-                "status": "active" if conn_id in self.connections else "closed"
+                "status": "active" if conn_id in active_ids else "closed"
             }
         return result
     
@@ -194,12 +224,34 @@ class ConnectionManager:
         Yields:
             Database cursor
         """
-        connection = self.get_connection(connection_id)
-        cursor = connection.cursor()
-        try:
-            yield cursor
-        finally:
-            cursor.close()
+        lock = self._connection_lock_for(connection_id)
+        with lock:
+            with self._registry_lock:
+                connection = self.connections.get(connection_id)
+            if connection is None:
+                raise DatabaseConnectionError(f"Connection {connection_id} not found")
+            try:
+                if getattr(connection, "closed", 0):
+                    raise DatabaseConnectionError("connection is closed")
+                if hasattr(connection, "ping"):
+                    connection.ping(reconnect=True)
+            except Exception as exc:
+                logger.warning("Connection %s is dead, removing: %s", connection_id, exc)
+                self._remove_connection(connection_id, connection)
+                raise DatabaseConnectionError(
+                    f"Connection {connection_id} is no longer valid"
+                ) from exc
+            try:
+                cursor = connection.cursor()
+            except Exception as exc:
+                self._remove_connection(connection_id, connection)
+                raise DatabaseConnectionError(
+                    f"Connection {connection_id} is no longer valid"
+                ) from exc
+            try:
+                yield cursor
+            finally:
+                cursor.close()
     
     def execute_query(self, connection_id: str, query: str, params: Optional[tuple] = None) -> List[Dict[str, Any]]:
         """
@@ -255,7 +307,12 @@ class ConnectionManager:
     
     def __del__(self):
         """Clean up connections on destruction"""
-        for connection_id in list(self.connections.keys()):
+        try:
+            with self._registry_lock:
+                connection_ids = list(self.connections.keys())
+        except Exception:
+            connection_ids = []
+        for connection_id in connection_ids:
             try:
                 self.close_connection(connection_id)
             except Exception:

--- a/src/dbjavagenix/database/mcp_tools.py
+++ b/src/dbjavagenix/database/mcp_tools.py
@@ -1,6 +1,7 @@
 """
 MCP tools for database connection and basic query operations
 """
+import asyncio
 import json
 import logging
 import os
@@ -54,6 +55,54 @@ _LOCKING_READ_CLAUSES = (
     ("FOR", "KEY", "SHARE"),
     ("LOCK", "IN", "SHARE", "MODE"),
 )
+
+
+async def _run_db_call(callable_obj, *args, **kwargs):
+    """Run one blocking database operation outside the MCP event loop."""
+    return await asyncio.to_thread(callable_obj, *args, **kwargs)
+
+
+async def _run_db_query(connection_id: str, query: str, params: Optional[tuple] = None):
+    """Execute SQL in a worker while preserving the two-argument call contract."""
+    if params is None:
+        return await _run_db_call(connection_manager.execute_query, connection_id, query)
+    return await _run_db_call(connection_manager.execute_query, connection_id, query, params)
+
+
+async def _run_async_db_call(callable_obj, *args, **kwargs):
+    """Run an async analyzer in a worker when its internals perform blocking I/O."""
+    def run():
+        return asyncio.run(callable_obj(*args, **kwargs))
+
+    return await _run_db_call(run)
+
+
+def _connect_and_probe(config: DatabaseConfig) -> tuple[str, str]:
+    """Create a connection and perform the initial blocking connectivity probe."""
+    connection_id = connection_manager.create_connection(config)
+    connection_manager.get_connection(connection_id)
+    server_info = ""
+    try:
+        if config.type == DatabaseType.MYSQL:
+            with connection_manager.get_cursor(connection_id) as cursor:
+                cursor.execute("SELECT VERSION() as version")
+                result = cursor.fetchone()
+                if result:
+                    version = result[0] if isinstance(result, tuple) else result["version"]
+                    server_info = f"MySQL {version}"
+        elif config.type == DatabaseType.POSTGRESQL:
+            with connection_manager.get_cursor(connection_id) as cursor:
+                cursor.execute("SELECT version() AS version")
+                result = cursor.fetchone()
+                if result:
+                    version = result[0] if isinstance(result, tuple) else result["version"]
+                    server_info = f"PostgreSQL {version}"
+        elif config.type == DatabaseType.SQLITE:
+            server_info = "SQLite"
+    except Exception as exc:
+        logger.warning("Could not get server info: %s", exc)
+        server_info = f"{config.type.value} (version unknown)"
+    return connection_id, server_info
 
 
 def _resolve_codegen_output_path(base_dir: Path, relative_path: object) -> Path:
@@ -633,37 +682,7 @@ async def handle_db_connect_test(arguments: Dict[str, Any]) -> List[TextContent]
             charset=arguments.get("charset", "utf8mb4")
         )
         
-        # Create connection
-        connection_id = connection_manager.create_connection(config)
-        
-        # Test basic connectivity
-        connection = connection_manager.get_connection(connection_id)
-        
-        # Get server information
-        server_info = ""
-        try:
-            if config.type == DatabaseType.MYSQL:
-                with connection_manager.get_cursor(connection_id) as cursor:
-                    cursor.execute("SELECT VERSION() as version")
-                    result = cursor.fetchone()
-                    if result:
-                        server_info = f"MySQL {result[0] if isinstance(result, tuple) else result['version']}"
-
-            elif config.type == DatabaseType.POSTGRESQL:
-                with connection_manager.get_cursor(connection_id) as cursor:
-                    cursor.execute("SELECT version() AS version")
-                    result = cursor.fetchone()
-                    if result:
-                        server_info = (
-                            f"PostgreSQL {result[0] if isinstance(result, tuple) else result['version']}"
-                        )
-
-            elif config.type == DatabaseType.SQLITE:
-                server_info = "SQLite"
-                
-        except Exception as e:
-            logger.warning(f"Could not get server info: {e}")
-            server_info = f"{config.type.value} (version unknown)"
+        connection_id, server_info = await _run_db_call(_connect_and_probe, config)
         
         response = {
             "success": True,
@@ -731,7 +750,7 @@ async def handle_db_disconnect(arguments: Dict[str, Any]) -> List[TextContent]:
         )]
 
     try:
-        closed = connection_manager.close_connection(connection_id)
+        closed = await _run_db_call(connection_manager.close_connection, connection_id)
     except Exception as exc:
         safe_error = redact_sensitive_text(exc)
         logger.error("Unexpected error in db_disconnect: %s", safe_error)
@@ -815,7 +834,7 @@ async def handle_db_query_databases(arguments: Dict[str, Any]) -> List[TextConte
         else:
             raise MCPServiceError(f"Listing databases not implemented for {config.type}")
         
-        results = connection_manager.execute_query(connection_id, query)
+        results = await _run_db_query(connection_id, query)
         
         # Extract database names
         databases = []
@@ -906,9 +925,9 @@ async def handle_db_query_tables(arguments: Dict[str, Any]) -> List[TextContent]
             raise MCPServiceError(f"Listing tables not implemented for {config.type}")
         
         if params is None:
-            results = connection_manager.execute_query(connection_id, query)
+            results = await _run_db_query(connection_id, query)
         else:
-            results = connection_manager.execute_query(connection_id, query, params)
+            results = await _run_db_query(connection_id, query, params)
         
         # Extract table names
         tables = []
@@ -994,7 +1013,7 @@ async def handle_db_query_table_exists(arguments: Dict[str, Any]) -> List[TextCo
             FROM information_schema.TABLES
             WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s
             """
-            results = connection_manager.execute_query(connection_id, query, (database, table))
+            results = await _run_db_query(connection_id, query, (database, table))
 
         elif config.type == DatabaseType.POSTGRESQL:
             schema_filter = "AND table_schema = %s" if schema else ""
@@ -1007,7 +1026,7 @@ async def handle_db_query_table_exists(arguments: Dict[str, Any]) -> List[TextCo
               {schema_filter}
             """.format(schema_filter=schema_filter)
             params = (database, table, schema) if schema else (database, table)
-            results = connection_manager.execute_query(connection_id, query, params)
+            results = await _run_db_query(connection_id, query, params)
             
         elif config.type == DatabaseType.SQLITE:
             query = """
@@ -1015,7 +1034,7 @@ async def handle_db_query_table_exists(arguments: Dict[str, Any]) -> List[TextCo
             FROM sqlite_master 
             WHERE type='table' AND name = ?
             """
-            results = connection_manager.execute_query(connection_id, query, (table,))
+            results = await _run_db_query(connection_id, query, (table,))
             
         else:
             raise MCPServiceError(f"Table existence check not implemented for {config.type}")
@@ -1083,7 +1102,7 @@ async def handle_db_query_execute(arguments: Dict[str, Any]) -> List[TextContent
 
         query = _apply_query_limit(query, limit)
 
-        results = connection_manager.execute_query(connection_id, query)
+        results = await _run_db_query(connection_id, query)
         
         response = {
             "success": True,
@@ -1249,7 +1268,7 @@ async def handle_db_table_describe(arguments: Dict[str, Any]) -> List[TextConten
         include_java_types = arguments.get("include_java_types", True)
         introspector = DatabaseIntrospector(connection_manager)
         config = introspector.get_config(connection_id)
-        metadata = introspector.describe_table(connection_id, table, schema)
+        metadata = await _run_db_call(introspector.describe_table, connection_id, table, schema)
         columns = []
         java_imports = set()
 
@@ -1386,11 +1405,14 @@ async def handle_db_table_columns(arguments: Dict[str, Any]) -> List[TextContent
             WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s
             ORDER BY ORDINAL_POSITION
             """
-            results = connection_manager.execute_query(connection_id, query, (database, table))
+            results = await _run_db_query(connection_id, query, (database, table))
 
         elif config.type == DatabaseType.POSTGRESQL:
-            columns = DatabaseIntrospector(connection_manager).get_columns(
-                connection_id, table, schema
+            columns = await _run_db_call(
+                DatabaseIntrospector(connection_manager).get_columns,
+                connection_id,
+                table,
+                schema,
             )
             results = [
                 {
@@ -1409,8 +1431,11 @@ async def handle_db_table_columns(arguments: Dict[str, Any]) -> List[TextContent
             ]
             
         elif config.type == DatabaseType.SQLITE:
-            columns = DatabaseIntrospector(connection_manager).get_columns(
-                connection_id, table, schema
+            columns = await _run_db_call(
+                DatabaseIntrospector(connection_manager).get_columns,
+                connection_id,
+                table,
+                schema,
             )
             results = [
                 {
@@ -1516,11 +1541,14 @@ async def handle_db_table_primary_keys(arguments: Dict[str, Any]) -> List[TextCo
               AND CONSTRAINT_NAME = 'PRIMARY'
             ORDER BY ORDINAL_POSITION
             """
-            results = connection_manager.execute_query(connection_id, query, (database, table))
+            results = await _run_db_query(connection_id, query, (database, table))
 
         elif config.type == DatabaseType.POSTGRESQL:
-            primary_keys = DatabaseIntrospector(connection_manager).get_primary_keys(
-                connection_id, table, schema
+            primary_keys = await _run_db_call(
+                DatabaseIntrospector(connection_manager).get_primary_keys,
+                connection_id,
+                table,
+                schema,
             )
             results = [
                 {"COLUMN_NAME": column_name, "ORDINAL_POSITION": position}
@@ -1528,8 +1556,11 @@ async def handle_db_table_primary_keys(arguments: Dict[str, Any]) -> List[TextCo
             ]
             
         elif config.type == DatabaseType.SQLITE:
-            primary_keys = DatabaseIntrospector(connection_manager).get_primary_keys(
-                connection_id, table, schema
+            primary_keys = await _run_db_call(
+                DatabaseIntrospector(connection_manager).get_primary_keys,
+                connection_id,
+                table,
+                schema,
             )
             results = [
                 {"COLUMN_NAME": column_name, "ORDINAL_POSITION": position}
@@ -1626,11 +1657,14 @@ async def handle_db_table_foreign_keys(arguments: Dict[str, Any]) -> List[TextCo
               AND kcu.REFERENCED_TABLE_NAME IS NOT NULL
             ORDER BY kcu.ORDINAL_POSITION
             """
-            results = connection_manager.execute_query(connection_id, query, (database, table))
+            results = await _run_db_query(connection_id, query, (database, table))
 
         elif config.type == DatabaseType.POSTGRESQL:
-            foreign_keys = DatabaseIntrospector(connection_manager).get_foreign_keys(
-                connection_id, table, schema
+            foreign_keys = await _run_db_call(
+                DatabaseIntrospector(connection_manager).get_foreign_keys,
+                connection_id,
+                table,
+                schema,
             )
             results = [
                 {
@@ -1646,8 +1680,11 @@ async def handle_db_table_foreign_keys(arguments: Dict[str, Any]) -> List[TextCo
             ]
             
         elif config.type == DatabaseType.SQLITE:
-            foreign_keys = DatabaseIntrospector(connection_manager).get_foreign_keys(
-                connection_id, table, schema
+            foreign_keys = await _run_db_call(
+                DatabaseIntrospector(connection_manager).get_foreign_keys,
+                connection_id,
+                table,
+                schema,
             )
             results = [
                 {
@@ -1764,11 +1801,14 @@ async def handle_db_table_indexes(arguments: Dict[str, Any]) -> List[TextContent
               AND TABLE_NAME = %s
             ORDER BY INDEX_NAME, SEQ_IN_INDEX
             """
-            results = connection_manager.execute_query(connection_id, query, (database, table))
+            results = await _run_db_query(connection_id, query, (database, table))
 
         elif config.type == DatabaseType.POSTGRESQL:
-            indexes = DatabaseIntrospector(connection_manager).get_indexes(
-                connection_id, table, schema
+            indexes = await _run_db_call(
+                DatabaseIntrospector(connection_manager).get_indexes,
+                connection_id,
+                table,
+                schema,
             )
             results = [
                 {
@@ -1784,8 +1824,11 @@ async def handle_db_table_indexes(arguments: Dict[str, Any]) -> List[TextContent
             ]
 
         elif config.type == DatabaseType.SQLITE:
-            indexes = DatabaseIntrospector(connection_manager).get_indexes(
-                connection_id, table, schema
+            indexes = await _run_db_call(
+                DatabaseIntrospector(connection_manager).get_indexes,
+                connection_id,
+                table,
+                schema,
             )
             results = [
                 {
@@ -2074,7 +2117,8 @@ async def handle_db_codegen_analyze(arguments: Dict[str, Any]) -> List[TextConte
         project_path = arguments.get("project_path")
         proj_struct = _detect_project_structure(project_path)
         project_root = str(proj_struct["project_root"]) if proj_struct.get("project_root") else None
-        analysis_result = await analyzer.analyze_table_for_codegen(
+        analysis_result = await _run_async_db_call(
+            analyzer.analyze_table_for_codegen,
             connection_id,
             table_name,
             template_category=template_category,
@@ -2283,7 +2327,9 @@ async def handle_db_codegen_generate(arguments: Dict[str, Any]) -> List[TextCont
         
         # ===== STEP 1: 获取数据库所有表名以支持前缀分析 =====
         logger.info("🔍 Getting all table names for package structure optimization...")
-        all_table_names = _collect_codegen_table_names(connection_id, table_name)
+        all_table_names = await _run_db_call(
+            _collect_codegen_table_names, connection_id, table_name
+        )
         logger.info(f"Found {len(all_table_names)} tables for prefix analysis: {all_table_names}")
         
         # ===== STEP 2: 分析表结构（包含前缀优化） =====
@@ -2293,7 +2339,8 @@ async def handle_db_codegen_generate(arguments: Dict[str, Any]) -> List[TextCont
         
         # Step 1: Analyze table structure with all table names for prefix optimization
         _ps = _detect_project_structure(project_path)
-        analysis_result = await analyzer.analyze_table_for_codegen(
+        analysis_result = await _run_async_db_call(
+            analyzer.analyze_table_for_codegen,
             connection_id,
             table_name,
             all_table_names=all_table_names,  # 传递所有表名用于前缀分析

--- a/src/dbjavagenix/database/visualization_tools.py
+++ b/src/dbjavagenix/database/visualization_tools.py
@@ -5,6 +5,7 @@ P3.1: 可视化工具 - 跨表 ER 图生成。
   - db_render_er_diagram: 给定多个表名,生成 Mermaid erDiagram (附加 mcp-apps/mermaid meta)
 """
 
+import asyncio
 import logging
 from typing import Any, Dict, List
 
@@ -81,8 +82,13 @@ async def handle_db_render_er_diagram(arguments: Dict[str, Any]) -> List[TextCon
         all_fks: List[ERForeignKey] = []
 
         for table_name in tables:
-            columns, fks = _collect_table_for_er(
-                connection_id, database, table_name, config.type, include_non_pk
+            columns, fks = await asyncio.to_thread(
+                _collect_table_for_er,
+                connection_id,
+                database,
+                table_name,
+                config.type,
+                include_non_pk,
             )
             er_tables.append(ERTable(name=table_name, columns=columns))
             all_fks.extend(fks)

--- a/tests/unit/test_async_db_boundary.py
+++ b/tests/unit/test_async_db_boundary.py
@@ -1,0 +1,180 @@
+"""Regression tests for the async MCP/database boundary."""
+
+import asyncio
+import threading
+import time
+
+import pytest
+
+from dbjavagenix.core.models import DatabaseConfig, DatabaseType
+from dbjavagenix.database import mcp_tools
+from dbjavagenix.database.connection_manager import ConnectionManager
+
+
+@pytest.fixture
+def sqlite_config():
+    return DatabaseConfig(
+        type=DatabaseType.SQLITE,
+        host="",
+        port=0,
+        database=":memory:",
+        username="",
+        password="",
+    )
+
+
+class _BlockingCursor:
+    description = None
+
+    def __init__(self, state):
+        self.state = state
+
+    def execute(self, _query, _params=()):
+        with self.state["lock"]:
+            self.state["active"] += 1
+            self.state["max_active"] = max(self.state["max_active"], self.state["active"])
+        self.state["entered"].set()
+        self.state["release"].wait(timeout=2)
+        with self.state["lock"]:
+            self.state["active"] -= 1
+
+    def close(self):
+        self.state["closed_cursors"] += 1
+
+
+class _BlockingConnection:
+    closed = 0
+
+    def __init__(self, state):
+        self.state = state
+
+    def cursor(self):
+        return _BlockingCursor(self.state)
+
+    def close(self):
+        self.closed = 1
+
+
+def _state():
+    return {
+        "lock": threading.Lock(),
+        "active": 0,
+        "max_active": 0,
+        "entered": threading.Event(),
+        "release": threading.Event(),
+        "closed_cursors": 0,
+    }
+
+
+def _manager_with_fake_connection(config, state):
+    manager = ConnectionManager()
+    connection_id = manager.create_connection(config)
+    manager.connections[connection_id] = _BlockingConnection(state)
+    return manager, connection_id
+
+
+@pytest.mark.asyncio
+async def test_mcp_query_keeps_event_loop_running_during_blocking_driver(monkeypatch):
+    started = threading.Event()
+
+    def blocking_execute(connection_id, query):
+        assert connection_id == "db-1"
+        assert query.endswith("LIMIT 100")
+        started.set()
+        time.sleep(0.06)
+        return []
+
+    monkeypatch.setattr(mcp_tools.connection_manager, "execute_query", blocking_execute)
+
+    ticks = 0
+
+    async def heartbeat():
+        nonlocal ticks
+        deadline = asyncio.get_running_loop().time() + 0.04
+        while asyncio.get_running_loop().time() < deadline:
+            ticks += 1
+            await asyncio.sleep(0.002)
+
+    await asyncio.gather(
+        mcp_tools.handle_db_query_execute({"connection_id": "db-1", "query": "SELECT 1"}),
+        heartbeat(),
+    )
+
+    assert started.is_set()
+    assert ticks >= 2
+
+
+@pytest.mark.asyncio
+async def test_sqlite_connection_can_be_used_by_worker_thread(sqlite_config):
+    manager = ConnectionManager()
+    connection_id = manager.create_connection(sqlite_config)
+    try:
+        rows = await asyncio.to_thread(manager.execute_query, connection_id, "SELECT 1 AS value")
+        assert rows == [{"value": 1}]
+    finally:
+        manager.close_connection(connection_id)
+
+
+@pytest.mark.asyncio
+async def test_same_connection_queries_are_serialized(sqlite_config):
+    state = _state()
+    manager, connection_id = _manager_with_fake_connection(sqlite_config, state)
+
+    first = asyncio.create_task(asyncio.to_thread(manager.execute_query, connection_id, "SELECT 1"))
+    assert await asyncio.to_thread(state["entered"].wait, 1)
+    second = asyncio.create_task(
+        asyncio.to_thread(manager.execute_query, connection_id, "SELECT 2")
+    )
+    await asyncio.sleep(0.02)
+    assert state["max_active"] == 1
+
+    state["release"].set()
+    await asyncio.gather(first, second)
+    assert state["closed_cursors"] == 2
+    manager.close_connection(connection_id)
+
+
+@pytest.mark.asyncio
+async def test_different_connections_can_execute_in_parallel(sqlite_config):
+    first_state = _state()
+    second_state = _state()
+    manager, first_id = _manager_with_fake_connection(sqlite_config, first_state)
+    second_id = manager.create_connection(sqlite_config)
+    manager.connections[second_id] = _BlockingConnection(second_state)
+
+    first = asyncio.create_task(asyncio.to_thread(manager.execute_query, first_id, "SELECT 1"))
+    second = asyncio.create_task(asyncio.to_thread(manager.execute_query, second_id, "SELECT 2"))
+    await asyncio.wait_for(
+        asyncio.gather(
+            asyncio.to_thread(first_state["entered"].wait, 1),
+            asyncio.to_thread(second_state["entered"].wait, 1),
+        ),
+        timeout=1,
+    )
+    assert first_state["max_active"] == second_state["max_active"] == 1
+
+    first_state["release"].set()
+    second_state["release"].set()
+    await asyncio.gather(first, second)
+    manager.close_connection(first_id)
+    manager.close_connection(second_id)
+
+
+@pytest.mark.asyncio
+async def test_close_waits_for_query_and_cleans_connection(sqlite_config):
+    state = _state()
+    manager, connection_id = _manager_with_fake_connection(sqlite_config, state)
+
+    query = asyncio.create_task(asyncio.to_thread(manager.execute_query, connection_id, "SELECT 1"))
+    assert await asyncio.to_thread(state["entered"].wait, 1)
+    close = asyncio.create_task(asyncio.to_thread(manager.close_connection, connection_id))
+    await asyncio.sleep(0.02)
+    assert not close.done()
+
+    state["release"].set()
+    result, closed = await asyncio.gather(query, close)
+    assert result == []
+    assert closed is True
+    assert connection_id not in manager.connections
+    assert connection_id not in manager.connection_configs
+    assert connection_id not in manager._connection_locks


### PR DESCRIPTION
## 关联 Issue  Closes #211  本 PR 完成 Issue #211 的数据库异步边界验收：把 MCP 入口中的同步数据库阶段移出事件循环，并为单连接并发访问建立明确的串行边界。  ## 背景（Situation）  MCP handler 使用 `async def`，但同步 DB-API 查询、元数据 introspection、代码生成分析和 ER 可视化会直接运行在事件循环线程。MySQL/PostgreSQL 网络等待或大型 SQLite 查询期间，同一会话的健康检查、取消和其他连接请求无法及时调度；SQLite 默认线程亲和性还会拒绝跨 worker 使用连接。  ## 任务（Task）  - 保留同步 `ConnectionManager` API、SQL、事务、权限和 MCP 文本/Raw Response 合同。 - 通过统一 worker 调度隔离 MCP 数据库阶段。 - 保证同一 `connection_id` 的 execute/cursor/close 串行，不同连接可以并行等待。 - 覆盖 SQLite worker、关闭竞争、旧测试替身兼容和 JSON 回归边界。 - 不宣称真实生产吞吐收益，不替换数据库驱动或引入连接池。  ## 行动（Action）  - `connection_manager.py`   - 为注册表增加短时 `RLock`，为每个 connection ID 建立可重入锁。   - 锁覆盖健康探测、cursor 生命周期和关闭；关闭时清理连接、脱敏配置和 per-connection lock。   - SQLite 连接启用 `check_same_thread=False`，兼容受控 worker 使用；对直接注入的旧测试连接懒创建锁。   - 保留 SQLite 成功提交与失败回滚、`DatabaseQueryError` 等同步行为。 - `mcp_tools.py`   - 新增 `_run_db_call`、`_run_db_query` 和 `_run_async_db_call`，统一迁移连接探测、释放、查询、元数据和代码生成分析。   - `_run_db_query` 在无参数时保留原有两参数调用合同，兼容外部 monkeypatch 和测试替身。 - `atomic_codegen_tools.py` 与 `visualization_tools.py`   - 原子上下文构建、CodegenAnalyzer 和 ER 元数据收集均通过 worker 调度。 - 文档与测试   - 新增 `docs/adr/016-async-database-boundary.md`，并更新 ADR 索引。   - 新增 `tests/unit/test_async_db_boundary.py`，覆盖事件循环心跳、SQLite worker、同连接串行、跨连接并行和关闭竞争。 - 没有做：未替换原生异步驱动、未引入连接池/TTL、未改变 SQL 或响应序列化、未把非数据库文件操作移入本 PR。  ## 验证（Verification）  环境：Windows；Python `3.10.1`（仓库声明 `>=3.11`，本机现有虚拟环境版本）；pytest `9.0.3`；pytest-asyncio `1.3.0`；SQLite 内存/文件 fixture。  ```text $env:PYTHONPATH='src'; python -m pytest tests/unit -q 774 passed in 5.84s  $env:PYTHONPATH='src'; python -m pytest tests/integration/test_sqlite_mcp_query_contract.py tests/integration/test_sqlite_file_codegen_contract.py -q 3 passed in 2.74s  ruff check . All checks passed!  ruff format --check src/dbjavagenix/database/connection_manager.py src/dbjavagenix/database/mcp_tools.py src/dbjavagenix/database/atomic_codegen_tools.py src/dbjavagenix/database/visualization_tools.py tests/unit/test_async_db_boundary.py 3 files already formatted  git diff --check (no output) ```  `ruff format --check .` 会报告仓库既有的 49 个文件需要格式化；本 PR 只检查并保持修改文件格式，没有把无关格式化混入提交。完整 `pytest` 未运行：收集阶段需要未提供的真实 MySQL 环境变量 `DBJAVAGENIX_TEST_DB_HOST`，因此不能把真实 MySQL/PostgreSQL 线程模型写成已验证。  ## 实验与证据（Evidence）  - 事件循环实验：monkeypatch 一个阻塞 `execute_query`，在 worker 内睡眠 `60 ms`；并发 heartbeat 每 `2 ms` 运行 `40 ms`，断言阻塞期间至少获得 2 次调度（测试 `test_mcp_query_keeps_event_loop_running_during_blocking_driver`）。 - 同连接实验：两个 worker 使用受控 fake cursor；第一个未释放时第二个无法进入，最大活动 cursor 数为 `1`，释放后两个 cursor 均关闭。 - 跨连接实验：两个独立 connection ID 同时进入受控 cursor，证明没有全局锁；各自释放后正常完成。 - 关闭竞争实验：query 持有连接锁时调用 `close_connection`，close 在 query 完成前保持等待，之后清理连接、配置和锁。 - SQLite worker 实验：`asyncio.to_thread(manager.execute_query, ..., 'SELECT 1 AS value')` 返回 `[{'value': 1}]`，无 thread-affinity 错误；既有 SQLite MCP/codegen 契约继续通过。 - 证据位置：`tests/unit/test_async_db_boundary.py`，提交 `01e720d`；以上是受控 stub 和 SQLite 证据，不代表真实网络数据库尾延迟或吞吐。  ## 兼容性、风险与回滚  - 兼容性：同步 `ConnectionManager` 方法签名、异常类型、SQL、SQLite 提交/回滚、MCP JSON/Raw Response 和 `db_disconnect` 生命周期保持不变；不同连接的并发度受 executor 和驱动限制。 - 风险：线程调度带来少量开销；同一连接仍串行；取消 async handler 不会强杀底层驱动调用，worker 返回后才释放 cursor/锁。真实 MySQL/PostgreSQL 驱动的线程绑定需在配置好的容器环境单独验证。 - 安全：不输出凭据；连接配置仍保存脱敏副本；异常路径沿用现有错误序列化。 - 回滚：恢复单一提交 `01e720d` 的父提交即可移除本次边界改动，不涉及用户数据迁移。 - 下一步：合并前只对最终 HEAD 统一检查 required checks；另行建立固定数据库、查询集和硬件条件的性能基线，不在本 PR 宣称性能提升。