### PR TITLE
:bug: fix(database): 修复元数据缓存与查询安全回归

### DIFF
--- a/src/dbjavagenix/database/atomic_codegen_tools.py
+++ b/src/dbjavagenix/database/atomic_codegen_tools.py
@@ -529,7 +529,7 @@ def _compute_file_path(
     package_name = context.get("package", "com.example")
     package_path = package_name.replace(".", "/")
     if file_path.endswith(".java"):
-        return f"{package_path}/{file_path}"
+        return "/".join(part for part in f"{package_path}/{file_path}".split("/") if part)
     return f"resources/{file_path}"
 
 

--- a/src/dbjavagenix/database/connection_manager.py
+++ b/src/dbjavagenix/database/connection_manager.py
@@ -28,6 +28,7 @@ class ConnectionManager:
         self.connection_configs: Dict[str, DatabaseConfig] = {}
         self._registry_lock = threading.RLock()
         self._connection_locks: Dict[str, Any] = {}
+        # Metadata is scoped by connection and schema so DDL cannot leak across sessions.
         self._metadata_cache: OrderedDict[tuple[str, str, str | None], Dict[str, Any]] = OrderedDict()
         self._metadata_cache_limit = 256
 

--- a/src/dbjavagenix/database/connection_manager.py
+++ b/src/dbjavagenix/database/connection_manager.py
@@ -3,10 +3,13 @@ Database connection manager for DBJavaGenix MCP tools
 """
 import uuid
 import threading
+from collections import OrderedDict
+from copy import deepcopy
 from typing import Dict, List, Any, Optional
 import pymysql
 import sqlite3
 import logging
+import re
 from contextlib import contextmanager
 
 from ..core.models import DatabaseConfig, DatabaseType
@@ -25,6 +28,41 @@ class ConnectionManager:
         self.connection_configs: Dict[str, DatabaseConfig] = {}
         self._registry_lock = threading.RLock()
         self._connection_locks: Dict[str, Any] = {}
+        self._metadata_cache: OrderedDict[tuple[str, str, str | None], Dict[str, Any]] = OrderedDict()
+        self._metadata_cache_limit = 256
+
+    def cache_metadata(
+        self, connection_id: str, table_name: str, schema: str | None, metadata: Dict[str, Any]
+    ) -> None:
+        """Store a defensive copy of table metadata in the bounded LRU cache."""
+        key = (connection_id, table_name, schema)
+        with self._registry_lock:
+            self._metadata_cache[key] = deepcopy(metadata)
+            self._metadata_cache.move_to_end(key)
+            while len(self._metadata_cache) > self._metadata_cache_limit:
+                self._metadata_cache.popitem(last=False)
+
+    def get_cached_metadata(
+        self, connection_id: str, table_name: str, schema: str | None = None
+    ) -> Dict[str, Any] | None:
+        """Return a defensive copy of cached metadata, if present."""
+        key = (connection_id, table_name, schema)
+        with self._registry_lock:
+            metadata = self._metadata_cache.get(key)
+            if metadata is None:
+                return None
+            self._metadata_cache.move_to_end(key)
+            return deepcopy(metadata)
+
+    def metadata_cache_size(self) -> int:
+        with self._registry_lock:
+            return len(self._metadata_cache)
+
+    def invalidate_metadata_cache(self, connection_id: str) -> None:
+        """Invalidate all table metadata associated with one connection."""
+        with self._registry_lock:
+            for key in [key for key in self._metadata_cache if key[0] == connection_id]:
+                self._metadata_cache.pop(key, None)
     
     def create_connection(self, config: DatabaseConfig) -> str:
         """
@@ -152,6 +190,7 @@ class ConnectionManager:
                 self.connections.pop(connection_id, None)
                 self.connection_configs.pop(connection_id, None)
                 self._connection_locks.pop(connection_id, None)
+                self.invalidate_metadata_cache(connection_id)
         logger.info("Closed connection %s", connection_id)
     
     def close_connection(self, connection_id: str) -> bool:
@@ -294,6 +333,14 @@ class ConnectionManager:
 
                 if isinstance(connection, sqlite3.Connection):
                     connection.commit()
+                statement = re.sub(
+                    r"^\s*(?:(?:/\*.*?\*/)|(?:--[^\n]*(?:\n|$)))\s*",
+                    "",
+                    query,
+                    flags=re.DOTALL,
+                ).upper()
+                if re.match(r"(?:ALTER|CREATE|DROP|RENAME|TRUNCATE)\b", statement):
+                    self.invalidate_metadata_cache(connection_id)
                 return result
                     
         except Exception as e:

--- a/src/dbjavagenix/database/mcp_tools.py
+++ b/src/dbjavagenix/database/mcp_tools.py
@@ -179,6 +179,19 @@ def _tokenize_read_only_sql(query: str) -> List[tuple[str, str]]:
             tokens.append(("quoted", query[start:index]))
             continue
 
+        if char == "$":
+            dollar_match = re.match(r"\$([A-Za-z_][A-Za-z0-9_]*)?\$", query[index:])
+            if dollar_match:
+                delimiter = dollar_match.group(0)
+                start = index
+                content_start = index + len(delimiter)
+                end = query.find(delimiter, content_start)
+                if end < 0:
+                    raise MCPServiceError("Unterminated dollar-quoted literal")
+                index = end + len(delimiter)
+                tokens.append(("quoted", query[start:index]))
+                continue
+
         if char.isalpha() or char == "_":
             start = index
             index += 1
@@ -236,6 +249,13 @@ def _validate_read_only_query(query: Any) -> str:
     if _contains_locking_read_clause(tokens):
         raise MCPServiceError("Only non-locking read-only SELECT queries are allowed")
 
+    for index, token in enumerate(tokens):
+        if token != ("word", "FETCH"):
+            continue
+        fetch_tail = [value for kind, value in tokens[index + 1 : index + 10] if kind == "word"]
+        if "WITH" in fetch_tail and "TIES" in fetch_tail[fetch_tail.index("WITH") + 1 :]:
+            raise MCPServiceError("FETCH WITH TIES is not supported for bounded read-only queries")
+
     depth = 0
     top_level_select = first_word == "SELECT"
     for kind, value in tokens:
@@ -276,6 +296,11 @@ def _has_top_level_limit_clause(query: str) -> bool:
             next_token = tokens[index + 1] if index + 1 < len(tokens) else None
             if next_token and (next_token[0] == "symbol" or next_token[1] == "ALL"):
                 return True
+        elif kind == "word" and value == "FETCH" and depth == 0:
+            words = [token[1] for token in tokens[index : index + 5] if token[0] == "word"]
+            if len(words) >= 4 and words[:2] == ["FETCH", words[1]] and words[1] in {"FIRST", "NEXT"}:
+                if words[-1] == "ONLY" or (len(words) >= 5 and words[-1] == "ROWS"):
+                    return True
     return False
 
 
@@ -289,6 +314,17 @@ def _top_level_limit_span(query: str) -> tuple[int, int, int | None] | None:
     masked = list(query)
     index = 0
     while index < len(masked):
+        if masked[index] == "$":
+            dollar_match = re.match(r"\$([A-Za-z_][A-Za-z0-9_]*)?\$", query[index:])
+            if dollar_match:
+                delimiter = dollar_match.group(0)
+                end = query.find(delimiter, index + len(delimiter))
+                if end < 0:
+                    raise MCPServiceError("Unterminated dollar-quoted literal")
+                for position in range(index, end + len(delimiter)):
+                    masked[position] = " "
+                index = end + len(delimiter)
+                continue
         if masked[index] not in "'\"`":
             index += 1
             continue
@@ -330,6 +366,13 @@ def _top_level_limit_span(query: str) -> tuple[int, int, int | None] | None:
         if is_top_level(match.start()):
             value = match.group(1).upper()
             return match.start(1), match.end(1), None if value == "ALL" else int(value)
+
+    fetch_form = re.compile(
+        r"\bFETCH\s+(FIRST|NEXT)\s+(\d+)\s+ROWS?\s+ONLY\b", re.IGNORECASE
+    )
+    for match in fetch_form.finditer(masked_query):
+        if is_top_level(match.start()):
+            return match.start(2), match.end(2), int(match.group(2))
     return None
 
 


### PR DESCRIPTION
## 关联 Issue

Closes #214

## 背景（Situation）

main CI 暴露 17 个单元测试回归：生成器在空 `packageSuffix` 时产生重复斜杠，ConnectionManager 没有连接级元数据缓存，公共只读 SQL 工具无法正确处理 PostgreSQL dollar-quoted literal 和 FETCH 限制。上述问题会导致生成路径错误、重复数据库 introspection，以及潜在的查询安全误判。

## 任务（Task）

恢复 Issue #214 的验收契约：实现有界、连接隔离、可失效且返回深拷贝的元数据缓存；规范化 Java 输出路径；扩展只读 SQL tokenizer 与结果上限逻辑，并在执行前拒绝 `FETCH WITH TIES`。不修改 MCP 工具名称、数据库 schema 或非相关生成行为。

## 行动（Action）

- `connection_manager.py`：增加 256 项 LRU 元数据缓存、深拷贝读写、按连接失效，并在 DDL/关闭连接时清理。
- `atomic_codegen_tools.py`：消除包路径中的重复 `/`。
- `mcp_tools.py`：支持 `$$...$$` 与 `$tag$...$tag$`，拒绝未闭合 dollar quote；识别并收紧顶层 `FETCH FIRST/NEXT`，拒绝 `FETCH WITH TIES`。
- 没有做什么：未连接真实 MySQL/PostgreSQL，未改变公开接口和数据库迁移。

## 验证（Verification）

```text
$ PYTHONPATH=src pytest -q tests/unit/test_connection_manager.py tests/unit/test_database_introspection.py tests/unit/test_introspection_benchmark.py tests/unit/test_atomic_codegen_tools.py tests/unit/test_mcp_query_safety.py
88 passed
$ ruff check src/dbjavagenix/database/connection_manager.py src/dbjavagenix/database/mcp_tools.py src/dbjavagenix/database/atomic_codegen_tools.py
All checks passed
```

完整 `pytest -q` 仍需真实 MySQL 环境，当前按仓库测试约定在未设置 `DBJAVAGENIX_TEST_DB_HOST` 时无法收集集成测试。

## 实验与证据（Evidence）

回归输入覆盖 256+1 项缓存淘汰、连接级失效、DDL 后刷新、空包后缀、`$$...$$`/`$tag$...$tag$`、未闭合 dollar quote、顶层与嵌套 FETCH 以及 `FETCH WITH TIES`。上述针对性单元测试结果为 88 passed；失败 introspection 不写入缓存由专门测试确认。未宣称真实数据库性能提升。

## 兼容性、风险与回滚

- 公共 API / 数据格式 / 迁移：不变；新增为 ConnectionManager 内部缓存能力。
- 风险与已知限制：真实 MySQL/PostgreSQL 连接和性能基线未在本地运行；Issue #213 保留后续验证。
- 回滚：回退本 PR 的 squash commit `4dbcc7a`。
- 后续 Issue：#213 负责真实数据库线程模型与性能基线。